### PR TITLE
docs: README facelift — hero, doctor demo, trust diagram, honest trade-offs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,29 @@
+<div align="center">
+
 # splice
 
-**Run [Claude Code](https://docs.anthropic.com/en/docs/claude-code) against non-Anthropic model backends — locally, on loopback — and keep each model's reasoning warm, legible, and cheap across the whole agent loop.**
+**Type `claudeor` instead of `claude` — [Claude Code](https://docs.anthropic.com/en/docs/claude-code), wrapped over your own model backends, on loopback.**
+
+[Install](#install) · [Quick start](#quick-start) · [How it works](#how-it-works) · [Providers](#provider-support) · [Trade-offs](#why-you-might-not-want-splice) · [Changelog](CHANGELOG.md) · [Security](SECURITY.md)
+
+[![ci](https://github.com/torad-labs/splice/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/torad-labs/splice/actions/workflows/ci.yml)
+[![release](https://img.shields.io/github/v/release/torad-labs/splice)](https://github.com/torad-labs/splice/releases/latest)
+[![releases attested](https://img.shields.io/badge/releases-attested-1f6feb)](https://github.com/torad-labs/splice/attestations)
+[![license](https://img.shields.io/github/license/torad-labs/splice)](LICENSE)
+
+</div>
 
 splice is a local, loopback-only proxy stack. A single Kotlin daemon (**spliced**) sits between Claude Code and one or more model backends, translating Anthropic's Messages API into each backend's own wire dialect. Each backend is exposed as a **head** — a thin Claude Code wrapper on its own loopback port (`claudex`, `claude-grok`, `claude-kimi`, `claudeor`, …). Its load-bearing feature is the **mirror**: the backend's reasoning summary is written back into the transcript as visible text, so conclusions persist and stay legible turn after turn instead of evaporating.
 
-Adding a backend is a TOML edit, not code: the daemon dispatches on `(dialect, auth.kind)` to a built-in provider. See [`config/splice.example.toml`](config/splice.example.toml) for the full sample topology.
-
-> Status: personal project, run locally on loopback. No warranty — see [License](#license).
-
 ## Not affiliated
 
-splice is an independent, personal project. It is **not affiliated with, endorsed by, or sponsored by** Anthropic, OpenAI, xAI, Moonshot, or OpenRouter. All product names and trademarks belong to their respective owners.
+> [!IMPORTANT]
+> splice is an independent, personal project. It is **not affiliated with, endorsed by, or sponsored by** Anthropic, OpenAI, xAI, Moonshot, or OpenRouter. All product names and trademarks belong to their respective owners.
+> Anthropic identifies routing Claude Code to non-Claude models through a custom gateway as **unsupported**. splice is exactly that kind of gateway; use it with that in mind, at your own risk. No warranty — see [License](#license), and [why you might not want splice](#why-you-might-not-want-splice).
 
-Anthropic identifies routing Claude Code to non-Claude models through a custom gateway as **unsupported**. splice is exactly that kind of gateway; use it with that in mind, at your own risk.
+When something is wrong, `splice doctor` names the exact fix:
+
+<img src="docs/assets/doctor.svg" alt="splice doctor output: every failing check prints its fix" width="760">
 
 ## Why it exists
 
@@ -21,6 +32,32 @@ Long coding-agent sessions bleed tokens and lose the thread. splice goes after b
 - **Cache warmth is engineered, not hoped for.** A stable cache key and — critically — **compaction that runs on the session's own model and reasoning effort** keep the prompt cache warm across a long session. Opaque encrypted reasoning-item replay is an explicit, default-off trade-off: it can add cache warmth, but measurements showed it also made fresh reasoning substantially thinner. A mismatched compaction model *or* effort silently invalidates the cache and re-reads the entire transcript uncached.
 - **Reasoning continuity is load-bearing.** The mirror preserves the provider-generated readable reasoning summary in the transcript, so the agent — and you — can inspect the summary and carry that context through later turns and compaction. It is not raw, private, or exact chain-of-thought.
 - **One instrument panel for the fleet.** The daemon serves a single dashboard over every head: live status, start/stop/restart, layered config with provenance, per-head 5-hour usage soft-warnings, auth, and logs.
+
+What you get, concretely:
+
+- [x] Wrapper commands per backend — [`claudeor` is one keystroke away from `claude`](#quick-start)
+- [x] The reasoning **mirror** — [summaries survive turns and compaction](#reasoning)
+- [x] Cache-warm compaction on the session's own model and effort
+- [x] A [fleet dashboard](#quick-start) on loopback — status, config with provenance, usage soft-warnings, logs
+- [x] [`splice doctor`](#troubleshooting) — every failing check prints its own fix
+- [x] [Checksummed **and** provenance-attested releases](#install), verified by the installer before anything goes live
+- [x] New backends are [a TOML edit, not code](#provider-support) — the daemon dispatches on `(dialect, auth.kind)`
+
+## How it works
+
+```mermaid
+flowchart LR
+    subgraph machine["your machine — everything binds 127.0.0.1"]
+        CC["Claude Code<br/>(claudeor · claudex · …)"]
+        HEAD["head<br/>:3101"]
+        D["spliced daemon<br/>dashboard + control :3096"]
+        CC -- "Anthropic Messages API" --> HEAD
+        HEAD --- D
+    end
+    HEAD -- "provider wire dialect" --> API["backend API<br/>(OpenRouter · Moonshot · …)"]
+```
+
+Each wrapper is an `argv[0]` symlink to the shared launch shim `bin/splice-launch`: it cold-starts the daemon if needed, asks it for an exec recipe over the loopback control plane, and execs the real `claude` pointed at the head's port. Only the head talks to the backend; the dashboard and every control endpoint are bearer-guarded and loopback-only. Adding a backend is a TOML edit, not code — see [`config/splice.example.toml`](config/splice.example.toml) for the full sample topology.
 
 ## Requirements
 
@@ -90,7 +127,7 @@ splice setup                      # write the supported API-key starter and inst
 claudeor                          # Claude Code through OpenRouter on loopback (:3101)
 ```
 
-`install.sh` builds the fat jar from a checkout (or fetches a release), installs the shared launch shim `bin/splice-launch`, links the wrapper commands into `~/.local/bin`, and finishes by running `splice doctor` so you see a verified state — not a hopeful one. Each wrapper is an `argv[0]` symlink to `splice-launch`, which cold-starts the daemon, asks it for an exec recipe over the loopback control plane, and execs `claude`.
+`install.sh` builds the fat jar from a checkout (or fetches a release), installs the shared launch shim, links the wrapper commands into `~/.local/bin`, and finishes by running `splice doctor` so you see a verified state — not a hopeful one.
 
 Codex, Grok, and Kimi OAuth routes are not first-run defaults. To try one, copy its clearly marked **experimental opt-in** provider and head from [`config/splice.example.toml`](config/splice.example.toml), restart splice, then run that head's `login` command. Those routes reuse public CLI OAuth client identities but are not vendor-documented third-party integrations.
 
@@ -142,6 +179,16 @@ Each of these is a **password-equivalent secret** — anything that can read the
 | kimi (Moonshot) | `kimi-oauth` | **Experimental**, pending vendor clarification |
 
 The **api-key** routes are ordinary pay-per-token API access and are supported. The **OAuth-identity** routes are **experimental**: they authenticate by reusing the public OAuth client identities of each vendor's own CLI, not a documented third-party integration. Whether that reuse is permitted is not settled — treat these routes as experimental pending clarification from each vendor, and use them at your own risk.
+
+## Why you might not want splice
+
+Honesty over marketing — reasons to walk away:
+
+- **It's an unsupported gateway.** Anthropic explicitly identifies this class of tool as unsupported. A Claude Code update can break splice at any time; the version handshake fails loudly rather than corrupting sessions, but "fails loudly" is still "fails".
+- **The OAuth routes are legally unsettled.** Codex, Grok, and Kimi routes reuse each vendor's own CLI OAuth client identity. That reuse is not vendor-documented; it may violate terms of service. They ship as explicit experimental opt-ins for a reason.
+- **It's a single-user, loopback tool.** No multi-user story, no remote access, no TLS — by design. If you want a team-facing model gateway, use a purpose-built one (e.g. LiteLLM).
+- **It runs a JVM daemon.** Java 21 is a hard dependency, and the daemon holds a bounded 2 GB heap while serving. On a small machine that's a real cost.
+- **It's a personal project.** One maintainer, no warranty, no SLA. The release gates are strict (every release is checksummed, provenance-attested, and installed hermetically in CI before it ships) — but strictness isn't staffing.
 
 ## Backends and protocols
 

--- a/docs/assets/doctor.svg
+++ b/docs/assets/doctor.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="418" viewBox="0 0 760 418" font-family="ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace" font-size="13">
+  <!-- Hand-built terminal mock of real `splice doctor` output (colors match GitHub dark). -->
+  <rect width="760" height="418" rx="8" fill="#0d1117" stroke="#30363d"/>
+  <circle cx="22" cy="20" r="6" fill="#f85149"/>
+  <circle cx="42" cy="20" r="6" fill="#d29922"/>
+  <circle cx="62" cy="20" r="6" fill="#3fb950"/>
+  <text x="380" y="24" fill="#8b949e" text-anchor="middle" font-size="12">splice doctor</text>
+  <g fill="#c9d1d9">
+    <text x="24" y="56"><tspan fill="#8b949e">$</tspan> splice doctor</text>
+    <text x="24" y="80"><tspan font-weight="bold">splice doctor</tspan> <tspan fill="#8b949e">— every ✗ and ! comes with its fix</tspan></text>
+    <text x="24" y="104" fill="#8b949e">prerequisites</text>
+    <text x="24" y="124"><tspan fill="#3fb950">✓</tspan> java     21.0.11</text>
+    <text x="24" y="144"><tspan fill="#3fb950">✓</tspan> claude   2.1.207 (Claude Code)</text>
+    <text x="24" y="164"><tspan fill="#3fb950">✓</tspan> node     v24.16.0</text>
+    <text x="404" y="124"><tspan fill="#3fb950">✓</tspan> python3  3.13.7</text>
+    <text x="404" y="144"><tspan fill="#3fb950">✓</tspan> curl     8.14.1</text>
+    <text x="404" y="164"><tspan fill="#3fb950">✓</tspan> bash     5.2.37</text>
+    <text x="24" y="188"><tspan fill="#d29922">!</tspan> gh       installed but not authenticated — release installs will abort</text>
+    <text x="24" y="206">           <tspan fill="#8b949e">fix:</tspan> <tspan fill="#58a6ff">gh auth login</tspan></text>
+    <text x="24" y="230" fill="#8b949e">installation</text>
+    <text x="24" y="250"><tspan fill="#3fb950">✓</tspan> jar      0.1.1   <tspan fill="#3fb950">✓</tspan> shim (shim-2)   <tspan fill="#3fb950">✓</tspan> wrapper 'claudeor'   <tspan fill="#3fb950">✓</tspan> PATH</text>
+    <text x="24" y="274" fill="#8b949e">daemon</text>
+    <text x="24" y="294"><tspan fill="#3fb950">✓</tspan> daemon   running 0.1.1 on :3096   <tspan fill="#3fb950">✓</tspan> mgmt-key</text>
+    <text x="24" y="318" fill="#8b949e">auth</text>
+    <text x="24" y="338"><tspan fill="#f85149">✗</tspan> openrouter  OPENROUTER_API_KEY is not set</text>
+    <text x="24" y="356">              <tspan fill="#8b949e">fix:</tspan> <tspan fill="#58a6ff">export OPENROUTER_API_KEY=…   then: splice restart</tspan></text>
+    <text x="24" y="392"><tspan fill="#f85149">1 issue(s)</tspan> — fixes listed above. Re-run <tspan fill="#58a6ff">splice doctor</tspan> after.</text>
+  </g>
+</svg>


### PR DESCRIPTION
README restructure applying live-researched patterns from top OSS projects (ripgrep, uv, ollama, LiteLLM, Supabase, tldraw, htmx et al.), tuned for a security-conscious local proxy:

- Hero: one-keystroke pitch, micro-nav, 4 posture-proving badges (ci · release · attested · license)
- "Not affiliated" promoted to a GitHub `[!IMPORTANT]` alert near the top
- SVG terminal mock of `splice doctor` (no binary assets, diffable)
- Checkbox what-you-get list doubling as navigation
- Mermaid trust-boundary diagram (everything on 127.0.0.1; only the head reaches the backend)
- New "Why you might not want splice" section — ripgrep-style honest trade-offs, giving the unsupported-gateway and experimental-OAuth caveats a prominent home

OSS-E content pins verified locally; all internal anchors checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)