### PR TITLE
codex: send tool_choice=auto on responses-lite turns — fixes broken tool-calling on gpt-5.6

### DIFF
--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesRequestBuilder.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesRequestBuilder.kt
@@ -184,10 +184,16 @@ public class ResponsesRequestBuilder(private val quirks: ResponsesQuirks) {
         // field on ResponsesRequest, a reviewable type change. Byte-identical to the old put() set
         // (ResponsesRequestBuilderTest pins it): fields in declaration order, null optionals omitted.
         val tools = if (!opts.compact && body.tools.isNotEmpty()) toolsArray(body) else null
-        val emitToolChoice = tools != null && quirks.emitToolChoice
+        val lite = quirks.isLite(opts)
+        // Lite turns carry tools as an additional_tools input item, not top-level `tools`; without
+        // an explicit tool_choice the backend never enables function-calling from them (the model
+        // then improvises tool calls in text — stuck/looping turns). codex-rs sends tool_choice:"auto"
+        // unconditionally (core/src/client.rs:896), so lite MUST too, independent of the grok-style
+        // emitToolChoice negotiation that codex otherwise leaves off.
+        val emitToolChoice = tools != null && (quirks.emitToolChoice || lite)
         val include =
             if (!opts.compact && opts.includeEncryptedReasoning.v) listOf(ENCRYPTED_CONTENT_INCLUDE) else null
-        val shape = wireShape(quirks.isLite(opts), input, instructions, tools)
+        val shape = wireShape(lite, input, instructions, tools)
         val dto = ResponsesRequest(
             model = opts.upstreamModel,
             input = shape.input,
@@ -197,7 +203,7 @@ public class ResponsesRequestBuilder(private val quirks: ResponsesQuirks) {
             promptCacheKey = cacheKey(body, opts),
             instructions = shape.instructions,
             tools = shape.tools,
-            toolChoice = if (emitToolChoice) toolChoice(body) else null,
+            toolChoice = toolChoiceFor(emitToolChoice, lite, body),
             parallelToolCalls = parallelToolCallsFor(emitToolChoice, body, opts),
             reasoning = reasoning,
             streamOptions = summaryDeliveryOptions(reasoning),
@@ -225,6 +231,14 @@ public class ResponsesRequestBuilder(private val quirks: ResponsesQuirks) {
             },
         )
         if (quirks.emitStrict && t.strict == true) put("strict", true)
+    }
+
+    /** Lite pins "auto" (the only value codex-rs validated against additional_tools — client.rs:896);
+     *  non-lite keeps the negotiated choice for grok's specific-tool path; null omits the field. */
+    private fun toolChoiceFor(emitToolChoice: Boolean, lite: Boolean, body: AnthropicRequest): JsonElement? = when {
+        !emitToolChoice -> null
+        lite -> JsonPrimitive("auto")
+        else -> toolChoice(body)
     }
 
     private fun toolChoice(body: AnthropicRequest): JsonElement {

--- a/gateway/dialect-openai-responses/src/test/kotlin/ResponsesRequestBuilderTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ResponsesRequestBuilderTest.kt
@@ -158,6 +158,10 @@ class ResponsesRequestBuilderTest {
         val req = build(tooled, options = opts(model = "gpt-5.6-sol"))
         assertNull(req["instructions"])
         assertNull(req["tools"])
+        // codex-rs parity (client.rs:896): tools ride as additional_tools, so the backend needs an
+        // explicit tool_choice:"auto" to enable function-calling — omitting it left the model
+        // improvising tool calls (stuck/looping turns). Emitted even though codex leaves emitToolChoice off.
+        assertEquals("auto", req["tool_choice"]?.jsonPrimitive?.content)
         assertEquals("false", req["parallel_tool_calls"]?.jsonPrimitive?.content)
         assertEquals("all_turns", req["reasoning"]?.jsonObject?.get("context")?.jsonPrimitive?.content)
         val input = req["input"]!!.jsonArray.map { it.jsonObject }
@@ -192,6 +196,9 @@ class ResponsesRequestBuilderTest {
         val req = build(tooled, options = opts(model = "gpt-5.5"))
         assertEquals("harness prompt", req["instructions"]?.jsonPrimitive?.content)
         assertEquals("Task", req["tools"]!!.jsonArray[0].jsonObject["name"]?.jsonPrimitive?.content)
+        // non-lite codex keeps its proven shape: top-level tools auto-enable calling, so tool_choice
+        // stays omitted (the lite tool_choice fix must not perturb this path).
+        assertNull(req["tool_choice"])
         assertNull(req["parallel_tool_calls"])
         assertNull(req["reasoning"]?.jsonObject?.get("context"))
         assertFalse(


### PR DESCRIPTION
## What
responses-lite (gpt-5.6 family) moves tool defs into an `additional_tools` input item and omits top-level `tools` — correct codex-rs parity. But splice also omitted `tool_choice` (codex has `emitToolChoice=false`), so nothing enabled function-calling from those tools. The model improvised tool calls in text → stuck/looping turns, malformed tool use, runaway subagent spawns.

## Fix
Emit `tool_choice:"auto"` on lite turns, matching codex-rs (`core/src/client.rs:896`, verified in the on-disk checkout). Non-lite keeps its proven top-level-tools shape with tool_choice omitted. Every other lite field already matched parity — tool_choice was the sole divergence.

## Proof
Red-green: the new lite `tool_choice` assertion fails on the old builder, passes with the fix. Full `gradlew check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)