### PR TITLE
fix: catalog membership recognizes [1m]-suffixed models — unbreaks kimi k3

### DIFF
--- a/gateway/core/src/main/kotlin/splice/core/model/ModelCatalog.kt
+++ b/gateway/core/src/main/kotlin/splice/core/model/ModelCatalog.kt
@@ -47,9 +47,14 @@ public data class ModelCatalog(
 
     private val exactWindows: Map<String, Long> =
         models.associate { it.id to it.contextWindow } + extraWindows.associate { it.id to it.contextWindow }
-    private val modelIds: Set<String> = models.mapTo(HashSet()) { it.id }
 
     private val suffixHint = Regex("\\[1m]$", RegexOption.IGNORE_CASE)
+
+    // Canonical (suffix-stripped) ids — `contains` strips its query the same way, so both sides
+    // compare on the upstream id. Storing the RAW id here let a "[1m]" picker model (kimi k3[1m])
+    // never match its own stripped upstream id "k3" → every k3 turn 400'd "proxies its own models
+    // only" (regression from the contains guard's introduction; no [1m] catalog test caught it).
+    private val modelIds: Set<String> = models.mapTo(HashSet()) { stripSuffixes(it.id) }
 
     public fun wrap(id: String): String = discoveryPrefix + id
 

--- a/gateway/core/src/test/kotlin/ModelCatalogTest.kt
+++ b/gateway/core/src/test/kotlin/ModelCatalogTest.kt
@@ -85,4 +85,26 @@ class ModelCatalogTest {
         assertTrue(openRouter.contains("claude-openrouter--anthropic/claude-haiku-4.5"))
         assertFalse(openRouter.contains("claude-3-opus"))
     }
+
+    @Test
+    fun `contains resolves a 1m-suffixed picker model by every address form`() {
+        // kimi k3[1m]: the picker id carries the "[1m]" tier hint; the upstream id is bare "k3".
+        // contains strips its query to "k3", so the catalog must recognize "k3" too — a raw modelIds
+        // set held "k3[1m]" and 400'd every k3 turn ("proxies its own models only").
+        val kimi = ModelCatalog(
+            discoveryPrefix = "claude-kimi--",
+            models = listOf(
+                ModelEntry(id = "k3[1m]", label = "Kimi K3 (1M)", contextWindow = 1_048_576),
+                ModelEntry(id = "kimi-for-coding", contextWindow = 262_144),
+            ),
+            extraWindows = listOf(ExtraWindow(id = "k3", contextWindow = 1_048_576)),
+            defaultContextWindow = 262_144,
+        )
+        assertTrue(kimi.contains("k3"), "bare upstream id")
+        assertTrue(kimi.contains("k3[1m]"), "picker id with the tier hint")
+        assertTrue(kimi.contains("claude-kimi--k3"), "wrapped upstream id")
+        assertTrue(kimi.contains("claude-kimi--k3[1m]"), "wrapped picker id")
+        assertTrue(kimi.contains("kimi-for-coding"), "a sibling non-suffixed model still resolves")
+        assertFalse(kimi.contains("k9"), "a genuinely foreign model is still rejected")
+    }
 }


### PR DESCRIPTION
## Symptom
kimi head 400s `this head proxies its own models only; got k3` on the pinned k3[1m] model; only kimi-for-coding* work.

## Cause
`ModelCatalog.contains(id)` strips the `[1m]` hint from its query but `modelIds` stored the **raw** picker id, so `k3` never matched `k3[1m]`. Regression from the `contains` guard introduced in f11f82a; no [1m] test covered it.

## Fix
Canonicalize both sides — `modelIds` now holds `stripSuffixes(id)`. A [1m] model resolves by every address form; non-suffixed models unchanged (strip is identity).

## Proof
Red-green: new ModelCatalogTest case fails on the old raw-id set, passes with the fix. Full `gradlew check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)