### PR TITLE
fix: close gateway review findings (3 adversarial passes)

### DIFF
--- a/gateway/app/src/main/kotlin/splice/app/Daemon.kt
+++ b/gateway/app/src/main/kotlin/splice/app/Daemon.kt
@@ -235,6 +235,9 @@ public class Daemon(
             // (a head that assembles fine but fails to start); captured by reference, so this
             // reads live rather than a stale snapshot taken before startDaemonHeads runs.
             { failed.size },
+            // Configured total so readyHeads + failedHeads == heads holds even when a head fails to
+            // ASSEMBLE (it never enters `heads`) — review 2026-07-23.
+            topology.heads.size,
         )
         control = srv
         // Start heads BEFORE opening the control plane so a launch-shim that sees /health and

--- a/gateway/app/src/main/kotlin/splice/app/Daemon.kt
+++ b/gateway/app/src/main/kotlin/splice/app/Daemon.kt
@@ -5,10 +5,13 @@
 // documented change).
 package splice.app
 
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.JsonElement
@@ -228,6 +231,10 @@ public class Daemon(
             log,
             LaunchService(ClaudeConfigMaterializer(statePaths.rootDir.parent ?: statePaths.rootDir)),
             shutdownDaemon,
+            // `failed` fills during assembleDaemonHeads above and again in startDaemonHeads below
+            // (a head that assembles fine but fails to start); captured by reference, so this
+            // reads live rather than a stale snapshot taken before startDaemonHeads runs.
+            { failed.size },
         )
         control = srv
         // Start heads BEFORE opening the control plane so a launch-shim that sees /health and
@@ -243,9 +250,24 @@ public class Daemon(
             stopped = true
             authProbes.values.forEach { it.stop() }
             probeScope.cancel()
-            heads.values.forEach {
-                runCatchingDaemonBoundary { it.head.stop() }
-                    .discard("shutdown: one head failing to stop must not block the rest")
+
+            // Heads stop in PARALLEL: each stop may drain in-flight turns for up to its 5s
+            // window, and serial stops compounded shutdown to ~5s x N heads (review 2026-07-22).
+            // SUPERVISOR scope: an exception escaping one head's stop (a type outside
+            // runCatchingDaemonBoundary's list) must not cancel the siblings' drains/flushes nor
+            // skip control.stop below — it surfaces via stopFailureHandler below instead of the
+            // JVM default, which is a black hole once production launches redirect stderr to
+            // /dev/null (review 2026-07-22 round 3).
+            val stopFailureHandler = CoroutineExceptionHandler { _, e ->
+                log("[daemon] head stop failed uncaught: ${e::class.simpleName}: ${e.message}\n")
+            }
+            supervisorScope {
+                heads.values.forEach {
+                    launch(stopFailureHandler) {
+                        runCatchingDaemonBoundary { it.head.stop() }
+                            .discard("shutdown: one head failing to stop must not block the rest")
+                    }
+                }
             }
             control?.stop()
         }

--- a/gateway/app/src/main/kotlin/splice/app/Daemon.kt
+++ b/gateway/app/src/main/kotlin/splice/app/Daemon.kt
@@ -230,9 +230,10 @@ public class Daemon(
             shutdownDaemon,
         )
         control = srv
-        srv.start()
-        // Start each head in isolation too — a listen() failure on one port must not sink the others.
+        // Start heads BEFORE opening the control plane so a launch-shim that sees /health and
+        // immediately POSTs /launch/<head> does not race a still-binding head (503 head is not running).
         startDaemonHeads(heads, failed, probeScope, log, authProbes)
+        srv.start()
         val degraded = if (failed.isEmpty()) "" else " DEGRADED=${failed.keys}"
         log("[daemon] up: control :$controlPort, heads ${heads.keys}$degraded\n")
     }
@@ -292,6 +293,7 @@ public class Daemon(
                     authPath = Paths.get(TopologyLoader.expandHome(providerCfg.auth.file ?: "~/.grok/auth.json")),
                     authCacheMs = ctx.cfg.authCacheMs,
                     refreshCall = { rt -> grokRefresh(tokenUrl, rt) },
+                    prefetchScope = probeScope,
                 )
             }
             else -> ApiKeyAuthProvider(
@@ -404,6 +406,7 @@ public class Daemon(
                     authPath = Paths.get(TopologyLoader.expandHome(cfg.codexAuthPath)),
                     authCacheMs = cfg.authCacheMs,
                     refreshCall = { rt -> refreshCall(tokenUrl, rt) },
+                    prefetchScope = probeScope,
                 )
                 Wired(
                     CodexProvider(
@@ -449,6 +452,7 @@ public class Daemon(
             authPath = Paths.get(TopologyLoader.expandHome(cfg.grokAuthPath)),
             authCacheMs = cfg.authCacheMs,
             refreshCall = { rt -> grokRefresh(tokenUrl, rt) },
+            prefetchScope = probeScope,
         )
         return Wired(
             GrokProvider(

--- a/gateway/app/src/test/kotlin/DaemonTest.kt
+++ b/gateway/app/src/test/kotlin/DaemonTest.kt
@@ -10,6 +10,9 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import mock.MockChatGptUpstream
 import mock.awaitListening
 import mock.freshPort
@@ -135,6 +138,75 @@ class DaemonTest {
         assertTrue(sse.contains("event: error"))
         assertTrue(sse.contains("authentication_error"))
         assertTrue(sse.contains("run: claudex login"))
+    }
+
+    // A 2-head topology: one valid (codex → mock) plus a `ghost` head whose provider does not exist.
+    // Extracted so the degraded-boot test body stays under the detekt LongMethod ceiling.
+    private fun degradedTopologyToml(control: Int, head: Int, ghost: Int, authFile: String) = """
+        [daemon]
+        control_port = $control
+
+        [providers.codex]
+        dialect = "openai-responses"
+        base_url = "${mock.baseUrl}"
+        auth = { kind = "chatgpt-oauth", file = "$authFile" }
+        quirks = { store = false, account_id_header = true, cache_key = "first-message-hash", effort_ceiling = "max", summary_field = true }
+
+        [[providers.codex.models]]
+        id = "gpt-5.6-sol"
+        label = "Sol"
+        context_window = 272000
+
+        [heads.claudex]
+        provider = "codex"
+        port = $head
+        discovery_prefix = "claude-codex--"
+        pinned_model = "gpt-5.6-sol"
+
+        [heads.ghost]
+        provider = "nonesuch"
+        port = $ghost
+        discovery_prefix = "claude-ghost--"
+        pinned_model = "ghost-1"
+    """.trimIndent()
+
+    @Test
+    fun `degraded boot - an unknown-provider head is failed while the valid head serves`() = runBlocking {
+        // finding 3 (review 2026-07-23): a head whose provider does not exist never enters the `heads`
+        // map — assembleDaemonHeads routes it to `failed` — so /health must report the CONFIGURED total
+        // as `heads`, else the launch shim's readyHeads + failedHeads == heads never converges. The
+        // discriminating case: heads.size (=1, assembled only) gives 1 == 1+1 (false); topology.heads.size
+        // (=2) gives 2 == 1+1 (true). One real head + one ghost, on their own ports.
+        val tmp = Files.createTempDirectory("daemon-degraded")
+        val authFile = tmp.resolve("auth.json")
+        Files.writeString(authFile, """{"tokens":{"access_token":"tok-1","account_id":"acct-1","refresh_token":"r"}}""")
+        val degradedControl = freshPort()
+        val degradedHead = freshPort()
+        val authPath = authFile.toString().replace("\\", "/")
+        val toml = degradedTopologyToml(degradedControl, degradedHead, freshPort(), authPath)
+        val degraded = Daemon(
+            topology = TopologyLoader.parse(toml),
+            statePaths = StatePaths(baseOverride = tmp.resolve("state")),
+            dashboardHtml = { "" },
+            log = {},
+            refreshCall = { _, _ -> RefreshAttempt.Denied("test-denied") },
+        )
+        degraded.start()
+        try {
+            awaitListening(degradedControl, degradedHead)
+            val obj = Json.parseToJsonElement(
+                client.get("http://127.0.0.1:$degradedControl/health").bodyAsText(),
+            ).jsonObject
+            val heads = obj["heads"]!!.jsonPrimitive.content.toInt()
+            val ready = obj["readyHeads"]!!.jsonPrimitive.content.toInt()
+            val failed = obj["failedHeads"]!!.jsonPrimitive.content.toInt()
+            assertEquals(2, heads, "configured total counts BOTH heads")
+            assertEquals(1, ready, "only the codex head assembled and started")
+            assertEquals(1, failed, "the unknown-provider head is failed, not assembled")
+            assertEquals(heads, ready + failed, "the invariant the launch shim converges on")
+        } finally {
+            degraded.stop()
+        }
     }
 
     @Test

--- a/gateway/app/src/test/kotlin/DaemonTest.kt
+++ b/gateway/app/src/test/kotlin/DaemonTest.kt
@@ -110,6 +110,16 @@ class DaemonTest {
     }
 
     @Test
+    fun `lowercase bearer is accepted on an inference route`() = runBlocking {
+        // review gap K: inference (HeadServer.authorize) shares the control plane's bearerToken parser,
+        // so a lowercase scheme must authenticate on /v1/models too — a wrong token still 401.
+        val ok = client.get("http://127.0.0.1:$headPort/v1/models") { header("Authorization", "bearer $key") }
+        assertEquals(200, ok.status.value)
+        val bad = client.get("http://127.0.0.1:$headPort/v1/models") { header("Authorization", "bearer wrong-token") }
+        assertEquals(401, bad.status.value)
+    }
+
+    @Test
     fun `a real turn flows through the assembled head to the mock upstream`() = runBlocking {
         val sse = client.post("http://127.0.0.1:$headPort/v1/messages") {
             header("Content-Type", "application/json")

--- a/gateway/control/src/main/kotlin/splice/control/ControlServer.kt
+++ b/gateway/control/src/main/kotlin/splice/control/ControlServer.kt
@@ -78,9 +78,13 @@ public class ControlServer(
     private val log: (String) -> Unit,
     private val launchService: LaunchService? = null,
     private val shutdownDaemon: () -> Unit = {},
+    // Live count of heads that failed to assemble or start (Daemon.start's `failed` map) — lets
+    // the /health readyHeads protocol converge on a degraded boot instead of waiting forever for
+    // a head that will never become ready (review 2026-07-22 round 3).
+    private val failedHeads: () -> Int = { 0 },
 ) {
     private val json = Json { ignoreUnknownKeys = true }
-    private val payloads = ControlPayloads(heads, config)
+    private val payloads = ControlPayloads(heads, config, failedHeads)
 
     @Volatile
     private var server: EmbeddedServer<NettyApplicationEngine, *>? = null
@@ -325,7 +329,7 @@ public class ControlServer(
             call.respondText("statusline body timed out", ContentType.Text.Plain, HttpStatusCode.RequestTimeout)
             return
         }
-        val line = StatuslineRenderer(managed.head.label)
+        val line = StatuslineRenderer(managed.head.label, config.getConfig().statuslineGitRoots)
             .render(stdin, managed.usage, managed.warnPct, managed.warnTokens5h)
         call.respondText(line, ContentType.Text.Plain)
     }
@@ -378,16 +382,20 @@ private class StatuslineBodyTooLarge : RuntimeException()
 private class ControlPayloads(
     private val heads: Map<String, ManagedHead>,
     private val config: ConfigService,
+    private val failedHeads: () -> Int,
 ) {
     fun controlHealthJson(): String = buildJsonObject {
         put("ok", true)
         put("version", GATEWAY_VERSION)
         put("wantShimVersion", SHIM_VERSION)
         put(HEADS, heads.size)
-        // How many heads are actually listening (post startDaemonHeads) — launch shims can wait
-        // for readyHeads == heads before POSTing /launch.
+        // Launch shims wait for readyHeads + failedHeads == heads before POSTing /launch (post
+        // startDaemonHeads) — NOT readyHeads == heads: a start-failed head stays in `heads`
+        // forever with running=false, so the old equality-wait spun forever on a degraded boot
+        // (review 2026-07-22 round 3).
         val ready = heads.values.count { it.head.healthSnapshot().running }
         put("readyHeads", ready)
+        put("failedHeads", failedHeads())
     }.toString()
 
     fun statusJson(): String = buildJsonObject {

--- a/gateway/control/src/main/kotlin/splice/control/ControlServer.kt
+++ b/gateway/control/src/main/kotlin/splice/control/ControlServer.kt
@@ -82,9 +82,13 @@ public class ControlServer(
     // the /health readyHeads protocol converge on a degraded boot instead of waiting forever for
     // a head that will never become ready (review 2026-07-22 round 3).
     private val failedHeads: () -> Int = { 0 },
+    // Total CONFIGURED heads (topology). The readyHeads + failedHeads == heads invariant only holds
+    // against the configured total: an assembly-failed head is counted in failedHeads but is NEVER
+    // in the `heads` map, so reporting heads.size broke the invariant for it (review 2026-07-23).
+    private val configuredHeads: Int = heads.size,
 ) {
     private val json = Json { ignoreUnknownKeys = true }
-    private val payloads = ControlPayloads(heads, config, failedHeads)
+    private val payloads = ControlPayloads(heads, config, failedHeads, configuredHeads)
 
     @Volatile
     private var server: EmbeddedServer<NettyApplicationEngine, *>? = null
@@ -383,12 +387,14 @@ private class ControlPayloads(
     private val heads: Map<String, ManagedHead>,
     private val config: ConfigService,
     private val failedHeads: () -> Int,
+    private val configuredHeads: Int,
 ) {
     fun controlHealthJson(): String = buildJsonObject {
         put("ok", true)
         put("version", GATEWAY_VERSION)
         put("wantShimVersion", SHIM_VERSION)
-        put(HEADS, heads.size)
+        // Configured total, NOT heads.size (assembled only) — see the ControlServer ctor comment.
+        put(HEADS, configuredHeads)
         // Launch shims wait for readyHeads + failedHeads == heads before POSTing /launch (post
         // startDaemonHeads) — NOT readyHeads == heads: a start-failed head stays in `heads`
         // forever with running=false, so the old equality-wait spun forever on a degraded boot

--- a/gateway/control/src/main/kotlin/splice/control/ControlServer.kt
+++ b/gateway/control/src/main/kotlin/splice/control/ControlServer.kt
@@ -384,6 +384,10 @@ private class ControlPayloads(
         put("version", GATEWAY_VERSION)
         put("wantShimVersion", SHIM_VERSION)
         put(HEADS, heads.size)
+        // How many heads are actually listening (post startDaemonHeads) — launch shims can wait
+        // for readyHeads == heads before POSTing /launch.
+        val ready = heads.values.count { it.head.healthSnapshot().running }
+        put("readyHeads", ready)
     }.toString()
 
     fun statusJson(): String = buildJsonObject {
@@ -395,7 +399,7 @@ private class ControlPayloads(
                 addJsonObject {
                     put(KEY, m.head.key)
                     put(LABEL, m.head.label)
-                    put("authKind", m.auth.let { "provider" })
+                    put("authKind", m.authKind)
                 }
             }
         }
@@ -420,8 +424,21 @@ private class ControlPayloads(
         put("version", if (h.running) GATEWAY_VERSION else null as String?)
         put("versionMatch", if (h.running) true else null as Boolean?)
         put("mode", null as String?)
-        put("gate", null as String?) // gate snapshot is nullable in the contract; heads self-report when wired
-        put("maxInflight", null as Int?)
+        // Live InflightGate snapshot for the dashboard (was permanently null after the Kotlin port).
+        putJsonObject("gate") {
+            put("inflight", h.gateInflight)
+            put("queued", h.gateQueued)
+            if (h.gateLimit <= 0) put("max", "unlimited") else put("max", h.gateLimit)
+            // Counters the Node gate tracked; Kotlin gate has no acquired/released totals —
+            // zero-fill so the GateSnapshot shape stays stable for the webui.
+            put("acquired", 0)
+            put("released", 0)
+            put("waited", 0)
+            put("avg_wait_ms", 0)
+            putJsonArray("live") {}
+            put("stream_idle_ms", 0)
+        }
+        put("maxInflight", if (h.gateLimit <= 0) null else h.gateLimit)
         // G20: passive per-head health counters, local-origin vs provider-error split — diagnosis
         // only, surfaced through this aggregation (never the per-head /health liveness route).
         putJsonObject("health") {

--- a/gateway/control/src/main/kotlin/splice/control/StatuslineRenderer.kt
+++ b/gateway/control/src/main/kotlin/splice/control/StatuslineRenderer.kt
@@ -86,7 +86,9 @@ public class StatuslineRenderer(private val label: String) {
     private fun locationSegment(root: JsonObject): String? {
         val cwd = str(obj(root, "workspace")?.get("current_dir")) ?: str(root["cwd"]) ?: return null
         val base = cwd.trim('/').substringAfterLast('/').ifEmpty { return null }
-        val branch = gitBranch(cwd)
+        // Only git when cwd is a real absolute directory under the user home (or /tmp) — never
+        // exec git -C against an attacker-chosen path from unauthenticated /statusline.
+        val branch = if (isSafeGitCwd(cwd)) gitBranch(cwd) else ""
         val loc = if (branch.isEmpty()) base else "$base  ⎇ $branch"
         return dim(loc)
     }
@@ -117,6 +119,23 @@ public class StatuslineRenderer(private val label: String) {
         fun num(element: JsonElement?): Long? = (element as? JsonPrimitive)?.content?.toDoubleOrNull()?.toLong()
         fun fmtK(n: Long): String = if (n >= K) "${n / K}k" else n.toString()
         fun dim(s: String) = "$DIM$s$RESET"
+
+        /** Absolute, existing directory under $HOME or /tmp, with ".." rejected after normalize. */
+        fun isSafeGitCwd(cwd: String): Boolean {
+            if (!cwd.startsWith("/")) return false
+            if (cwd.any { it.code == 0 }) return false
+            val path = runCatching { java.nio.file.Paths.get(cwd).toAbsolutePath().normalize() }.getOrNull()
+                ?: return false
+            if (path.toString().contains("..")) return false
+            val home = runCatching {
+                java.nio.file.Paths.get(System.getProperty("user.home")).toAbsolutePath().normalize()
+            }.getOrNull()
+            val tmp = java.nio.file.Paths.get("/tmp").toAbsolutePath().normalize()
+            val underHome = home != null && path.startsWith(home)
+            val underTmp = path.startsWith(tmp)
+            if (!underHome && !underTmp) return false
+            return java.nio.file.Files.isDirectory(path)
+        }
 
         const val RESET = "[0m"
         const val DIM = "[2m"

--- a/gateway/control/src/main/kotlin/splice/control/StatuslineRenderer.kt
+++ b/gateway/control/src/main/kotlin/splice/control/StatuslineRenderer.kt
@@ -16,7 +16,16 @@ import splice.core.usage.RateLimitState
 import splice.core.usage.computeUsageWarn
 import java.util.concurrent.TimeUnit
 
-public class StatuslineRenderer(private val label: String) {
+public class StatuslineRenderer(
+    private val label: String,
+    extraGitRoots: List<String> = emptyList(),
+) {
+    // Operator-trusted roots beyond $HOME//tmp for the git-branch lookup (statuslineGitRoots
+    // knob / CLAUDEX_STATUSLINE_GIT_ROOTS) — devcontainer /workspace, /srv layouts. Normalized once.
+    private val extraGitRoots: List<java.nio.file.Path> = extraGitRoots.mapNotNull { root ->
+        runCatching { java.nio.file.Paths.get(root).toAbsolutePath().normalize() }.getOrNull()
+    }
+
     private val json = Json { ignoreUnknownKeys = true }
 
     public fun render(stdinJson: String, usage: HeadUsageSource?, warnPct: Int, warnTokens5h: Long): String {
@@ -102,6 +111,26 @@ public class StatuslineRenderer(private val label: String) {
             (num(cu["cache_creation_input_tokens"]) ?: 0)
     }
 
+    /** Absolute, existing directory under $HOME, /tmp, or an operator-trusted extra root — never
+     *  exec git -C against any other path from unauthenticated /statusline. Repos outside the
+     *  trusted roots lose only the branch segment. */
+    private fun isSafeGitCwd(cwd: String): Boolean {
+        if (!cwd.startsWith("/") || cwd.any { it.code == 0 }) return false
+        // normalize() resolves every ".." traversal before the prefix checks; the old substring
+        // ".." test on the normalized path only false-negatived legit names like "my..proj"
+        // (review 2026-07-22).
+        val path = runCatching { java.nio.file.Paths.get(cwd).toAbsolutePath().normalize() }.getOrNull()
+            ?: return false
+        val home = runCatching {
+            java.nio.file.Paths.get(System.getProperty("user.home")).toAbsolutePath().normalize()
+        }.getOrNull()
+        val tmp = java.nio.file.Paths.get("/tmp").toAbsolutePath().normalize()
+        val trusted = (home != null && path.startsWith(home)) ||
+            path.startsWith(tmp) ||
+            extraGitRoots.any { path.startsWith(it) }
+        return trusted && java.nio.file.Files.isDirectory(path)
+    }
+
     private fun gitBranch(cwd: String): String = runCatching {
         val process = ProcessBuilder("git", "-C", cwd, "branch", "--show-current")
             .redirectErrorStream(false)
@@ -119,23 +148,6 @@ public class StatuslineRenderer(private val label: String) {
         fun num(element: JsonElement?): Long? = (element as? JsonPrimitive)?.content?.toDoubleOrNull()?.toLong()
         fun fmtK(n: Long): String = if (n >= K) "${n / K}k" else n.toString()
         fun dim(s: String) = "$DIM$s$RESET"
-
-        /** Absolute, existing directory under $HOME or /tmp, with ".." rejected after normalize. */
-        fun isSafeGitCwd(cwd: String): Boolean {
-            if (!cwd.startsWith("/")) return false
-            if (cwd.any { it.code == 0 }) return false
-            val path = runCatching { java.nio.file.Paths.get(cwd).toAbsolutePath().normalize() }.getOrNull()
-                ?: return false
-            if (path.toString().contains("..")) return false
-            val home = runCatching {
-                java.nio.file.Paths.get(System.getProperty("user.home")).toAbsolutePath().normalize()
-            }.getOrNull()
-            val tmp = java.nio.file.Paths.get("/tmp").toAbsolutePath().normalize()
-            val underHome = home != null && path.startsWith(home)
-            val underTmp = path.startsWith(tmp)
-            if (!underHome && !underTmp) return false
-            return java.nio.file.Files.isDirectory(path)
-        }
 
         const val RESET = "[0m"
         const val DIM = "[2m"

--- a/gateway/control/src/main/kotlin/splice/control/StatuslineRenderer.kt
+++ b/gateway/control/src/main/kotlin/splice/control/StatuslineRenderer.kt
@@ -118,7 +118,7 @@ public class StatuslineRenderer(
      *  "..": a symlink under /tmp pointing OUTSIDE the trusted roots would pass a lexical prefix
      *  check yet run git elsewhere, so resolve REAL paths on BOTH sides and compare those
      *  (review 2026-07-23). Repos outside the trusted roots lose only the branch segment. */
-    private fun safeGitCwd(cwd: String): java.nio.file.Path? {
+    internal fun safeGitCwd(cwd: String): java.nio.file.Path? {
         if (!cwd.startsWith("/") || cwd.any { it.code == 0 }) return null
         // toRealPath resolves symlinks AND requires existence — a non-existent path returns null.
         val real = runCatching { java.nio.file.Paths.get(cwd).toRealPath() }.getOrNull() ?: return null

--- a/gateway/control/src/main/kotlin/splice/control/StatuslineRenderer.kt
+++ b/gateway/control/src/main/kotlin/splice/control/StatuslineRenderer.kt
@@ -26,6 +26,15 @@ public class StatuslineRenderer(
         runCatching { java.nio.file.Paths.get(root).toAbsolutePath().normalize() }.getOrNull()
     }
 
+    // Real (symlink-resolved) trusted roots for safeGitCwd's containment check — resolved ONCE here
+    // since the root set ($HOME, /tmp, extraGitRoots) is process-invariant, unlike the per-request
+    // candidate cwd (still resolved fresh on each call). A root missing at construction is dropped,
+    // same as the old per-call runCatching { root.toRealPath() }.getOrNull().
+    private val trustedRoots: List<java.nio.file.Path> = (
+        listOfNotNull(System.getProperty("user.home"), "/tmp").map { java.nio.file.Paths.get(it) } +
+            this.extraGitRoots
+        ).mapNotNull { root -> runCatching { root.toRealPath() }.getOrNull() }
+
     private val json = Json { ignoreUnknownKeys = true }
 
     public fun render(stdinJson: String, usage: HeadUsageSource?, warnPct: Int, warnTokens5h: Long): String {
@@ -122,10 +131,7 @@ public class StatuslineRenderer(
         if (!cwd.startsWith("/") || cwd.any { it.code == 0 }) return null
         // toRealPath resolves symlinks AND requires existence — a non-existent path returns null.
         val real = runCatching { java.nio.file.Paths.get(cwd).toRealPath() }.getOrNull() ?: return null
-        val trustedDirs = listOfNotNull(System.getProperty("user.home"), "/tmp")
-            .map { java.nio.file.Paths.get(it) } + extraGitRoots
-        val roots = trustedDirs.mapNotNull { root -> runCatching { root.toRealPath() }.getOrNull() }
-        return real.takeIf { p -> java.nio.file.Files.isDirectory(p) && roots.any { p.startsWith(it) } }
+        return real.takeIf { p -> java.nio.file.Files.isDirectory(p) && trustedRoots.any { p.startsWith(it) } }
     }
 
     private fun gitBranch(cwd: String): String = runCatching {

--- a/gateway/control/src/main/kotlin/splice/control/StatuslineRenderer.kt
+++ b/gateway/control/src/main/kotlin/splice/control/StatuslineRenderer.kt
@@ -95,9 +95,11 @@ public class StatuslineRenderer(
     private fun locationSegment(root: JsonObject): String? {
         val cwd = str(obj(root, "workspace")?.get("current_dir")) ?: str(root["cwd"]) ?: return null
         val base = cwd.trim('/').substringAfterLast('/').ifEmpty { return null }
-        // Only git when cwd is a real absolute directory under the user home (or /tmp) — never
-        // exec git -C against an attacker-chosen path from unauthenticated /statusline.
-        val branch = if (isSafeGitCwd(cwd)) gitBranch(cwd) else ""
+        // Only git when cwd RESOLVES to a real directory under the user home (or /tmp) — never
+        // exec git -C against an attacker-chosen path from unauthenticated /statusline. Run git in
+        // the symlink-resolved path, not the raw cwd.
+        val safe = safeGitCwd(cwd)
+        val branch = if (safe != null) gitBranch(safe.toString()) else ""
         val loc = if (branch.isEmpty()) base else "$base  ⎇ $branch"
         return dim(loc)
     }
@@ -111,24 +113,19 @@ public class StatuslineRenderer(
             (num(cu["cache_creation_input_tokens"]) ?: 0)
     }
 
-    /** Absolute, existing directory under $HOME, /tmp, or an operator-trusted extra root — never
-     *  exec git -C against any other path from unauthenticated /statusline. Repos outside the
-     *  trusted roots lose only the branch segment. */
-    private fun isSafeGitCwd(cwd: String): Boolean {
-        if (!cwd.startsWith("/") || cwd.any { it.code == 0 }) return false
-        // normalize() resolves every ".." traversal before the prefix checks; the old substring
-        // ".." test on the normalized path only false-negatived legit names like "my..proj"
-        // (review 2026-07-22).
-        val path = runCatching { java.nio.file.Paths.get(cwd).toAbsolutePath().normalize() }.getOrNull()
-            ?: return false
-        val home = runCatching {
-            java.nio.file.Paths.get(System.getProperty("user.home")).toAbsolutePath().normalize()
-        }.getOrNull()
-        val tmp = java.nio.file.Paths.get("/tmp").toAbsolutePath().normalize()
-        val trusted = (home != null && path.startsWith(home)) ||
-            path.startsWith(tmp) ||
-            extraGitRoots.any { path.startsWith(it) }
-        return trusted && java.nio.file.Files.isDirectory(path)
+    /** The symlink-RESOLVED absolute directory if it lies under $HOME, /tmp, or an operator-trusted
+     *  root — else null (the resolved path is what git -C runs in). `normalize()` only collapses
+     *  "..": a symlink under /tmp pointing OUTSIDE the trusted roots would pass a lexical prefix
+     *  check yet run git elsewhere, so resolve REAL paths on BOTH sides and compare those
+     *  (review 2026-07-23). Repos outside the trusted roots lose only the branch segment. */
+    private fun safeGitCwd(cwd: String): java.nio.file.Path? {
+        if (!cwd.startsWith("/") || cwd.any { it.code == 0 }) return null
+        // toRealPath resolves symlinks AND requires existence — a non-existent path returns null.
+        val real = runCatching { java.nio.file.Paths.get(cwd).toRealPath() }.getOrNull() ?: return null
+        val trustedDirs = listOfNotNull(System.getProperty("user.home"), "/tmp")
+            .map { java.nio.file.Paths.get(it) } + extraGitRoots
+        val roots = trustedDirs.mapNotNull { root -> runCatching { root.toRealPath() }.getOrNull() }
+        return real.takeIf { p -> java.nio.file.Files.isDirectory(p) && roots.any { p.startsWith(it) } }
     }
 
     private fun gitBranch(cwd: String): String = runCatching {

--- a/gateway/control/src/test/kotlin/ControlServerGateTest.kt
+++ b/gateway/control/src/test/kotlin/ControlServerGateTest.kt
@@ -1,0 +1,170 @@
+// NEW (review gaps K & L, 2026-07-23): control-plane contract tests split out of ControlServerTest
+// (which is at its detekt LargeClass ceiling). K: a lowercase `bearer` scheme authenticates on a
+// guarded route — the control plane once rejected it until it shared bearerToken. L: /api/heads emits
+// the live InflightGate as NUMERIC inflight/queued/max + numeric maxInflight, and unlimited mode as
+// max:"unlimited" / maxInflight:null — the webui-shape test only checks gate PRESENCE with zero fakes.
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.expectSuccess
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import splice.control.CompactView
+import splice.control.ControlServer
+import splice.control.HeadCompactSource
+import splice.control.HeadLogSource
+import splice.control.HeadUsageSource
+import splice.control.ManagedHead
+import splice.control.UsageView
+import splice.core.auth.AuthDescription
+import splice.core.auth.AuthProvider
+import splice.core.config.ConfigService
+import splice.core.config.MgmtKey
+import splice.core.config.StatePaths
+import splice.core.head.Head
+import splice.core.head.HeadHealth
+import java.net.ServerSocket
+import java.net.Socket
+import java.nio.file.Files
+
+private class GateFakeHead(
+    override val key: String,
+    override val port: Int,
+    private val inflight: Int,
+    private val queued: Int,
+    private val limit: Int,
+) : Head {
+    override val label: String = key
+    override suspend fun start() = Unit
+    override suspend fun stop() = Unit
+    override fun healthSnapshot() = HeadHealth(
+        ok = true,
+        running = true,
+        port = port,
+        version = "kt-1",
+        gateInflight = inflight,
+        gateQueued = queued,
+        gateLimit = limit,
+    )
+}
+
+private class GateFakeAuth : AuthProvider {
+    override suspend fun credentials() = null
+    override suspend fun describe() = AuthDescription(true, "chatgpt-oauth")
+}
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ControlServerGateTest {
+
+    private val client = HttpClient(CIO) { expectSuccess = false }
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @AfterAll
+    fun tearDown() = client.close()
+
+    @Test
+    fun `lowercase bearer scheme is accepted on a guarded control route`() = runTest {
+        val tmp = Files.createTempDirectory("control-bearer")
+        val paths = StatePaths(baseOverride = tmp.resolve("state"))
+        val mgmt = MgmtKey(paths)
+        val port = freshPort()
+        val server = ControlServer(port, emptyMap(), ConfigService(paths), mgmt, { "" }, {})
+        server.start()
+        try {
+            awaitListening(port)
+            val ok = client.get("http://127.0.0.1:$port/api/status") {
+                header("Authorization", "bearer ${mgmt.get()}")
+            }
+            assertEquals(HttpStatusCode.OK, ok.status)
+            val wrong = client.get("http://127.0.0.1:$port/api/status") {
+                header("Authorization", "bearer wrong-key")
+            }
+            assertEquals(HttpStatusCode.Unauthorized, wrong.status)
+        } finally {
+            server.stop()
+        }
+    }
+
+    @Test
+    fun `api heads emits numeric gate values, and unlimited mode as string-or-null`() = runTest {
+        val tmp = Files.createTempDirectory("control-gate")
+        val paths = StatePaths(baseOverride = tmp.resolve("state"))
+        val mgmt = MgmtKey(paths)
+        val port = freshPort()
+        val server = ControlServer(
+            port = port,
+            heads = mapOf(
+                "bounded" to gateHead("bounded", 4101, inflight = 3, queued = 2, limit = 100),
+                "unlimited" to gateHead("unlimited", 4102, inflight = 5, queued = 0, limit = 0),
+            ),
+            config = ConfigService(paths),
+            mgmtKey = mgmt,
+            dashboardHtml = { "" },
+            log = {},
+        )
+        server.start()
+        try {
+            awaitListening(port)
+            val heads = json.parseToJsonElement(
+                client.get("http://127.0.0.1:$port/api/heads") {
+                    header("Authorization", "Bearer ${mgmt.get()}")
+                }.bodyAsText(),
+            ).jsonObject["heads"]!!.jsonArray.map { it.jsonObject }
+
+            val bounded = heads.first { it["key"]?.jsonPrimitive?.content == "bounded" }
+            val g = bounded["gate"]!!.jsonObject
+            assertFalse(g["inflight"]!!.jsonPrimitive.isString, "inflight must be a JSON number")
+            assertEquals(3, g["inflight"]!!.jsonPrimitive.int)
+            assertEquals(2, g["queued"]!!.jsonPrimitive.int)
+            assertFalse(g["max"]!!.jsonPrimitive.isString, "bounded max must be a JSON number")
+            assertEquals(100, g["max"]!!.jsonPrimitive.int)
+            assertEquals(100, bounded["maxInflight"]!!.jsonPrimitive.int)
+
+            val unlimited = heads.first { it["key"]?.jsonPrimitive?.content == "unlimited" }
+            val umax = unlimited["gate"]!!.jsonObject["max"]!!.jsonPrimitive
+            assertTrue(umax.isString && umax.content == "unlimited", "unlimited max must be the string")
+            assertTrue(unlimited["maxInflight"] is JsonNull, "unlimited maxInflight must be JSON null")
+        } finally {
+            server.stop()
+        }
+    }
+
+    private fun gateHead(key: String, port: Int, inflight: Int, queued: Int, limit: Int) = ManagedHead(
+        head = GateFakeHead(key, port, inflight, queued, limit),
+        auth = GateFakeAuth(),
+        usage = HeadUsageSource { UsageView(0L, 0, null) },
+        compact = object : HeadCompactSource {
+            override fun summary(tailN: Int) = CompactView(0, emptyMap(), emptyList())
+        },
+        logs = object : HeadLogSource {
+            override fun tail(lines: Int) = ""
+            override fun path() = "/tmp/$key.log"
+        },
+        warnPct = 80,
+        warnTokens5h = 0,
+    )
+}
+
+private fun freshPort(): Int = ServerSocket(0).use { it.localPort }
+
+private fun awaitListening(port: Int) {
+    val deadline = System.currentTimeMillis() + 10_000
+    while (runCatching { Socket("127.0.0.1", port).use { } }.isFailure) {
+        check(System.currentTimeMillis() < deadline) { "nothing listening on :$port" }
+        Thread.sleep(50)
+    }
+}

--- a/gateway/control/src/test/kotlin/ControlServerTest.kt
+++ b/gateway/control/src/test/kotlin/ControlServerTest.kt
@@ -193,6 +193,42 @@ class ControlServerTest {
     }
 
     @Test
+    fun `degraded health denominator counts configured heads so ready plus failed equals heads`() = runTest {
+        // An ASSEMBLY-failed head never enters the `heads` map but IS counted in failedHeads;
+        // reporting heads.size (assembled only) broke the readyHeads + failedHeads == heads
+        // invariant a launch shim waits on. Report the configured total (review 2026-07-23).
+        val tmp = Files.createTempDirectory("control-degraded")
+        val paths = StatePaths(baseOverride = tmp.resolve("state"))
+        val degradedPort = freshPort()
+        val degraded = ControlServer(
+            port = degradedPort,
+            heads = emptyMap(), // the sole configured head failed to ASSEMBLE — never entered `heads`
+            config = ConfigService(paths),
+            mgmtKey = MgmtKey(paths),
+            dashboardHtml = { "" },
+            log = {},
+            failedHeads = { 1 },
+            configuredHeads = 1,
+        )
+        degraded.start()
+        try {
+            awaitListening(degradedPort)
+            val body = json.parseToJsonElement(
+                client.get("http://127.0.0.1:$degradedPort/health").bodyAsText(),
+            ).jsonObject
+            val heads = body["heads"]!!.jsonPrimitive.content.toInt()
+            val ready = body["readyHeads"]!!.jsonPrimitive.content.toInt()
+            val failed = body["failedHeads"]!!.jsonPrimitive.content.toInt()
+            assertEquals(1, heads)
+            assertEquals(0, ready)
+            assertEquals(1, failed)
+            assertEquals(heads, ready + failed) // the invariant the launch shim converges on
+        } finally {
+            degraded.stop()
+        }
+    }
+
+    @Test
     fun `bearer guard - 401 without the key, 200 with`() = runTest {
         val unauth = client.get("http://127.0.0.1:$port/api/status")
         assertEquals(HttpStatusCode.Unauthorized, unauth.status)

--- a/gateway/control/src/test/kotlin/StatuslineGitRootTest.kt
+++ b/gateway/control/src/test/kotlin/StatuslineGitRootTest.kt
@@ -1,0 +1,48 @@
+// NEW (finding 5, review 2026-07-23): the unauthenticated /statusline endpoint only runs `git -C`
+// under $HOME, /tmp, or an operator-trusted root. That containment must resolve symlinks FIRST — a
+// lexical startsWith() check let a symlink sitting UNDER a trusted root (e.g. /tmp/link) point git at
+// a target OUTSIDE the roots. safeGitCwd now resolves real paths on both sides, so the escape is
+// rejected while a genuinely-contained symlink still resolves (and git runs in the resolved path).
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import splice.control.StatuslineRenderer
+import java.nio.file.Files
+import java.nio.file.Paths
+
+class StatuslineGitRootTest {
+
+    private val renderer = StatuslineRenderer(label = "codex")
+
+    @Test
+    fun `a symlink under a trusted root pointing outside the roots is rejected`() {
+        // /usr exists on every Linux host and is NOT under $HOME or /tmp — the review's concrete
+        // "/tmp/link -> /outside/roots" escape. The link itself lexically sits under /tmp (trusted),
+        // so only realpath resolution reveals the escape: the old startsWith check passed this.
+        val outside = Paths.get("/usr")
+        assumeTrue(Files.isDirectory(outside), "/usr must exist to serve as an outside-roots target")
+        val tmpDir = Files.createTempDirectory("statusline-escape")
+        val link = tmpDir.resolve("repo-link")
+        Files.createSymbolicLink(link, outside)
+        assertNull(renderer.safeGitCwd(link.toString()), "a symlink escaping the trusted roots must not run git")
+    }
+
+    @Test
+    fun `a symlink whose real path stays under a trusted root resolves to that real path`() {
+        val tmpDir = Files.createTempDirectory("statusline-contained")
+        val realRepo = Files.createDirectory(tmpDir.resolve("real-repo"))
+        val link = tmpDir.resolve("repo-link")
+        Files.createSymbolicLink(link, realRepo)
+        // Trust the temp tree explicitly (not relying on java.io.tmpdir == /tmp). Contained: the
+        // resolved real path stays under the trusted root, so it is returned — and it is the RESOLVED
+        // path (proving toRealPath ran), which is what git -C is handed.
+        val trusting = StatuslineRenderer(label = "codex", extraGitRoots = listOf(tmpDir.toString()))
+        assertEquals(realRepo.toRealPath(), trusting.safeGitCwd(link.toString()))
+    }
+
+    @Test
+    fun `a non-existent path is rejected because toRealPath requires existence`() {
+        assertNull(renderer.safeGitCwd("/tmp/splice-statusline-does-not-exist-xyzzy"))
+    }
+}

--- a/gateway/core/src/main/kotlin/splice/core/auth/BearerToken.kt
+++ b/gateway/core/src/main/kotlin/splice/core/auth/BearerToken.kt
@@ -1,0 +1,14 @@
+// NEW: the ONE bearer-scheme parser. Control-plane (MgmtKey.matchesBearer) and inference
+// (HeadServer.authorize) must accept identical Authorization bytes; each carried its own copy of
+// this regex and they drifted once already — the control plane rejected lowercase `bearer` until
+// 2026-07-22 because only the inference copy was case-insensitive.
+package splice.core.auth
+
+private val BEARER = Regex("^Bearer\\s+(.+)$", RegexOption.IGNORE_CASE)
+
+/** The token after a case-insensitive `Bearer` scheme, trimmed; null when [header] isn't bearer-shaped. */
+public fun bearerToken(header: String?): String? =
+    BEARER.find(header.orEmpty().trim())
+        ?.groupValues
+        ?.get(1)
+        ?.trim()

--- a/gateway/core/src/main/kotlin/splice/core/config/ConfigService.kt
+++ b/gateway/core/src/main/kotlin/splice/core/config/ConfigService.kt
@@ -250,7 +250,11 @@ public class ConfigService(
             }
             KnobKind.NUMBER -> {
                 val s = raw.toString().trim().lowercase()
-                if (knob == Knob.MAX_INFLIGHT && s in setOf("", "unlimited", "off", "none")) {
+                // maxInflight AND maxQueued both treat <=0 as unlimited in InflightGate — accept
+                // the same named sentinels so PATCH/env maxQueued=unlimited is not rejected.
+                if (knob in setOf(Knob.MAX_INFLIGHT, Knob.MAX_QUEUED) &&
+                    s in setOf("", "unlimited", "off", "none")
+                ) {
                     0L
                 } else {
                     s.toDoubleOrNull()?.takeIf { it.isFinite() }?.toLong()

--- a/gateway/core/src/main/kotlin/splice/core/config/ConfigService.kt
+++ b/gateway/core/src/main/kotlin/splice/core/config/ConfigService.kt
@@ -326,6 +326,11 @@ public class SpliceConfig internal constructor(private val m: Map<String, Any?>)
     public val usageWarnPct: Int get() = long(Knob.USAGE_WARN_PCT).toInt()
     public val usageWarnTokens5h: Long get() = long(Knob.USAGE_WARN_TOKENS_5H)
 
+    // Colon-separated absolute paths → list; relative segments are dropped (trust boundary).
+    public val statuslineGitRoots: List<String>
+        get() = string(Knob.STATUSLINE_GIT_ROOTS).orEmpty()
+            .split(':').map { it.trim() }.filter { it.startsWith("/") }
+
     public fun asMap(): Map<String, Any?> = m
 
     private fun string(k: Knob): String? = m[k.key]?.toString()

--- a/gateway/core/src/main/kotlin/splice/core/config/Knob.kt
+++ b/gateway/core/src/main/kotlin/splice/core/config/Knob.kt
@@ -226,6 +226,17 @@ public enum class Knob(
         0L,
         restartRequired = true,
     ),
+
+    // Extra trusted roots (colon-separated absolute paths) for the statusline git-branch lookup.
+    // Default empty: only $HOME and /tmp are trusted, so repos elsewhere (devcontainer /workspace,
+    // /srv layouts) show no branch segment — unauthenticated /statusline must never exec
+    // `git -C` against an untrusted path (review 2026-07-22).
+    STATUSLINE_GIT_ROOTS(
+        "statuslineGitRoots",
+        KnobKind.STRING,
+        listOf("CLAUDEX_STATUSLINE_GIT_ROOTS"),
+        "",
+    ),
     ;
 
     public companion object {

--- a/gateway/core/src/main/kotlin/splice/core/config/Knob.kt
+++ b/gateway/core/src/main/kotlin/splice/core/config/Knob.kt
@@ -126,10 +126,11 @@ public enum class Knob(
         restartRequired = true,
     ),
 
-    // Bounded by default since the 2026-07-19 storm: unlimited (0) let ~650 concurrent streams
-    // hit one rate-limited account and OOM the 1G heap. 0 still means unlimited for an explicit
-    // operator opt-out; both stay live-PATCHable.
-    MAX_INFLIGHT("maxInflight", KnobKind.NUMBER, listOf("CLAUDEX_MAX_INFLIGHT"), 48L),
+    // Per-head admission (each head is a different backend/account). Bounded by default since the
+    // 2026-07-19 storm: unlimited (0) let ~650 concurrent streams OOM the 1G heap. Default 100
+    // (was 48) leaves headroom for multi-agent fleets without reopening the unlimited storm.
+    // 0 still means unlimited for an explicit operator opt-out; both stay live-PATCHable.
+    MAX_INFLIGHT("maxInflight", KnobKind.NUMBER, listOf("CLAUDEX_MAX_INFLIGHT"), 100L),
     MAX_QUEUED("maxQueued", KnobKind.NUMBER, listOf("CLAUDEX_MAX_QUEUED"), 512L),
     UPSTREAM_RETRIES(
         "upstreamRetries",

--- a/gateway/core/src/main/kotlin/splice/core/config/MgmtKey.kt
+++ b/gateway/core/src/main/kotlin/splice/core/config/MgmtKey.kt
@@ -3,6 +3,7 @@
 // before the port opens (a dashboard load must never race an unminted key). timingSafe compare.
 package splice.core.config
 
+import splice.core.auth.bearerToken
 import splice.core.util.SecureFile
 import splice.core.util.discard
 import java.nio.file.Files
@@ -29,16 +30,10 @@ public class MgmtKey(private val statePaths: StatePaths) {
         return key
     }
 
-    /** Constant-time bearer check (`Authorization: Bearer <key>`). Case-insensitive scheme
-     *  (HTTP-common `bearer` lowercase) — matches HeadServer.authorize so the same token bytes
-     *  work on inference and the control plane. */
+    /** Constant-time bearer check (`Authorization: Bearer <key>`) — scheme parsing shared with
+     *  HeadServer.authorize via [bearerToken] so the same token bytes work on both planes. */
     public fun matchesBearer(header: String?): Boolean {
-        val presented = Regex("^Bearer\\s+(.+)$", RegexOption.IGNORE_CASE)
-            .find(header.orEmpty().trim())
-            ?.groupValues
-            ?.get(1)
-            ?.trim()
-            ?: return false
+        val presented = bearerToken(header) ?: return false
         val a = presented.toByteArray()
         val b = value.toByteArray()
         return a.size == b.size && MessageDigest.isEqual(a, b)

--- a/gateway/core/src/main/kotlin/splice/core/config/MgmtKey.kt
+++ b/gateway/core/src/main/kotlin/splice/core/config/MgmtKey.kt
@@ -29,9 +29,15 @@ public class MgmtKey(private val statePaths: StatePaths) {
         return key
     }
 
-    /** Constant-time bearer check (`Authorization: Bearer <key>`). */
+    /** Constant-time bearer check (`Authorization: Bearer <key>`). Case-insensitive scheme
+     *  (HTTP-common `bearer` lowercase) — matches HeadServer.authorize so the same token bytes
+     *  work on inference and the control plane. */
     public fun matchesBearer(header: String?): Boolean {
-        val presented = Regex("^Bearer\\s+(.+)$").find(header.orEmpty().trim())?.groupValues?.get(1)?.trim()
+        val presented = Regex("^Bearer\\s+(.+)$", RegexOption.IGNORE_CASE)
+            .find(header.orEmpty().trim())
+            ?.groupValues
+            ?.get(1)
+            ?.trim()
             ?: return false
         val a = presented.toByteArray()
         val b = value.toByteArray()

--- a/gateway/core/src/main/kotlin/splice/core/head/Head.kt
+++ b/gateway/core/src/main/kotlin/splice/core/head/Head.kt
@@ -28,4 +28,8 @@ public data class HeadHealth(
     // split_external_local_origin_errors shape). Reset on head restart — diagnosis, not telemetry.
     val localOriginErrors: Long = 0,
     val providerErrors: Long = 0,
+    // Live InflightGate snapshot (webui HeadPlate "gate inflight / queued"). limit<=0 = unlimited.
+    val gateInflight: Int = 0,
+    val gateQueued: Int = 0,
+    val gateLimit: Int = 0,
 )

--- a/gateway/core/src/main/kotlin/splice/core/model/ModelCatalog.kt
+++ b/gateway/core/src/main/kotlin/splice/core/model/ModelCatalog.kt
@@ -45,10 +45,15 @@ public data class ModelCatalog(
 
     public val defaultModel: String get() = models.first().id
 
-    private val exactWindows: Map<String, Long> =
-        models.associate { it.id to it.contextWindow } + extraWindows.associate { it.id to it.contextWindow }
-
     private val suffixHint = Regex("\\[1m]$", RegexOption.IGNORE_CASE)
+
+    // Canonical (suffix-stripped) ids — `contains` and `contextWindowFor` both strip the query the
+    // same way. Storing the RAW picker id (e.g. "k3[1m]") let membership pass after the contains
+    // fix while contextWindowFor("k3[1m]") looked up stripped "k3" and missed → default 256k window
+    // / early autocompact (residual of the [1m] membership fix).
+    private val exactWindows: Map<String, Long> =
+        models.associate { stripSuffixes(it.id) to it.contextWindow } +
+            extraWindows.associate { stripSuffixes(it.id) to it.contextWindow }
 
     // Canonical (suffix-stripped) ids — `contains` strips its query the same way, so both sides
     // compare on the upstream id. Storing the RAW id here let a "[1m]" picker model (kimi k3[1m])

--- a/gateway/core/src/main/kotlin/splice/core/util/JsonScalars.kt
+++ b/gateway/core/src/main/kotlin/splice/core/util/JsonScalars.kt
@@ -14,6 +14,9 @@ import kotlinx.serialization.json.JsonPrimitive
 /** The scalar content of this element, or null if it is absent, JSON `null`, or not a primitive. */
 public fun JsonElement?.str(): String? = (this as? JsonPrimitive)?.takeUnless { it is JsonNull }?.content
 
+/** Prefix-form non-null read: "" for absent / JSON null / non-primitive — the dialects' shared shape. */
+public fun strOrEmpty(el: JsonElement?): String = el.str().orEmpty()
+
 /** The scalar string at [key] (JsonNull-safe). */
 public fun JsonObject.str(key: String): String? = this[key].str()
 

--- a/gateway/core/src/main/kotlin/splice/core/util/MonoClock.kt
+++ b/gateway/core/src/main/kotlin/splice/core/util/MonoClock.kt
@@ -1,0 +1,16 @@
+// NEW: monotonic wall-clock hybrid for idle/deadline budgets. System.currentTimeMillis jumps on
+// sleep/wake and NTP steps, which made TurnWatchdog/InflightGate.Slot either abort healthy turns
+// (forward jump) or pin gate slots forever (backward jump). This clock advances only with
+// System.nanoTime (monotonic) while still reporting values near epoch-ms so existing log lines
+// and injected test clocks stay comparable.
+package splice.core.util
+
+import java.util.concurrent.TimeUnit
+
+public object MonoClock {
+    private val originMs: Long = System.currentTimeMillis()
+    private val originNs: Long = System.nanoTime()
+
+    /** Milliseconds since an arbitrary origin, advancing only with monotonic nano time. */
+    public fun nowMs(): Long = originMs + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - originNs)
+}

--- a/gateway/core/src/main/kotlin/splice/core/wire/AnthropicRequest.kt
+++ b/gateway/core/src/main/kotlin/splice/core/wire/AnthropicRequest.kt
@@ -149,10 +149,14 @@ public object SystemTextSerializer : KSerializer<String?> {
 
     private fun JsonElement.jsonObjectListTexts(): String? {
         val arr = this as? JsonArray ?: return null
+        // Byte-preserving concatenation with NO separator — Anthropic's own multi-block system
+        // behavior joins text blocks back-to-back (verified 2026-07-23); a delimiter here invents a
+        // character the client never sent and can break cache-control prefixes. Callers that want a
+        // boundary put it in the block text (the fixtures carry their own trailing spaces).
         return arr.mapNotNull { el ->
             val obj = el as? JsonObject ?: return@mapNotNull null
             if (obj["type"]?.jsonPrimitive?.content == "text") obj["text"]?.jsonPrimitive?.content else null
-        }.joinToString("\n")
+        }.joinToString("")
     }
 }
 

--- a/gateway/core/src/main/kotlin/splice/core/wire/AnthropicRequest.kt
+++ b/gateway/core/src/main/kotlin/splice/core/wire/AnthropicRequest.kt
@@ -152,7 +152,7 @@ public object SystemTextSerializer : KSerializer<String?> {
         return arr.mapNotNull { el ->
             val obj = el as? JsonObject ?: return@mapNotNull null
             if (obj["type"]?.jsonPrimitive?.content == "text") obj["text"]?.jsonPrimitive?.content else null
-        }.joinToString("")
+        }.joinToString("\n")
     }
 }
 

--- a/gateway/core/src/main/kotlin/splice/core/wire/OpenAiToolChoice.kt
+++ b/gateway/core/src/main/kotlin/splice/core/wire/OpenAiToolChoice.kt
@@ -1,0 +1,20 @@
+// NEW: Anthropic tool_choice → OpenAI tool_choice. ONE mapper for both OpenAI-family dialects — Chat
+// and Responses carried byte-identical private copies (the v29 copies-drift class; review
+// 2026-07-22): auto/none map straight through, Anthropic "any" is OpenAI "required", and a named
+// tool becomes {"type":"function","function":{"name":...}}. Absent or unrecognized → "auto".
+package splice.core.wire
+
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+public fun openAiToolChoice(choice: ToolChoice?): JsonElement = when {
+    choice?.type == "none" -> JsonPrimitive("none")
+    choice?.type == "any" -> JsonPrimitive("required")
+    choice?.type == "tool" && choice.name != null -> buildJsonObject {
+        put("type", "function")
+        put("function", buildJsonObject { put("name", choice.name) })
+    }
+    else -> JsonPrimitive("auto") // null / "auto" / unrecognized types
+}

--- a/gateway/core/src/test/kotlin/AnthropicParseTest.kt
+++ b/gateway/core/src/test/kotlin/AnthropicParseTest.kt
@@ -32,8 +32,9 @@ class AnthropicParseTest {
         val req = body.typed
 
         assertEquals("claude-codex--gpt-5.6-sol", req.model)
-        // Multi-block system joins with newline (not "") so adjacent blocks don't glue last/first chars.
-        assertEquals("You are terse. \nSecond part.", req.system)
+        // Byte-preserving: multi-block system concatenates with NO separator (Anthropic-native), so
+        // the block's own trailing space survives and no newline is invented (review 2026-07-23).
+        assertEquals("You are terse. Second part.", req.system)
         assertEquals(2, req.tools.size)
         assertEquals("run", req.tools[0].name)
         assertEquals("object", req.tools[0].inputSchema?.get("type")?.jsonPrimitive?.content)
@@ -58,6 +59,18 @@ class AnthropicParseTest {
         val unknown = userTurn.filterIsInstance<UnknownBlock>().single()
         assertEquals("future_widget", unknown.type)
         assertEquals("kept", unknown.raw["payload"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `adjacent system blocks concatenate with no invented separator`() {
+        // Byte-preservation: two blocks with NO trailing whitespace must NOT gain a newline/space
+        // between them (Anthropic joins system blocks back-to-back). Inventing a delimiter would
+        // break cache-control prefixes and identifiers split across blocks (review 2026-07-23).
+        val body = parseAnthropicBody(
+            """{"model":"m","system":[{"type":"text","text":"prefix="},{"type":"text","text":"VALUE"}],
+               "messages":[{"role":"user","content":"x"}]}""",
+        )
+        assertEquals("prefix=VALUE", body.typed.system)
     }
 
     @Test

--- a/gateway/core/src/test/kotlin/AnthropicParseTest.kt
+++ b/gateway/core/src/test/kotlin/AnthropicParseTest.kt
@@ -32,7 +32,8 @@ class AnthropicParseTest {
         val req = body.typed
 
         assertEquals("claude-codex--gpt-5.6-sol", req.model)
-        assertEquals("You are terse. Second part.", req.system)
+        // Multi-block system joins with newline (not "") so adjacent blocks don't glue last/first chars.
+        assertEquals("You are terse. \nSecond part.", req.system)
         assertEquals(2, req.tools.size)
         assertEquals("run", req.tools[0].name)
         assertEquals("object", req.tools[0].inputSchema?.get("type")?.jsonPrimitive?.content)

--- a/gateway/core/src/test/kotlin/BearerTokenTest.kt
+++ b/gateway/core/src/test/kotlin/BearerTokenTest.kt
@@ -1,0 +1,34 @@
+// NEW (review gap K, 2026-07-23): bearerToken is the ONE scheme parser both the control plane
+// (MgmtKey.matchesBearer) and inference (HeadServer.authorize) delegate to. The control copy once
+// rejected lowercase `bearer` until the two parsers were unified; pin the case-insensitivity and the
+// negatives so that exact drift can never silently return.
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import splice.core.auth.bearerToken
+
+class BearerTokenTest {
+
+    @Test
+    fun `lowercase and mixed-case bearer schemes are accepted`() {
+        assertEquals("tok", bearerToken("bearer tok"))
+        assertEquals("tok", bearerToken("Bearer tok"))
+        assertEquals("tok", bearerToken("BEARER tok"))
+        assertEquals("tok", bearerToken("BeArEr    tok"))
+    }
+
+    @Test
+    fun `surrounding whitespace on the header and token is trimmed`() {
+        assertEquals("tok", bearerToken("  bearer   tok  "))
+    }
+
+    @Test
+    fun `non-bearer, malformed, and missing headers are rejected`() {
+        assertNull(bearerToken("Basic tok"))
+        assertNull(bearerToken("bearertok")) // no scheme delimiter
+        assertNull(bearerToken("bearer")) // scheme only, no token
+        assertNull(bearerToken("bearer   ")) // scheme + only whitespace
+        assertNull(bearerToken(""))
+        assertNull(bearerToken(null))
+    }
+}

--- a/gateway/core/src/test/kotlin/ConfigServiceTest.kt
+++ b/gateway/core/src/test/kotlin/ConfigServiceTest.kt
@@ -194,4 +194,13 @@ class ConfigServiceTest {
         assertEquals("high", svc.getConfig().effort)
         assertEquals(77, svc.getConfig().maxQueued)
     }
+
+    @Test
+    fun `statuslineGitRoots parses colon-separated absolute paths and drops relative entries`() {
+        assertEquals(emptyList<String>(), service().getConfig().statuslineGitRoots)
+        val cfg = service(
+            env = mapOf("CLAUDEX_STATUSLINE_GIT_ROOTS" to "/workspace:/srv/repos:relative:"),
+        ).getConfig()
+        assertEquals(listOf("/workspace", "/srv/repos"), cfg.statuslineGitRoots)
+    }
 }

--- a/gateway/core/src/test/kotlin/ConfigServiceTest.kt
+++ b/gateway/core/src/test/kotlin/ConfigServiceTest.kt
@@ -38,7 +38,7 @@ class ConfigServiceTest {
         assertEquals(ReasoningDisplay.TEXT, cfg.showReasoning)
         assertEquals(false, cfg.replayReasoning)
         // Bounded by default since the 2026-07-19 storm (0 = unlimited stays an explicit opt-out).
-        assertEquals(48, cfg.maxInflight)
+        assertEquals(100, cfg.maxInflight)
         assertEquals(512, cfg.maxQueued)
         assertEquals(3096, cfg.controlPort)
     }
@@ -135,7 +135,7 @@ class ConfigServiceTest {
                 "CLAUDEX_MAX_QUEUED" to "Infinity",
             ),
         ).getConfig()
-        assertEquals(48, nonFinite.maxInflight)
+        assertEquals(100, nonFinite.maxInflight)
         assertEquals(512, nonFinite.maxQueued)
     }
 

--- a/gateway/core/src/test/kotlin/ModelCatalogTest.kt
+++ b/gateway/core/src/test/kotlin/ModelCatalogTest.kt
@@ -107,4 +107,21 @@ class ModelCatalogTest {
         assertTrue(kimi.contains("kimi-for-coding"), "a sibling non-suffixed model still resolves")
         assertFalse(kimi.contains("k9"), "a genuinely foreign model is still rejected")
     }
+
+    @Test
+    fun `contextWindowFor strips 1m suffix so picker id windows resolve without extraWindows`() {
+        // Residual of the membership fix: modelIds stripped but exactWindows keyed raw picker ids,
+        // so contains("k3[1m]") passed while contextWindowFor fell to default 256k.
+        val kimi = ModelCatalog(
+            discoveryPrefix = "claude-kimi--",
+            models = listOf(
+                ModelEntry(id = "k3[1m]", label = "Kimi K3 (1M)", contextWindow = 1_048_576),
+            ),
+            defaultContextWindow = 262_144,
+        )
+        assertEquals(1_048_576, kimi.contextWindowFor("k3[1m]"), "picker id")
+        assertEquals(1_048_576, kimi.contextWindowFor("k3"), "bare upstream after strip")
+        assertEquals(1_048_576, kimi.contextWindowFor("claude-kimi--k3[1m]"), "wrapped picker id")
+        assertEquals(1_048_576, kimi.contextWindowFor("claude-kimi--k3"), "wrapped bare id")
+    }
 }

--- a/gateway/dialect-anthropic-passthrough/src/main/kotlin/splice/dialect/passthrough/PassthroughRequestBuilder.kt
+++ b/gateway/dialect-anthropic-passthrough/src/main/kotlin/splice/dialect/passthrough/PassthroughRequestBuilder.kt
@@ -11,16 +11,15 @@ package splice.dialect.passthrough
 
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonObjectBuilder
-import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import splice.core.parse.AnthropicTurnBody
 import splice.core.turn.ReasoningDisplay
 import splice.core.turn.TurnMeta
+import splice.core.util.strOrEmpty
 import splice.core.wire.AnthropicRequest
 
 public data class PassthroughQuirks(
@@ -151,7 +150,7 @@ public class PassthroughRequestBuilder(private val quirks: PassthroughQuirks) {
 
     /** Keep an accepted block (cache_control stripped, tool_result inner content filtered) or drop. */
     private fun scrubBlock(block: JsonObject): JsonObject? {
-        val type = str(block["type"])
+        val type = strOrEmpty(block["type"])
         if (type !in ALLOWED_BLOCK_TYPES) return null
         if (isEmptyThinking(type, block)) return null
         return rebuildBlock(block, type)
@@ -160,7 +159,7 @@ public class PassthroughRequestBuilder(private val quirks: PassthroughQuirks) {
     /** A whitespace-only thinking block that carries no signature holds nothing worth keeping. */
     private fun isEmptyThinking(type: String, block: JsonObject): Boolean {
         if (type != TYPE_THINKING) return false
-        return str(block["thinking"]).isBlank() && str(block["signature"]).isEmpty()
+        return strOrEmpty(block["thinking"]).isBlank() && strOrEmpty(block["signature"]).isEmpty()
     }
 
     private fun rebuildBlock(block: JsonObject, type: String): JsonObject = buildJsonObject {
@@ -203,10 +202,6 @@ public class PassthroughRequestBuilder(private val quirks: PassthroughQuirks) {
         is JsonArray -> buildJsonArray { element.forEach { add(stripCacheControl(it)) } }
         else -> element
     }
-
-    // JsonNull IS a JsonPrimitive whose `.content` is "null"; treat an explicit null as absent.
-    private fun str(element: JsonElement?): String =
-        (element as? JsonPrimitive)?.takeUnless { it is JsonNull }?.content ?: ""
 
     private companion object {
         const val MODEL = "model"

--- a/gateway/dialect-anthropic-passthrough/src/main/kotlin/splice/dialect/passthrough/PassthroughStreamTranslator.kt
+++ b/gateway/dialect-anthropic-passthrough/src/main/kotlin/splice/dialect/passthrough/PassthroughStreamTranslator.kt
@@ -16,17 +16,18 @@ package splice.dialect.passthrough
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import splice.core.index.WireBlockIndex
 import splice.core.turn.ErrorType
 import splice.core.turn.TurnOutcome
 import splice.core.turn.Usage
+import splice.core.util.strOrEmpty
 import splice.spi.StreamTranslator
+import splice.spi.TerminalStates
 import splice.spi.WatchdogFired
 import splice.spi.WireSink
+import splice.spi.terminalPrecedence
 import java.io.IOException
 import java.util.concurrent.CancellationException
 
@@ -76,21 +77,21 @@ public class PassthroughStreamTranslator(private val ctx: PassthroughTurnContext
         return terminalOutcome()
     }
 
-    // A FINISHED turn wins over a late watchdog fire (Chat/Responses parity): the poller watches
-    // the whole coroutine, which can sit on the socket-EOF read AFTER message_stop already arrived.
-    // Preferring watchdog here discarded successful kimi turns and burned quota on retries.
-    private fun terminalOutcome(): TurnOutcome =
-        failureType?.let {
-            // a genuine upstream SSE error event (e.g. overloaded_error) — provider-reported (G20)
-            TurnOutcome.Failure(it, "kimi: $failureMessage", providerReported = true)
-        }
-            ?: if (finished) {
-                successOutcome()
-            } else {
-                ctx.watchdogFired()?.let {
-                    TurnOutcome.Failure(ErrorType.OVERLOADED, "kimi: upstream stalled — aborted; retry")
-                } ?: unfinishedOutcome()
-            }
+    // Ordering enforced by the shared spi.terminalPrecedence (a FINISHED turn beats a late
+    // watchdog fire — preferring watchdog here discarded successful kimi turns and burned quota).
+    private fun terminalOutcome(): TurnOutcome = terminalPrecedence(
+        TerminalStates(
+            providerFailure = failureType?.let {
+                // a genuine upstream SSE error event (e.g. overloaded_error) — provider-reported (G20)
+                TurnOutcome.Failure(it, "kimi: $failureMessage", providerReported = true)
+            },
+            finished = finished,
+            watchdogFired = ctx.watchdogFired(),
+        ),
+        onFinished = ::successOutcome,
+        onWatchdog = { TurnOutcome.Failure(ErrorType.OVERLOADED, "kimi: upstream stalled — aborted; retry") },
+        onUnfinished = ::unfinishedOutcome,
+    )
 
     private fun unfinishedOutcome(): TurnOutcome =
         if (ctx.clientGone()) {
@@ -118,7 +119,7 @@ public class PassthroughStreamTranslator(private val ctx: PassthroughTurnContext
     )
 
     private suspend fun onEvent(evt: JsonObject, sink: WireSink) {
-        when (str(evt["type"])) {
+        when (strOrEmpty(evt["type"])) {
             "message_start" -> harvestUsage((evt["message"] as? JsonObject)?.get("usage") as? JsonObject)
             "content_block_start" -> onBlockStart(evt, sink)
             "content_block_delta" -> onBlockDelta(evt, sink)
@@ -135,13 +136,15 @@ public class PassthroughStreamTranslator(private val ctx: PassthroughTurnContext
     private suspend fun onBlockStart(evt: JsonObject, sink: WireSink) {
         val index = intIndex(evt) ?: return
         val cb = evt["content_block"] as? JsonObject
-        blocks[index] = when (str(cb?.get("type"))) {
+        blocks[index] = when (strOrEmpty(cb?.get("type"))) {
             "text" -> Block(Kind.TEXT, sink.openText())
             "thinking" -> Block(Kind.THINKING, sink.openThinking())
             "tool_use" -> {
-                // Pass Kimi's tool id VERBATIM: it round-trips back to Kimi on the next turn.
+                // Pass Kimi's tool id VERBATIM: it round-trips back to Kimi on the next turn — a
+                // JsonNull id must never leak as the literal string "null" into that round-trip (L3);
+                // strOrEmpty keeps it filtered (review 2026-07-22 round 3).
                 hasToolUse = true
-                Block(Kind.TOOL, sink.openTool(str(cb?.get("id")), str(cb?.get("name"))))
+                Block(Kind.TOOL, sink.openTool(strOrEmpty(cb?.get("id")), strOrEmpty(cb?.get("name"))))
             }
             // server_tool_use / web_search_tool_result / unknown: record + swallow its deltas.
             else -> Block(Kind.IGNORED, null)
@@ -157,21 +160,21 @@ public class PassthroughStreamTranslator(private val ctx: PassthroughTurnContext
     }
 
     private suspend fun applyDelta(block: Block, wire: WireBlockIndex, delta: JsonObject, sink: WireSink) {
-        when (str(delta["type"])) {
+        when (strOrEmpty(delta["type"])) {
             "text_delta" -> {
-                val t = str(delta["text"])
+                val t = strOrEmpty(delta["text"])
                 textBuf.append(t)
                 emittedText = true
                 sink.textDelta(wire, t)
             }
             "thinking_delta" -> {
-                val t = str(delta["thinking"])
+                val t = strOrEmpty(delta["thinking"])
                 thinkingBuf.append(t)
                 sink.thinkingDelta(wire, t)
             }
-            "input_json_delta" -> sink.inputJsonDelta(wire, str(delta["partial_json"]))
+            "input_json_delta" -> sink.inputJsonDelta(wire, strOrEmpty(delta["partial_json"]))
             "signature_delta" -> {
-                sink.signatureDelta(wire, str(delta["signature"]))
+                sink.signatureDelta(wire, strOrEmpty(delta["signature"]))
                 block.signatureSeen = true
             }
             else -> Unit
@@ -190,7 +193,7 @@ public class PassthroughStreamTranslator(private val ctx: PassthroughTurnContext
     }
 
     private fun onMessageDelta(evt: JsonObject) {
-        val reason = str((evt["delta"] as? JsonObject)?.get("stop_reason"))
+        val reason = strOrEmpty((evt["delta"] as? JsonObject)?.get("stop_reason"))
         when (reason) {
             "tool_use" -> hasToolUse = true
             "max_tokens" -> incomplete = true
@@ -201,14 +204,14 @@ public class PassthroughStreamTranslator(private val ctx: PassthroughTurnContext
 
     private fun onError(evt: JsonObject) {
         val err = evt["error"] as? JsonObject
-        failureType = when (str(err?.get("type"))) {
+        failureType = when (strOrEmpty(err?.get("type"))) {
             "overloaded_error" -> ErrorType.OVERLOADED
             "rate_limit_error" -> ErrorType.RATE_LIMIT
             "authentication_error" -> ErrorType.AUTHENTICATION
             "invalid_request_error" -> ErrorType.INVALID_REQUEST
             else -> ErrorType.API_ERROR
         }
-        failureMessage = str(err?.get("message")).ifEmpty { "error" }
+        failureMessage = strOrEmpty(err?.get("message")).ifEmpty { "error" }
     }
 
     private fun harvestUsage(u: JsonObject?) {
@@ -222,11 +225,6 @@ public class PassthroughStreamTranslator(private val ctx: PassthroughTurnContext
     private fun intIndex(evt: JsonObject): Int? = (evt["index"] as? JsonPrimitive)?.content?.toIntOrNull()
 
     private fun num(obj: JsonObject, key: String): Long? = (obj[key] as? JsonPrimitive)?.content?.toLongOrNull()
-
-    // JsonNull IS a JsonPrimitive whose `.content` is "null"; treat an explicit null as absent so it
-    // never leaks into text/ids and a null field cannot masquerade as a real value (L3).
-    private fun str(element: JsonElement?): String =
-        (element as? JsonPrimitive)?.takeUnless { it is JsonNull }?.content ?: ""
 
     private companion object {
         // Short stable constant — Kimi never verifies signatures; Claude Code only needs one present.

--- a/gateway/dialect-anthropic-passthrough/src/main/kotlin/splice/dialect/passthrough/PassthroughStreamTranslator.kt
+++ b/gateway/dialect-anthropic-passthrough/src/main/kotlin/splice/dialect/passthrough/PassthroughStreamTranslator.kt
@@ -76,15 +76,21 @@ public class PassthroughStreamTranslator(private val ctx: PassthroughTurnContext
         return terminalOutcome()
     }
 
+    // A FINISHED turn wins over a late watchdog fire (Chat/Responses parity): the poller watches
+    // the whole coroutine, which can sit on the socket-EOF read AFTER message_stop already arrived.
+    // Preferring watchdog here discarded successful kimi turns and burned quota on retries.
     private fun terminalOutcome(): TurnOutcome =
         failureType?.let {
             // a genuine upstream SSE error event (e.g. overloaded_error) — provider-reported (G20)
             TurnOutcome.Failure(it, "kimi: $failureMessage", providerReported = true)
         }
-            ?: ctx.watchdogFired()?.let {
-                TurnOutcome.Failure(ErrorType.OVERLOADED, "kimi: upstream stalled — aborted; retry")
+            ?: if (finished) {
+                successOutcome()
+            } else {
+                ctx.watchdogFired()?.let {
+                    TurnOutcome.Failure(ErrorType.OVERLOADED, "kimi: upstream stalled — aborted; retry")
+                } ?: unfinishedOutcome()
             }
-            ?: if (!finished) unfinishedOutcome() else successOutcome()
 
     private fun unfinishedOutcome(): TurnOutcome =
         if (ctx.clientGone()) {

--- a/gateway/dialect-anthropic-passthrough/src/test/kotlin/PassthroughStreamTranslatorTest.kt
+++ b/gateway/dialect-anthropic-passthrough/src/test/kotlin/PassthroughStreamTranslatorTest.kt
@@ -195,4 +195,30 @@ class PassthroughStreamTranslatorTest {
         assertFalse(s.bodyText.contains("null"))
         assertEquals(10, s.usage.inputTokens)
     }
+
+    @Test
+    fun `finished turn beats a late watchdog fire - success not overloaded`() = runTest {
+        // Chat/Responses parity: message_stop already delivered, then poller fires on EOF wait.
+        // Preferring watchdog discarded successful kimi turns and burned quota on retries.
+        val late = PassthroughTurnContext(
+            { false },
+            { splice.spi.WatchdogFired.Idle(180_000, true) },
+            180_000,
+            900_000,
+        )
+        val sink = Rec()
+        val outcome = PassthroughStreamTranslator(late).driveTurn(
+            listOf(
+                ev("""{"type":"message_start","message":{"usage":{"input_tokens":1}}}"""),
+                ev("""{"type":"content_block_start","index":0,"content_block":{"type":"text"}}"""),
+                ev("""{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"done"}}"""),
+                ev("""{"type":"content_block_stop","index":0}"""),
+                ev("""{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}"""),
+                ev("""{"type":"message_stop"}"""),
+            ).asFlow(),
+            sink,
+        )
+        assertTrue(outcome is TurnOutcome.Success, "got $outcome")
+        assertEquals("done", (outcome as TurnOutcome.Success).bodyText)
+    }
 }

--- a/gateway/dialect-openai-chat/src/main/kotlin/splice/dialect/chat/ChatRequest.kt
+++ b/gateway/dialect-openai-chat/src/main/kotlin/splice/dialect/chat/ChatRequest.kt
@@ -19,6 +19,8 @@ internal data class ChatRequest(
     val messages: JsonArray,
     val stream: Boolean,
     val tools: JsonArray? = null,
+    /** OpenAI chat tool_choice: "auto" | "none" | "required" | {"type":"function","function":{name}}. */
+    @SerialName("tool_choice") val toolChoice: kotlinx.serialization.json.JsonElement? = null,
     @SerialName("reasoning_effort") val reasoningEffort: String? = null,
     val reasoning: JsonObject? = null,
     /** Session-pinned server-side prompt cache (xAI honors it on /chat/completions: 135k tokens

--- a/gateway/dialect-openai-chat/src/main/kotlin/splice/dialect/chat/ChatRequestBuilder.kt
+++ b/gateway/dialect-openai-chat/src/main/kotlin/splice/dialect/chat/ChatRequestBuilder.kt
@@ -7,6 +7,7 @@ package splice.dialect.chat
 
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonArrayBuilder
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.JsonPrimitive
@@ -22,6 +23,7 @@ import splice.core.wire.DocumentBlock
 import splice.core.wire.ImageBlock
 import splice.core.wire.MediaSource
 import splice.core.wire.TextBlock
+import splice.core.wire.ToolChoice
 import splice.core.wire.ToolResultBlock
 import splice.core.wire.ToolUseBlock
 
@@ -105,6 +107,7 @@ public class ChatRequestBuilder(
             messages = messages,
             stream = true,
             tools = if (emitTools) toolsArray(body) else null,
+            toolChoice = if (emitTools) chatToolChoice(body.toolChoice) else null,
             reasoningEffort = if (quirks.emitReasoningEffort) effort else null,
             reasoning = if (quirks.emitReasoningEffort && effort != null) {
                 buildJsonObject { put("effort", effort) }
@@ -222,6 +225,10 @@ public class ChatRequestBuilder(
         sink: JsonArrayBuilder,
         toolResults: List<ToolResultBlock>,
     ) {
+        // Emit ALL tool messages first (OpenAI adjacency: every tool must immediately follow
+        // assistant.tool_calls with no intervening user). Image follow-ups land AFTER the full
+        // tool block — inserting user(images) between parallel tools 400s strict validators.
+        val trailingImages = mutableListOf<Pair<String, List<JsonObject>>>()
         toolResults.forEach { tr ->
             val out = tr.content.filterIsInstance<TextBlock>().joinToString("\n") { it.text }
             val images = tr.content.filterIsInstance<ImageBlock>().mapNotNull { imagePart(it.source) }
@@ -232,11 +239,14 @@ public class ChatRequestBuilder(
                 // string-only channel: dropped images (no vision) are declared IN the output.
                 put(CONTENT, if (imageCount > 0 && images.isEmpty()) markerFold(out, imageCount) else out)
             }
-            // v25 doctrine: chat `tool` messages are string-only, so tool_result images ride a
-            // follow-up user message right after the tool output (same as the Responses builder).
             if (images.isNotEmpty()) {
-                appendUserContent(sink, "user", "[images from tool_result ${tr.toolUseId}]", images)
+                trailingImages.add(tr.toolUseId to images)
             }
+        }
+        // v25 doctrine: chat `tool` messages are string-only, so tool_result images ride
+        // follow-up user messages after the contiguous tool block (Responses parity).
+        trailingImages.forEach { (toolUseId, images) ->
+            appendUserContent(sink, "user", "[images from tool_result $toolUseId]", images)
         }
     }
 
@@ -308,11 +318,12 @@ public class ChatRequestBuilder(
 
 /**
  * Map Anthropic thinking budget → chat `reasoning_effort`. Default high so backends that
- * support cleartext CoT actually emit `reasoning_content`. Compact turns stay low-cost.
+ * support cleartext CoT actually emit `reasoning_content`. Compact INHERITS the session effort
+ * (AGENTS cache law — a mismatched effort cold-starts the prompt cache); tools are stripped
+ * separately, effort is not pinned low.
  */
-private fun chatReasoningEffort(body: AnthropicRequest, compact: Boolean): String? {
+private fun chatReasoningEffort(body: AnthropicRequest, @Suppress("UNUSED_PARAMETER") compact: Boolean): String? {
     if (body.thinking?.disabled == true) return null
-    if (compact) return "low"
     val budget = body.thinking?.budgetTokens
     return when {
         budget == null -> "high"
@@ -320,6 +331,20 @@ private fun chatReasoningEffort(body: AnthropicRequest, compact: Boolean): Strin
         budget >= MEDIUM_BUDGET_FLOOR -> "medium"
         budget > 0L -> "low"
         else -> "high"
+    }
+}
+
+/** Anthropic tool_choice → OpenAI chat tool_choice (Responses toolChoice parity). */
+private fun chatToolChoice(choice: ToolChoice?): JsonElement {
+    return when {
+        choice == null || choice.type == "auto" -> JsonPrimitive("auto")
+        choice.type == "none" -> JsonPrimitive("none")
+        choice.type == "any" -> JsonPrimitive("required")
+        choice.type == "tool" && choice.name != null -> buildJsonObject {
+            put("type", "function")
+            put("function", buildJsonObject { put("name", choice.name) })
+        }
+        else -> JsonPrimitive("auto")
     }
 }
 

--- a/gateway/dialect-openai-chat/src/main/kotlin/splice/dialect/chat/ChatRequestBuilder.kt
+++ b/gateway/dialect-openai-chat/src/main/kotlin/splice/dialect/chat/ChatRequestBuilder.kt
@@ -7,7 +7,6 @@ package splice.dialect.chat
 
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonArrayBuilder
-import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.JsonPrimitive
@@ -23,9 +22,9 @@ import splice.core.wire.DocumentBlock
 import splice.core.wire.ImageBlock
 import splice.core.wire.MediaSource
 import splice.core.wire.TextBlock
-import splice.core.wire.ToolChoice
 import splice.core.wire.ToolResultBlock
 import splice.core.wire.ToolUseBlock
+import splice.core.wire.openAiToolChoice
 
 public data class ChatQuirks(
     val providerTag: String,
@@ -69,7 +68,7 @@ public class ChatRequestBuilder(
             body.messages.forEach { msg -> appendMessage(this, msg.role, msg.content) }
         }
         val emitTools = quirks.supportsTools && !compact && body.tools.isNotEmpty()
-        val effort = chatReasoningEffort(body, compact)
+        val effort = chatReasoningEffort(body)
         // TIER-1 (#924): the request is a CLOSED ChatRequest DTO (see chatRequestObject) — a knob
         // that doesn't belong can't be added without a field.
         val cacheKey = quirks.sessionCacheKeyPrefix?.let { prefix -> sessionId?.let { "$prefix:$it" } }
@@ -107,7 +106,7 @@ public class ChatRequestBuilder(
             messages = messages,
             stream = true,
             tools = if (emitTools) toolsArray(body) else null,
-            toolChoice = if (emitTools) chatToolChoice(body.toolChoice) else null,
+            toolChoice = if (emitTools) openAiToolChoice(body.toolChoice) else null,
             reasoningEffort = if (quirks.emitReasoningEffort) effort else null,
             reasoning = if (quirks.emitReasoningEffort && effort != null) {
                 buildJsonObject { put("effort", effort) }
@@ -318,11 +317,11 @@ public class ChatRequestBuilder(
 
 /**
  * Map Anthropic thinking budget → chat `reasoning_effort`. Default high so backends that
- * support cleartext CoT actually emit `reasoning_content`. Compact INHERITS the session effort
- * (AGENTS cache law — a mismatched effort cold-starts the prompt cache); tools are stripped
- * separately, effort is not pinned low.
+ * support cleartext CoT actually emit `reasoning_content`. Compact turns INHERIT the session
+ * effort (AGENTS cache law — a mismatched effort cold-starts the prompt cache); tools are
+ * stripped separately, effort is deliberately not compact-aware.
  */
-private fun chatReasoningEffort(body: AnthropicRequest, @Suppress("UNUSED_PARAMETER") compact: Boolean): String? {
+private fun chatReasoningEffort(body: AnthropicRequest): String? {
     if (body.thinking?.disabled == true) return null
     val budget = body.thinking?.budgetTokens
     return when {
@@ -331,20 +330,6 @@ private fun chatReasoningEffort(body: AnthropicRequest, @Suppress("UNUSED_PARAME
         budget >= MEDIUM_BUDGET_FLOOR -> "medium"
         budget > 0L -> "low"
         else -> "high"
-    }
-}
-
-/** Anthropic tool_choice → OpenAI chat tool_choice (Responses toolChoice parity). */
-private fun chatToolChoice(choice: ToolChoice?): JsonElement {
-    return when {
-        choice == null || choice.type == "auto" -> JsonPrimitive("auto")
-        choice.type == "none" -> JsonPrimitive("none")
-        choice.type == "any" -> JsonPrimitive("required")
-        choice.type == "tool" && choice.name != null -> buildJsonObject {
-            put("type", "function")
-            put("function", buildJsonObject { put("name", choice.name) })
-        }
-        else -> JsonPrimitive("auto")
     }
 }
 

--- a/gateway/dialect-openai-chat/src/main/kotlin/splice/dialect/chat/ChatStreamTranslator.kt
+++ b/gateway/dialect-openai-chat/src/main/kotlin/splice/dialect/chat/ChatStreamTranslator.kt
@@ -10,17 +10,18 @@ package splice.dialect.chat
 import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import splice.core.index.WireBlockIndex
 import splice.core.turn.ErrorType
 import splice.core.turn.TurnOutcome
 import splice.core.turn.Usage
+import splice.core.util.strOrEmpty
 import splice.spi.StreamTranslator
+import splice.spi.TerminalStates
 import splice.spi.WatchdogFired
 import splice.spi.WireSink
+import splice.spi.terminalPrecedence
 import java.io.IOException
 import java.util.concurrent.CancellationException
 
@@ -53,6 +54,7 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
     // parallel call into one corrupted block (ids/names dropped, arguments concatenated).
     private var nextSynthToolIndex = SYNTH_INDEX_BASE
     private val toolIndexById = HashMap<String, Int>()
+
     // Deferred opens: backends often emit index+id first and function.name on a later delta.
     // Opening with name="" freezes an empty tool_use on the Anthropic wire — buffer until name
     // arrives (or finish_reason forces a flush).
@@ -82,35 +84,42 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
         return terminalOutcome()
     }
 
-    // A FINISHED turn wins over a late watchdog fire (same rule the Responses translator pins:
-    // the poller watches the whole coroutine, which can sit on the socket-EOF read AFTER
-    // finish_reason already arrived — discarding a delivered turn retries a successful
-    // generation, the exact quota waste the watchdog exists to prevent).
-    private fun terminalOutcome(): TurnOutcome = when {
-        failure != null ->
-            TurnOutcome.Failure(ErrorType.API_ERROR, "chat backend: $failure", providerReported = true)
-        // finish_reason=content_filter is a CENSORED turn — a clean end_turn would let a blocked
-        // generation masquerade as complete (honesty invariant). Retry an api_error honestly.
-        contentFiltered -> TurnOutcome.Failure(
-            ErrorType.API_ERROR,
-            "chat backend: generation stopped by content filter",
-            providerReported = true, // finish_reason the backend sent, not a local verdict (G20)
-        )
-        finished -> successOutcome()
-        ctx.watchdogFired() != null ->
-            TurnOutcome.Failure(ErrorType.OVERLOADED, "chat: upstream stalled — aborted; retry")
-        else -> unfinishedOutcome()
-    }
-
-    private fun unfinishedOutcome(): TurnOutcome =
-        if (ctx.clientGone()) {
-            TurnOutcome.ClientAbandoned
-        } else {
-            TurnOutcome.Failure(
-                ErrorType.OVERLOADED,
-                "chat: stream ended without a finish_reason (truncated); retry",
+    // Ordering enforced by the shared spi.terminalPrecedence (a FINISHED turn beats a late
+    // watchdog fire — the poller can sit on the socket-EOF read AFTER finish_reason arrived).
+    private fun terminalOutcome(): TurnOutcome {
+        val providerFailure = when {
+            failure != null ->
+                TurnOutcome.Failure(ErrorType.API_ERROR, "chat backend: $failure", providerReported = true)
+            // finish_reason=content_filter is a CENSORED turn — a clean end_turn would let a
+            // blocked generation masquerade as complete (honesty invariant); it outranks
+            // `finished` (the same frame sets both). Retry an api_error honestly.
+            contentFiltered -> TurnOutcome.Failure(
+                ErrorType.API_ERROR,
+                "chat backend: generation stopped by content filter",
+                providerReported = true, // finish_reason the backend sent, not a local verdict (G20)
             )
+            else -> null
         }
+        return terminalPrecedence(
+            TerminalStates(
+                providerFailure = providerFailure,
+                finished = finished,
+                watchdogFired = ctx.watchdogFired(),
+            ),
+            onFinished = ::successOutcome,
+            onWatchdog = { TurnOutcome.Failure(ErrorType.OVERLOADED, "chat: upstream stalled — aborted; retry") },
+            onUnfinished = {
+                if (ctx.clientGone()) {
+                    TurnOutcome.ClientAbandoned
+                } else {
+                    TurnOutcome.Failure(
+                        ErrorType.OVERLOADED,
+                        "chat: stream ended without a finish_reason (truncated); retry",
+                    )
+                }
+            },
+        )
+    }
 
     private fun successOutcome(): TurnOutcome = TurnOutcome.Success(
         hasToolUse = hasToolUse,
@@ -123,7 +132,7 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
 
     private suspend fun onEvent(evt: JsonObject, sink: WireSink) {
         (evt["error"] as? JsonObject)?.let {
-            failure = str(it["message"]).ifEmpty { "error" }
+            failure = strOrEmpty(it["message"]).ifEmpty { "error" }
             return
         }
         usage(evt)
@@ -131,38 +140,68 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
         (choice["delta"] as? JsonObject)?.let { applyDelta(it, sink) }
         // Non-stream / final-message shape: reasoning lands on `message` instead of `delta`.
         (choice["message"] as? JsonObject)?.let { applyFinalMessage(it, sink) }
-        str(choice["finish_reason"]).takeIf { it.isNotEmpty() }?.let { onFinish(it) }
+        // A null finish_reason would trip `finished` and let a truncated stream masquerade as a
+        // clean end (L3) — strOrEmpty (core JsonScalars) filters the JsonNull first (review 2026-07-22 round 3).
+        strOrEmpty(choice["finish_reason"]).takeIf { it.isNotEmpty() }?.let { onFinish(it) }
     }
 
     /** The final-message fold: only fills channels the streamed deltas left empty/unseen. */
     private suspend fun applyFinalMessage(msg: JsonObject, sink: WireSink) {
+        foldFinalProse(msg, sink)
+        foldFinalToolCalls(msg, sink)
+    }
+
+    /** The reasoning + text halves of the final-message fold, both prefix-aware via
+     *  [unseenSuffix] (extracted so applyFinalMessage stays under the complexity gate). */
+    private suspend fun foldFinalProse(msg: JsonObject, sink: WireSink) {
         reasoningDeltaText(msg)?.let { r ->
-            // Prefix-aware: if we already streamed a prefix of the final payload, only emit the
-            // suffix (substring contains() would append "Hello world" onto "Hello" → "HelloHello world").
-            val already = thinkingBuf.toString()
-            val toEmit = when {
-                already.isEmpty() -> r
-                r.startsWith(already) -> r.substring(already.length)
-                already.contains(r) -> ""
-                else -> r
-            }
+            val toEmit = unseenSuffix(thinkingBuf.toString(), r)
             if (toEmit.isNotEmpty()) {
                 val idx = thinkingBlock ?: sink.openThinking().also { thinkingBlock = it }
                 thinkingBuf.append(toEmit)
                 sink.thinkingDelta(idx, toEmit)
             }
         }
-        str(msg["content"]).takeIf { it.isNotEmpty() }?.let { c ->
-            if (textBuf.isEmpty()) {
+        strOrEmpty(msg["content"]).takeIf { it.isNotEmpty() }?.let { c ->
+            val toEmit = unseenSuffix(textBuf.toString(), c)
+            if (toEmit.isNotEmpty()) {
                 val idx = textBlock ?: sink.openText().also { textBlock = it }
                 emittedText = true
-                textBuf.append(c)
-                sink.textDelta(idx, c)
+                textBuf.append(toEmit)
+                sink.textDelta(idx, toEmit)
             }
         }
-        // Non-stream / final-message shape: tool_calls land on `message`, not `delta`.
-        (msg["tool_calls"] as? JsonArray)?.forEach { tc ->
-            applyToolCall(tc as? JsonObject ?: return@forEach, sink)
+    }
+
+    // Non-stream / final-message shape: tool_calls land on `message`, not `delta`. Two paths.
+    // GAP-FILL — the deltas carried NO tool activity (both maps empty), so the final message IS
+    // the calls: apply every entry. MERGE — the deltas already opened or buffered tools, so the
+    // final tool_calls are an echo. Echo-suppression is ABSOLUTE for OPEN blocks: re-applying
+    // would append the full arguments onto an open block, or mint a SECOND tool_use for the same
+    // id (final-shape calls carry no `index`, and the explicit-index delta path never records
+    // id→index, so resolveToolIndex cannot map an echo back to its streamed slot). A PENDING slot
+    // buffered from deltas that never carried function.name is the exception: adopt the name the
+    // echo supplies, matched by id — else flushPendingTools opens it under the "tool" fallback
+    // name. Merge names into pending only; never append the echo's arguments, the deltas already
+    // buffered them (review 2026-07-22 round 3).
+    private suspend fun foldFinalToolCalls(msg: JsonObject, sink: WireSink) {
+        val calls = msg["tool_calls"] as? JsonArray ?: return
+        val gapFill = toolBlocks.isEmpty() && pendingTools.isEmpty()
+        calls.forEach { tc ->
+            val obj = tc as? JsonObject ?: return@forEach
+            if (gapFill) {
+                applyToolCall(obj, sink)
+                return@forEach
+            }
+            val fn = obj["function"] as? JsonObject
+            val name = strOrEmpty(fn?.get("name"))
+            if (name.isEmpty()) return@forEach
+            val id = strOrEmpty(obj["id"])
+            val entry = pendingTools.entries.firstOrNull { it.value.id == id } ?: return@forEach
+            if (entry.value.name.isEmpty()) {
+                entry.value.name = name
+                openPendingTool(entry.key, entry.value, sink)
+            }
         }
     }
 
@@ -174,7 +213,7 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
             thinkingBuf.append(r)
             sink.thinkingDelta(idx, r)
         }
-        str(delta["content"]).takeIf { it.isNotEmpty() }?.let { c ->
+        strOrEmpty(delta["content"]).takeIf { it.isNotEmpty() }?.let { c ->
             val idx = textBlock ?: sink.openText().also { textBlock = it }
             emittedText = true
             textBuf.append(c)
@@ -186,7 +225,7 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
     /** First non-empty cleartext reasoning field on a chat delta/message. */
     private fun reasoningDeltaText(obj: JsonObject): String? {
         for (key in REASONING_KEYS) {
-            val v = str(obj[key])
+            val v = strOrEmpty(obj[key])
             if (v.isNotEmpty()) return v
         }
         return null
@@ -195,9 +234,9 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
     private suspend fun applyToolCall(tc: JsonObject, sink: WireSink) {
         val index = resolveToolIndex(tc)
         val fn = tc["function"] as? JsonObject
-        val name = str(fn?.get("name"))
-        val idChunk = str(tc["id"])
-        val args = str(fn?.get("arguments"))
+        val name = strOrEmpty(fn?.get("name"))
+        val idChunk = strOrEmpty(tc["id"])
+        val args = strOrEmpty(fn?.get("arguments"))
         val opened = toolBlocks[index]
         if (opened != null) {
             if (args.isNotEmpty()) sink.inputJsonDelta(opened, args)
@@ -214,8 +253,10 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
         }
     }
 
+    // Callers guarantee toolBlocks[index] is absent: applyToolCall early-returns on an open block
+    // with no suspension before calling here, and flushPendingTools only iterates keys still in
+    // pendingTools (removed below in the same uninterruptible span that fills toolBlocks).
     private suspend fun openPendingTool(index: Int, pending: PendingTool, sink: WireSink) {
-        if (toolBlocks.containsKey(index)) return
         val opened = sink.openTool(pending.id, pending.name.ifEmpty { "tool" })
         toolBlocks[index] = opened
         hasToolUse = true
@@ -235,7 +276,7 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
      *  slot, and an id-less index-less call gets a fresh slot per event (complete-call shape). */
     private fun resolveToolIndex(tc: JsonObject): Int {
         (tc["index"] as? JsonPrimitive)?.content?.toIntOrNull()?.let { return it }
-        val id = str(tc["id"])
+        val id = strOrEmpty(tc["id"])
         if (id.isEmpty()) return nextSynthToolIndex++
         return toolIndexById.getOrPut(id) { nextSynthToolIndex++ }
     }
@@ -253,6 +294,8 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
 
     private fun usage(evt: JsonObject) {
         val u = evt["usage"] as? JsonObject ?: return
+        fun num(obj: JsonObject, vararg keys: String): Long =
+            keys.firstNotNullOfOrNull { (obj[it] as? JsonPrimitive)?.content?.toLongOrNull() } ?: 0L
         (u["prompt_tokens"] as? JsonPrimitive)?.content?.toLongOrNull()?.let { inputTokens = it }
         (u["completion_tokens"] as? JsonPrimitive)?.content?.toLongOrNull()?.let { outputTokens = it }
         // Prompt-cache read tokens — surfaced so the HUD/cache-log see a real hit rate. Details
@@ -265,20 +308,21 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
         if (cached > 0) cachedTokens = cached
     }
 
-    private fun num(obj: JsonObject, vararg keys: String): Long =
-        keys.firstNotNullOfOrNull { (obj[it] as? JsonPrimitive)?.content?.toLongOrNull() } ?: 0L
-
-    // JsonNull IS a JsonPrimitive and its `.content` is the 4-char string "null"; treat an explicit
-    // JSON null (which every OpenAI-compatible vendor sends for finish_reason/content/id on
-    // non-final chunks) as absent — else "null" leaks into text/reasoning/ids and, worst, a null
-    // finish_reason would trip `finished` and let a truncated stream masquerade as a clean end (L3).
-    private fun str(el: JsonElement?): String =
-        (el as? JsonPrimitive)?.takeUnless { it is JsonNull }?.content ?: ""
-
     private companion object {
         val REASONING_KEYS = listOf("reasoning_content", "reasoning", "thinking", "reasoning_text")
 
         // Synthesized tool slots live far above any real streamed index (OpenAI streams 0..n).
         const val SYNTH_INDEX_BASE = 1_000_000
     }
+}
+
+/** Prefix-aware fold shared by the reasoning and text final-message channels: emit only what the
+ *  streamed deltas haven't already carried ("Hello" streamed + "Hello world" final → " world";
+ *  full duplicate → nothing; disjoint payload → all of it). A plain contains() check appended
+ *  "Hello world" onto "Hello" → "HelloHello world". */
+private fun unseenSuffix(already: String, final: String): String = when {
+    already.isEmpty() -> final
+    final.startsWith(already) -> final.substring(already.length)
+    already.contains(final) -> ""
+    else -> final
 }

--- a/gateway/dialect-openai-chat/src/main/kotlin/splice/dialect/chat/ChatStreamTranslator.kt
+++ b/gateway/dialect-openai-chat/src/main/kotlin/splice/dialect/chat/ChatStreamTranslator.kt
@@ -53,6 +53,16 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
     // parallel call into one corrupted block (ids/names dropped, arguments concatenated).
     private var nextSynthToolIndex = SYNTH_INDEX_BASE
     private val toolIndexById = HashMap<String, Int>()
+    // Deferred opens: backends often emit index+id first and function.name on a later delta.
+    // Opening with name="" freezes an empty tool_use on the Anthropic wire — buffer until name
+    // arrives (or finish_reason forces a flush).
+    private val pendingTools = HashMap<Int, PendingTool>()
+
+    private data class PendingTool(
+        var id: String,
+        var name: String = "",
+        val args: StringBuilder = StringBuilder(),
+    )
 
     override suspend fun driveTurn(upstream: Flow<JsonObject>, sink: WireSink): TurnOutcome {
         try {
@@ -67,6 +77,7 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
         } catch (ignored: IllegalArgumentException) {
             // malformed value in a frame: surface via the honest terminal decision
         }
+        flushPendingTools(sink)
         sink.closeAll()
         return terminalOutcome()
     }
@@ -126,10 +137,19 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
     /** The final-message fold: only fills channels the streamed deltas left empty/unseen. */
     private suspend fun applyFinalMessage(msg: JsonObject, sink: WireSink) {
         reasoningDeltaText(msg)?.let { r ->
-            if (!thinkingBuf.contains(r)) {
+            // Prefix-aware: if we already streamed a prefix of the final payload, only emit the
+            // suffix (substring contains() would append "Hello world" onto "Hello" → "HelloHello world").
+            val already = thinkingBuf.toString()
+            val toEmit = when {
+                already.isEmpty() -> r
+                r.startsWith(already) -> r.substring(already.length)
+                already.contains(r) -> ""
+                else -> r
+            }
+            if (toEmit.isNotEmpty()) {
                 val idx = thinkingBlock ?: sink.openThinking().also { thinkingBlock = it }
-                thinkingBuf.append(r)
-                sink.thinkingDelta(idx, r)
+                thinkingBuf.append(toEmit)
+                sink.thinkingDelta(idx, toEmit)
             }
         }
         str(msg["content"]).takeIf { it.isNotEmpty() }?.let { c ->
@@ -139,6 +159,10 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
                 textBuf.append(c)
                 sink.textDelta(idx, c)
             }
+        }
+        // Non-stream / final-message shape: tool_calls land on `message`, not `delta`.
+        (msg["tool_calls"] as? JsonArray)?.forEach { tc ->
+            applyToolCall(tc as? JsonObject ?: return@forEach, sink)
         }
     }
 
@@ -171,14 +195,40 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
     private suspend fun applyToolCall(tc: JsonObject, sink: WireSink) {
         val index = resolveToolIndex(tc)
         val fn = tc["function"] as? JsonObject
-        val idx = toolBlocks[index] ?: run {
-            val id = str(tc["id"]).ifEmpty { "toolu_$index" }
-            val opened = sink.openTool(id, str(fn?.get("name")))
-            toolBlocks[index] = opened
-            hasToolUse = true
-            opened
+        val name = str(fn?.get("name"))
+        val idChunk = str(tc["id"])
+        val args = str(fn?.get("arguments"))
+        val opened = toolBlocks[index]
+        if (opened != null) {
+            if (args.isNotEmpty()) sink.inputJsonDelta(opened, args)
+            return
         }
-        str(fn?.get("arguments")).takeIf { it.isNotEmpty() }?.let { sink.inputJsonDelta(idx, it) }
+        val pending = pendingTools.getOrPut(index) {
+            PendingTool(id = idChunk.ifEmpty { "toolu_$index" })
+        }
+        if (idChunk.isNotEmpty()) pending.id = idChunk
+        if (name.isNotEmpty()) pending.name = name
+        if (args.isNotEmpty()) pending.args.append(args)
+        if (pending.name.isNotEmpty()) {
+            openPendingTool(index, pending, sink)
+        }
+    }
+
+    private suspend fun openPendingTool(index: Int, pending: PendingTool, sink: WireSink) {
+        if (toolBlocks.containsKey(index)) return
+        val opened = sink.openTool(pending.id, pending.name.ifEmpty { "tool" })
+        toolBlocks[index] = opened
+        hasToolUse = true
+        pendingTools.remove(index)
+        if (pending.args.isNotEmpty()) sink.inputJsonDelta(opened, pending.args.toString())
+    }
+
+    private suspend fun flushPendingTools(sink: WireSink) {
+        if (pendingTools.isEmpty()) return
+        // Snapshot keys — openPendingTool mutates pendingTools.
+        pendingTools.keys.toList().forEach { index ->
+            pendingTools[index]?.let { openPendingTool(index, it, sink) }
+        }
     }
 
     /** Explicit index wins (OpenAI streaming); otherwise each distinct id gets a synthesized
@@ -194,7 +244,8 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
         finished = true
         when (reason) {
             "tool_calls" -> hasToolUse = true
-            "length" -> incomplete = true
+            // OpenAI standard is "length"; several OpenAI-compat vendors also emit "max_tokens".
+            "length", "max_tokens" -> incomplete = true
             "content_filter" -> contentFiltered = true
             else -> Unit // stop / others -> end_turn
         }

--- a/gateway/dialect-openai-chat/src/main/kotlin/splice/dialect/chat/ChatStreamTranslator.kt
+++ b/gateway/dialect-openai-chat/src/main/kotlin/splice/dialect/chat/ChatStreamTranslator.kt
@@ -55,6 +55,10 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
     private var nextSynthToolIndex = SYNTH_INDEX_BASE
     private val toolIndexById = HashMap<String, Int>()
 
+    // Ids of tool blocks already opened this turn — lets the final-message fold tell an ECHO of a
+    // streamed call (suppress) from a call present ONLY in the final consolidated array (emit).
+    private val openedToolIds = HashSet<String>()
+
     // Deferred opens: backends often emit index+id first and function.name on a later delta.
     // Opening with name="" freezes an empty tool_use on the Anthropic wire — buffer until name
     // arrives (or finish_reason forces a flush).
@@ -173,35 +177,37 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
         }
     }
 
-    // Non-stream / final-message shape: tool_calls land on `message`, not `delta`. Two paths.
-    // GAP-FILL — the deltas carried NO tool activity (both maps empty), so the final message IS
-    // the calls: apply every entry. MERGE — the deltas already opened or buffered tools, so the
-    // final tool_calls are an echo. Echo-suppression is ABSOLUTE for OPEN blocks: re-applying
-    // would append the full arguments onto an open block, or mint a SECOND tool_use for the same
-    // id (final-shape calls carry no `index`, and the explicit-index delta path never records
-    // id→index, so resolveToolIndex cannot map an echo back to its streamed slot). A PENDING slot
-    // buffered from deltas that never carried function.name is the exception: adopt the name the
-    // echo supplies, matched by id — else flushPendingTools opens it under the "tool" fallback
-    // name. Merge names into pending only; never append the echo's arguments, the deltas already
-    // buffered them (review 2026-07-22 round 3).
+    // Non-stream / final-message shape: tool_calls land on `message`, not `delta`. Classified PER
+    // CALL, not per turn — a turn-global gap-fill flag dropped a call present only in the final
+    // array when it rode alongside an echo of a streamed call (review 2026-07-23). Three cases:
+    //   ECHO of an already-opened block (matched by id) — SUPPRESS: re-applying appends the full
+    //     arguments onto the open block or mints a duplicate tool_use (final-shape calls carry no
+    //     `index`, so resolveToolIndex cannot map an echo back to its streamed slot).
+    //   PENDING slot buffered from deltas that never carried function.name — adopt the echo's name
+    //     by id, else flushPendingTools opens it under the "tool" fallback. Names only; never the
+    //     echo's arguments (the deltas already buffered them).
+    //   NEW — never streamed, present ONLY in the final consolidated message (or the pure gap-fill
+    //     case where deltas carried nothing) — emit it, or it is silently lost while the turn still
+    //     reports tool_use.
     private suspend fun foldFinalToolCalls(msg: JsonObject, sink: WireSink) {
         val calls = msg["tool_calls"] as? JsonArray ?: return
         val gapFill = toolBlocks.isEmpty() && pendingTools.isEmpty()
-        calls.forEach { tc ->
-            val obj = tc as? JsonObject ?: return@forEach
-            if (gapFill) {
-                applyToolCall(obj, sink)
-                return@forEach
+        calls.forEach { tc -> (tc as? JsonObject)?.let { applyFinalToolCall(it, gapFill, sink) } }
+    }
+
+    private suspend fun applyFinalToolCall(obj: JsonObject, gapFill: Boolean, sink: WireSink) {
+        val id = strOrEmpty(obj["id"])
+        if (id.isNotEmpty() && id in openedToolIds) return // echo of an already-open block
+        val name = strOrEmpty((obj["function"] as? JsonObject)?.get("name"))
+        val pending = if (id.isEmpty()) null else pendingTools.entries.firstOrNull { it.value.id == id }
+        when {
+            // Nameless pending slot buffered from deltas — adopt the echo's name by id (names only).
+            pending != null -> if (name.isNotEmpty() && pending.value.name.isEmpty()) {
+                pending.value.name = name
+                openPendingTool(pending.key, pending.value, sink)
             }
-            val fn = obj["function"] as? JsonObject
-            val name = strOrEmpty(fn?.get("name"))
-            if (name.isEmpty()) return@forEach
-            val id = strOrEmpty(obj["id"])
-            val entry = pendingTools.entries.firstOrNull { it.value.id == id } ?: return@forEach
-            if (entry.value.name.isEmpty()) {
-                entry.value.name = name
-                openPendingTool(entry.key, entry.value, sink)
-            }
+            // Gap-fill, or a call present ONLY in the final consolidated array — emit it.
+            gapFill || name.isNotEmpty() -> applyToolCall(obj, sink)
         }
     }
 
@@ -220,15 +226,6 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
             sink.textDelta(idx, c)
         }
         (delta["tool_calls"] as? JsonArray)?.forEach { tc -> applyToolCall(tc as? JsonObject ?: return@forEach, sink) }
-    }
-
-    /** First non-empty cleartext reasoning field on a chat delta/message. */
-    private fun reasoningDeltaText(obj: JsonObject): String? {
-        for (key in REASONING_KEYS) {
-            val v = strOrEmpty(obj[key])
-            if (v.isNotEmpty()) return v
-        }
-        return null
     }
 
     private suspend fun applyToolCall(tc: JsonObject, sink: WireSink) {
@@ -259,6 +256,7 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
     private suspend fun openPendingTool(index: Int, pending: PendingTool, sink: WireSink) {
         val opened = sink.openTool(pending.id, pending.name.ifEmpty { "tool" })
         toolBlocks[index] = opened
+        openedToolIds.add(pending.id)
         hasToolUse = true
         pendingTools.remove(index)
         if (pending.args.isNotEmpty()) sink.inputJsonDelta(opened, pending.args.toString())
@@ -309,11 +307,21 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
     }
 
     private companion object {
-        val REASONING_KEYS = listOf("reasoning_content", "reasoning", "thinking", "reasoning_text")
-
         // Synthesized tool slots live far above any real streamed index (OpenAI streams 0..n).
         const val SYNTH_INDEX_BASE = 1_000_000
     }
+}
+
+private val REASONING_KEYS = listOf("reasoning_content", "reasoning", "thinking", "reasoning_text")
+
+/** First non-empty cleartext reasoning field on a chat delta/message. Top-level (off the class
+ *  function budget) — reads only its argument. */
+private fun reasoningDeltaText(obj: JsonObject): String? {
+    for (key in REASONING_KEYS) {
+        val v = strOrEmpty(obj[key])
+        if (v.isNotEmpty()) return v
+    }
+    return null
 }
 
 /** Prefix-aware fold shared by the reasoning and text final-message channels: emit only what the

--- a/gateway/dialect-openai-chat/src/main/kotlin/splice/dialect/chat/ChatStreamTranslator.kt
+++ b/gateway/dialect-openai-chat/src/main/kotlin/splice/dialect/chat/ChatStreamTranslator.kt
@@ -184,30 +184,44 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
     //     arguments onto the open block or mints a duplicate tool_use (final-shape calls carry no
     //     `index`, so resolveToolIndex cannot map an echo back to its streamed slot).
     //   PENDING slot buffered from deltas that never carried function.name — adopt the echo's name
-    //     by id, else flushPendingTools opens it under the "tool" fallback. Names only; never the
-    //     echo's arguments (the deltas already buffered them).
-    //   NEW — never streamed, present ONLY in the final consolidated message (or the pure gap-fill
-    //     case where deltas carried nothing) — emit it, or it is silently lost while the turn still
-    //     reports tool_use.
+    //     by id, else flushPendingTools opens it under the "tool" fallback. Take the echo's args
+    //     too ONLY when the deltas buffered none (name AND args both final-only, finding 3); a
+    //     non-empty buffer is never appended twice.
+    //   NEW — never streamed, present ONLY in the final consolidated message (including when NO
+    //     deltas streamed any tool call) — emit it, even when it carries no name (opened under the
+    //     "tool" fallback, finding 5a), or it is silently lost while the turn reports tool_use.
+    // KNOWN LIMITATIONS (non-standard vendors only — not codex/grok/kimi; a name+args suppressor
+    // would risk dropping a legitimate distinct call, so both are left as documented gaps):
+    //   • a call STREAMED without an id (synth "toolu_<n>" slot) but echoed WITH an id can't be
+    //     matched back, so the echo mints a duplicate tool_use (finding 4);
+    //   • an id-matched echo is suppressed wholesale, so if the stream UNDER-delivered a call's
+    //     arguments the final's complete copy is discarded (finding 5b).
     private suspend fun foldFinalToolCalls(msg: JsonObject, sink: WireSink) {
         val calls = msg["tool_calls"] as? JsonArray ?: return
-        val gapFill = toolBlocks.isEmpty() && pendingTools.isEmpty()
-        calls.forEach { tc -> (tc as? JsonObject)?.let { applyFinalToolCall(it, gapFill, sink) } }
+        calls.forEach { tc -> (tc as? JsonObject)?.let { applyFinalToolCall(it, sink) } }
     }
 
-    private suspend fun applyFinalToolCall(obj: JsonObject, gapFill: Boolean, sink: WireSink) {
+    private suspend fun applyFinalToolCall(obj: JsonObject, sink: WireSink) {
         val id = strOrEmpty(obj["id"])
         if (id.isNotEmpty() && id in openedToolIds) return // echo of an already-open block
-        val name = strOrEmpty((obj["function"] as? JsonObject)?.get("name"))
-        val pending = if (id.isEmpty()) null else pendingTools.entries.firstOrNull { it.value.id == id }
-        when {
-            // Nameless pending slot buffered from deltas — adopt the echo's name by id (names only).
-            pending != null -> if (name.isNotEmpty() && pending.value.name.isEmpty()) {
-                pending.value.name = name
-                openPendingTool(pending.key, pending.value, sink)
+        val fn = obj["function"] as? JsonObject
+        val slot = if (id.isEmpty()) null else pendingTools.entries.firstOrNull { it.value.id == id }
+        if (slot == null) {
+            // A call present ONLY in the final array (never an open block — those returned at the
+            // top) — emit it, even when it carries no name (openPendingTool falls back to "tool",
+            // finding 5a), else it is silently lost while the turn reports tool_use.
+            applyToolCall(obj, sink)
+        } else {
+            // Pending slot from deltas that never carried a name — adopt the echo's name by id, and
+            // take its arguments too only when the deltas buffered none (name AND args both final-
+            // only, finding 3); a non-empty buffer is never double-appended (append("") is a no-op).
+            val pending = slot.value
+            val name = strOrEmpty(fn?.get("name"))
+            if (name.isNotEmpty() && pending.name.isEmpty()) {
+                pending.name = name
+                if (pending.args.isEmpty()) pending.args.append(strOrEmpty(fn?.get("arguments")))
+                openPendingTool(slot.key, pending, sink)
             }
-            // Gap-fill, or a call present ONLY in the final consolidated array — emit it.
-            gapFill || name.isNotEmpty() -> applyToolCall(obj, sink)
         }
     }
 
@@ -327,7 +341,10 @@ private fun reasoningDeltaText(obj: JsonObject): String? {
 /** Prefix-aware fold shared by the reasoning and text final-message channels: emit only what the
  *  streamed deltas haven't already carried ("Hello" streamed + "Hello world" final → " world";
  *  full duplicate → nothing; disjoint payload → all of it). A plain contains() check appended
- *  "Hello world" onto "Hello" → "HelloHello world". */
+ *  "Hello world" onto "Hello" → "HelloHello world". Known gap (left as-is): a final message that
+ *  re-emits the streamed prose with NORMALIZED whitespace is neither a clean prefix nor a
+ *  substring, so it falls to the `else` and re-sends in full — a whitespace-aware compare can't be
+ *  made provably safe (it would drop legitimately-repeated content). */
 private fun unseenSuffix(already: String, final: String): String = when {
     already.isEmpty() -> final
     final.startsWith(already) -> final.substring(already.length)

--- a/gateway/dialect-openai-chat/src/test/kotlin/ChatRequestBuilderTest.kt
+++ b/gateway/dialect-openai-chat/src/test/kotlin/ChatRequestBuilderTest.kt
@@ -215,15 +215,20 @@ class ChatRequestBuilderTest {
     }
 
     @Test
-    fun `compact inherits session effort instead of pinning low`() {
-        // AGENTS cache law: compact mismatch on effort cold-starts the prompt cache.
+    fun `compact inherits session effort and strips tools plus tool_choice`() {
+        // AGENTS cache law: compact mismatch on effort cold-starts the prompt cache. Compact also
+        // strips tools — and with them tool_choice, else a tool_choice with no tools 400s strict
+        // vendors. Supplying real tools + tool_choice makes the stripping assertions bite.
         val compact = build(
             """{"model":"m","thinking":{"type":"enabled","budget_tokens":40000},
+                "tools":[{"name":"run","input_schema":{"type":"object"}}],
+                "tool_choice":{"type":"any"},
                 "messages":[{"role":"user","content":"summarize"}]}""",
             compact = true,
         )
         assertEquals("high", compact["reasoning_effort"]?.jsonPrimitive?.content)
         assertFalse(compact.containsKey("tools"))
+        assertFalse(compact.containsKey("tool_choice"))
     }
 
     @Test

--- a/gateway/dialect-openai-chat/src/test/kotlin/ChatRequestBuilderTest.kt
+++ b/gateway/dialect-openai-chat/src/test/kotlin/ChatRequestBuilderTest.kt
@@ -190,4 +190,60 @@ class ChatRequestBuilderTest {
         assertFalse(off.containsKey("reasoning_effort"))
         assertFalse(off.containsKey("reasoning"))
     }
+
+    @Test
+    fun `tool_choice maps Anthropic types onto the chat wire`() {
+        val none = build(
+            """{"model":"m","tools":[{"name":"t","input_schema":{"type":"object"}}],
+                "tool_choice":{"type":"none"},"messages":[{"role":"user","content":"x"}]}""",
+        )
+        assertEquals("none", none["tool_choice"]?.jsonPrimitive?.content)
+        val any = build(
+            """{"model":"m","tools":[{"name":"t","input_schema":{"type":"object"}}],
+                "tool_choice":{"type":"any"},"messages":[{"role":"user","content":"x"}]}""",
+        )
+        assertEquals("required", any["tool_choice"]?.jsonPrimitive?.content)
+        val specific = build(
+            """{"model":"m","tools":[{"name":"run","input_schema":{"type":"object"}}],
+                "tool_choice":{"type":"tool","name":"run"},"messages":[{"role":"user","content":"x"}]}""",
+        )
+        assertEquals("function", specific["tool_choice"]?.jsonObject?.get("type")?.jsonPrimitive?.content)
+        assertEquals(
+            "run",
+            specific["tool_choice"]?.jsonObject?.get("function")?.jsonObject?.get("name")?.jsonPrimitive?.content,
+        )
+    }
+
+    @Test
+    fun `compact inherits session effort instead of pinning low`() {
+        // AGENTS cache law: compact mismatch on effort cold-starts the prompt cache.
+        val compact = build(
+            """{"model":"m","thinking":{"type":"enabled","budget_tokens":40000},
+                "messages":[{"role":"user","content":"summarize"}]}""",
+            compact = true,
+        )
+        assertEquals("high", compact["reasoning_effort"]?.jsonPrimitive?.content)
+        assertFalse(compact.containsKey("tools"))
+    }
+
+    @Test
+    fun `parallel tool_results with images keep tool messages contiguous`() {
+        val msgs = build(
+            """{"model":"m","messages":[
+                {"role":"assistant","content":[
+                    {"type":"tool_use","id":"t1","name":"shot","input":{}},
+                    {"type":"tool_use","id":"t2","name":"run","input":{}}
+                ]},
+                {"role":"user","content":[
+                    {"type":"tool_result","tool_use_id":"t1","content":[
+                        {"type":"image","source":{"type":"base64","media_type":"image/png","data":"aGk="}}
+                    ]},
+                    {"type":"tool_result","tool_use_id":"t2","content":"ok"}
+                ]}
+            ]}""",
+        ).messages()
+        val roles = msgs.map { it["role"]?.jsonPrimitive?.content }
+        // assistant, tool, tool, then user(images) — never tool, user, tool
+        assertEquals(listOf("assistant", "tool", "tool", "user"), roles)
+    }
 }

--- a/gateway/dialect-openai-chat/src/test/kotlin/ChatRequestBuilderTest.kt
+++ b/gateway/dialect-openai-chat/src/test/kotlin/ChatRequestBuilderTest.kt
@@ -215,6 +215,25 @@ class ChatRequestBuilderTest {
     }
 
     @Test
+    fun `tool_choice defaults to auto when tools ride and the client sent none`() {
+        // Unlike the Responses builder (gated behind quirks.emitToolChoice / lite), chat emits
+        // tool_choice whenever tools ride regardless of client choice — openAiToolChoice(null) is
+        // "auto", the harmless default every OpenAI-compat vendor already assumes absent the field.
+        // Pinned so this centralization can't silently drift without a test noticing.
+        val req = build(
+            """{"model":"m","tools":[{"name":"t","input_schema":{"type":"object"}}],
+                "messages":[{"role":"user","content":"x"}]}""",
+        )
+        assertEquals("auto", req["tool_choice"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `no tool_choice field when there are no tools to choose from`() {
+        val req = build("""{"model":"m","messages":[{"role":"user","content":"hi"}]}""")
+        assertFalse(req.containsKey("tool_choice"))
+    }
+
+    @Test
     fun `compact inherits session effort and strips tools plus tool_choice`() {
         // AGENTS cache law: compact mismatch on effort cold-starts the prompt cache. Compact also
         // strips tools — and with them tool_choice, else a tool_choice with no tools 400s strict

--- a/gateway/dialect-openai-chat/src/test/kotlin/ChatStreamTranslatorTest.kt
+++ b/gateway/dialect-openai-chat/src/test/kotlin/ChatStreamTranslatorTest.kt
@@ -360,4 +360,79 @@ class ChatStreamTranslatorTest {
         assertEquals(listOf("call_a" to "fn_a", "call_b" to "fn_b"), sink.toolOpens)
         assertEquals(listOf("json:{\"x\":1}", "json:{\"y\":2}"), sink.calls.filter { it.startsWith("json:") })
     }
+
+    @Test
+    fun `streamed tool_calls are not re-applied from a trailing final-message echo`() = runTest {
+        // OpenRouter/vLLM-style mixed stream: deltas carry the call (explicit index), then a
+        // message-shaped frame echoes the consolidated tool_calls (id, no index). The echo must
+        // be a no-op — re-applying it appended the args again onto the open block, or minted a
+        // SECOND tool_use for the same id via a fresh synth slot (review 2026-07-22).
+        val sink = Rec()
+        val outcome = ChatStreamTranslator(ctx()).driveTurn(
+            listOf(
+                ev(
+                    """{"choices":[{"delta":{"tool_calls":[""" +
+                        """{"index":0,"id":"t1","function":{"name":"run","arguments":"{\"x\":1}"}}]}}]}""",
+                ),
+                ev(
+                    """{"choices":[{"message":{"role":"assistant","tool_calls":[""" +
+                        """{"id":"t1","type":"function","function":{"name":"run","arguments":"{\"x\":1}"}}""" +
+                        """]},"finish_reason":"tool_calls"}]}""",
+                ),
+            ).asFlow(),
+            sink,
+        )
+        assertTrue((outcome as TurnOutcome.Success).hasToolUse)
+        assertEquals(listOf("t1" to "run"), sink.toolOpens)
+        assertEquals(listOf("openTool:run", "json:{\"x\":1}", "closeAll"), sink.calls)
+    }
+
+    @Test
+    fun `final-message name completes a nameless pending tool without duplicating args`() = runTest {
+        // A backend streams the tool's arguments but never function.name on any delta, then supplies
+        // the name only in the trailing consolidated message. The pending slot must adopt that name
+        // (not flush under the "tool" fallback), and the echo's arguments must NOT be appended a
+        // second time onto the buffered slot (review 2026-07-22 round 3).
+        val sink = Rec()
+        val outcome = ChatStreamTranslator(ctx()).driveTurn(
+            listOf(
+                ev(
+                    """{"choices":[{"delta":{"tool_calls":[""" +
+                        """{"index":0,"id":"t1","function":{"arguments":"{\"x\":1}"}}]}}]}""",
+                ),
+                ev(
+                    """{"choices":[{"message":{"role":"assistant","tool_calls":[""" +
+                        """{"id":"t1","type":"function","function":{"name":"run","arguments":"{\"x\":1}"}}""" +
+                        """]},"finish_reason":"tool_calls"}]}""",
+                ),
+            ).asFlow(),
+            sink,
+        )
+        assertTrue((outcome as TurnOutcome.Success).hasToolUse)
+        assertEquals(listOf("t1" to "run"), sink.toolOpens)
+        assertEquals(1, sink.calls.count { it == "openTool:run" })
+        assertEquals(listOf("json:{\"x\":1}"), sink.calls.filter { it.startsWith("json:") })
+    }
+
+    @Test
+    fun `final-message content extends a streamed prefix without duplicating or dropping the tail`() = runTest {
+        // Sibling of the reasoning prefix-fold: streamed "Hello", final message completes to
+        // "Hello world" — the old isEmpty() guard dropped " world" entirely.
+        val sink = Rec()
+        val outcome = ChatStreamTranslator(ctx()).driveTurn(
+            listOf(
+                ev("""{"choices":[{"delta":{"content":"Hello"}}]}"""),
+                ev(
+                    """{"choices":[{"message":{"role":"assistant","content":"Hello world"},""" +
+                        """"finish_reason":"stop"}]}""",
+                ),
+            ).asFlow(),
+            sink,
+        )
+        val s = outcome as TurnOutcome.Success
+        assertEquals("Hello world", s.bodyText)
+        assertTrue(sink.calls.contains("text:Hello"))
+        assertTrue(sink.calls.contains("text: world"))
+        assertFalse(s.bodyText.contains("HelloHello"))
+    }
 }

--- a/gateway/dialect-openai-chat/src/test/kotlin/ChatStreamTranslatorTest.kt
+++ b/gateway/dialect-openai-chat/src/test/kotlin/ChatStreamTranslatorTest.kt
@@ -108,6 +108,61 @@ class ChatStreamTranslatorTest {
     }
 
     @Test
+    fun `tool name deferred to a later delta opens with the real name`() = runTest {
+        // Vendors emit index+id first, function.name on a later chunk — opening early freezes "".
+        val sink = Rec()
+        val outcome = ChatStreamTranslator(ctx()).driveTurn(
+            listOf(
+                ev(
+                    """{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"t1","function":{"arguments":""}}]}}]}""",
+                ),
+                ev(
+                    """{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"Read","arguments":"{\"p\":1}"}}]}}]}""",
+                ),
+                ev("""{"choices":[{"delta":{},"finish_reason":"tool_calls"}]}"""),
+            ).asFlow(),
+            sink,
+        )
+        assertTrue((outcome as TurnOutcome.Success).hasToolUse)
+        assertEquals(listOf("openTool:Read", "json:{\"p\":1}", "closeAll"), sink.calls)
+    }
+
+    @Test
+    fun `final-message tool_calls are harvested when no deltas carried them`() = runTest {
+        val sink = Rec()
+        val outcome = ChatStreamTranslator(ctx()).driveTurn(
+            listOf(
+                ev(
+                    """{"choices":[{"message":{"role":"assistant","tool_calls":[
+                        {"id":"t9","type":"function","function":{"name":"run","arguments":"{\"x\":1}"}}
+                    ]},"finish_reason":"tool_calls"}]}""",
+                ),
+            ).asFlow(),
+            sink,
+        )
+        assertTrue((outcome as TurnOutcome.Success).hasToolUse)
+        assertEquals(listOf("openTool:run", "json:{\"x\":1}", "closeAll"), sink.calls)
+    }
+
+    @Test
+    fun `final-message reasoning extends a streamed prefix without duplicating it`() = runTest {
+        val sink = Rec()
+        val outcome = ChatStreamTranslator(ctx()).driveTurn(
+            listOf(
+                ev("""{"choices":[{"delta":{"reasoning_content":"Hello"}}]}"""),
+                ev(
+                    """{"choices":[{"message":{"role":"assistant","content":"ok",
+                        "reasoning_content":"Hello world"},"finish_reason":"stop"}]}""",
+                ),
+            ).asFlow(),
+            sink,
+        )
+        val s = outcome as TurnOutcome.Success
+        assertEquals("Hello world", s.thinkingText)
+        assertFalse(s.thinkingText.contains("HelloHello"))
+    }
+
+    @Test
     fun `truncated without finish is overloaded`() = runTest {
         val outcome = ChatStreamTranslator(ctx()).driveTurn(
             listOf(ev("""{"choices":[{"delta":{"content":"partial"}}]}""")).asFlow(),

--- a/gateway/dialect-openai-chat/src/test/kotlin/ChatStreamTranslatorTest.kt
+++ b/gateway/dialect-openai-chat/src/test/kotlin/ChatStreamTranslatorTest.kt
@@ -160,6 +160,11 @@ class ChatStreamTranslatorTest {
         val s = outcome as TurnOutcome.Success
         assertEquals("Hello world", s.thinkingText)
         assertFalse(s.thinkingText.contains("HelloHello"))
+        // Wire-level: the streamed prefix went out, the final fold emits ONLY the unseen suffix,
+        // and the full "Hello world" is never re-sent (the buffer alone can't prove this).
+        assertTrue(sink.calls.contains("think:Hello"))
+        assertTrue(sink.calls.contains("think: world"))
+        assertFalse(sink.calls.contains("think:Hello world"))
     }
 
     @Test
@@ -388,6 +393,34 @@ class ChatStreamTranslatorTest {
     }
 
     @Test
+    fun `a final-only tool call alongside an echo of a streamed call is emitted, not dropped`() = runTest {
+        // Superset final message: t1 was streamed (its final echo must be SUPPRESSED) while t2
+        // appears ONLY in the consolidated final array (never streamed → must be EMITTED). A
+        // turn-global gap-fill flag dropped t2 while still reporting tool_use (review 2026-07-23).
+        val sink = Rec()
+        val outcome = ChatStreamTranslator(ctx()).driveTurn(
+            listOf(
+                ev(
+                    """{"choices":[{"delta":{"tool_calls":[""" +
+                        """{"index":0,"id":"t1","function":{"name":"first","arguments":"{}"}}]}}]}""",
+                ),
+                ev(
+                    """{"choices":[{"message":{"role":"assistant","tool_calls":[""" +
+                        """{"id":"t1","type":"function","function":{"name":"first","arguments":"{}"}},""" +
+                        """{"id":"t2","type":"function","function":{"name":"second","arguments":"{\"x\":1}"}}""" +
+                        """]},"finish_reason":"tool_calls"}]}""",
+                ),
+            ).asFlow(),
+            sink,
+        )
+        assertTrue((outcome as TurnOutcome.Success).hasToolUse)
+        // t1 opened once (echo suppressed), t2 opened once (final-only, emitted) — neither dropped.
+        assertEquals(listOf("t1" to "first", "t2" to "second"), sink.toolOpens)
+        assertEquals(1, sink.calls.count { it == "openTool:first" })
+        assertEquals(1, sink.calls.count { it == "openTool:second" })
+    }
+
+    @Test
     fun `final-message name completes a nameless pending tool without duplicating args`() = runTest {
         // A backend streams the tool's arguments but never function.name on any delta, then supplies
         // the name only in the trailing consolidated message. The pending slot must adopt that name
@@ -434,5 +467,21 @@ class ChatStreamTranslatorTest {
         assertTrue(sink.calls.contains("text:Hello"))
         assertTrue(sink.calls.contains("text: world"))
         assertFalse(s.bodyText.contains("HelloHello"))
+    }
+
+    @Test
+    fun `finish_reason max_tokens marks the turn incomplete like the standard length`() = runTest {
+        // OpenAI standard is "length"; several OpenAI-compat vendors emit "max_tokens". Both must
+        // set incomplete so the Anthropic terminal is max_tokens, not a clean end_turn.
+        val outcome = ChatStreamTranslator(ctx()).driveTurn(
+            listOf(
+                ev("""{"choices":[{"delta":{"content":"partial answer"}}]}"""),
+                ev("""{"choices":[{"delta":{},"finish_reason":"max_tokens"}]}"""),
+            ).asFlow(),
+            Rec(),
+        )
+        val s = outcome as TurnOutcome.Success
+        assertTrue(s.incomplete, "max_tokens must mark the turn incomplete")
+        assertFalse(s.hasToolUse)
     }
 }

--- a/gateway/dialect-openai-chat/src/test/kotlin/ChatToolFoldTest.kt
+++ b/gateway/dialect-openai-chat/src/test/kotlin/ChatToolFoldTest.kt
@@ -1,0 +1,153 @@
+// NEW (final review 2026-07-23): the final-message tool-fold cases, split out of
+// ChatStreamTranslatorTest (which hit the detekt LargeClass ceiling). Covers finding 3 (name+args
+// both final-only open with real input), finding 5a (a nameless final-only call is surfaced, not
+// dropped), and PINS the two documented known limitations — finding 4 (id-less stream echoed with an
+// id duplicates) and finding 5b (an id-matched echo does not repair under-delivered stream args).
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import splice.core.index.WireBlockIndex
+import splice.core.turn.TurnOutcome
+import splice.dialect.chat.ChatStreamTranslator
+import splice.dialect.chat.ChatTurnContext
+import splice.spi.WireSink
+
+private class FoldRec : WireSink {
+    val calls = mutableListOf<String>()
+    val toolOpens = mutableListOf<Pair<String, String>>() // (id, name) — inspect ids without disturbing `calls`
+    private var n = 0
+    override suspend fun openText() = WireBlockIndex(n++).also { calls.add("openText") }
+    override suspend fun openThinking() = WireBlockIndex(n++).also { calls.add("openThinking") }
+    override suspend fun openTool(id: String, name: String) = WireBlockIndex(n++).also {
+        calls.add("openTool:$name")
+        toolOpens.add(id to name)
+    }
+    override suspend fun textDelta(index: WireBlockIndex, text: String) { calls.add("text:$text") }
+    override suspend fun thinkingDelta(index: WireBlockIndex, thinking: String) { calls.add("think:$thinking") }
+    override suspend fun inputJsonDelta(index: WireBlockIndex, partialJson: String) { calls.add("json:$partialJson") }
+    override suspend fun closeBlock(index: WireBlockIndex) { calls.add("close") }
+    override suspend fun closeAll() { calls.add("closeAll") }
+    override suspend fun addTextBlock(text: String) { calls.add("addText:$text") }
+    override suspend fun addRedactedThinking(data: String) = Unit
+}
+
+private fun foldEv(json: String): JsonObject = Json.parseToJsonElement(json).jsonObject
+private fun foldCtx() = ChatTurnContext({ false }, { null }, 180_000, 900_000)
+
+class ChatToolFoldTest {
+
+    @Test
+    fun `final-message name and args both final-only open the tool with real input not empty`() = runTest {
+        // A delta reserves the slot by id but streams neither function.name NOR arguments; both
+        // arrive only in the trailing consolidated message. The pending slot must adopt the name
+        // AND the final entry's arguments — opening with real input, never an empty {} (finding 3).
+        val sink = FoldRec()
+        val outcome = ChatStreamTranslator(foldCtx()).driveTurn(
+            listOf(
+                foldEv("""{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"t1","function":{}}]}}]}"""),
+                foldEv(
+                    """{"choices":[{"message":{"role":"assistant","tool_calls":[""" +
+                        """{"id":"t1","type":"function","function":{"name":"run","arguments":"{\"x\":1}"}}""" +
+                        """]},"finish_reason":"tool_calls"}]}""",
+                ),
+            ).asFlow(),
+            sink,
+        )
+        assertTrue((outcome as TurnOutcome.Success).hasToolUse)
+        assertEquals(listOf("t1" to "run"), sink.toolOpens)
+        assertEquals(1, sink.calls.count { it == "openTool:run" })
+        // the tool opens with the final entry's real arguments, not an empty input block
+        assertEquals(listOf("json:{\"x\":1}"), sink.calls.filter { it.startsWith("json:") })
+    }
+
+    @Test
+    fun `a nameless final-only tool call alongside an echo is surfaced, not dropped`() = runTest {
+        // Superset final message: t1 was streamed (echo SUPPRESSED); t2 appears ONLY in the final
+        // array AND carries no function.name. With a delta already open, the old
+        // `gapFill || name.isNotEmpty()` guard matched no branch and dropped t2 while the turn still
+        // reported tool_use — it must be surfaced under the "tool" fallback instead (finding 5a).
+        val sink = FoldRec()
+        val outcome = ChatStreamTranslator(foldCtx()).driveTurn(
+            listOf(
+                foldEv(
+                    """{"choices":[{"delta":{"tool_calls":[""" +
+                        """{"index":0,"id":"t1","function":{"name":"first","arguments":"{}"}}]}}]}""",
+                ),
+                foldEv(
+                    """{"choices":[{"message":{"role":"assistant","tool_calls":[""" +
+                        """{"id":"t1","type":"function","function":{"name":"first","arguments":"{}"}},""" +
+                        """{"id":"t2","type":"function","function":{"arguments":"{\"y\":2}"}}""" +
+                        """]},"finish_reason":"tool_calls"}]}""",
+                ),
+            ).asFlow(),
+            sink,
+        )
+        assertTrue((outcome as TurnOutcome.Success).hasToolUse)
+        // t1 opened once (echo suppressed); t2 surfaced under the "tool" fallback with its args.
+        assertEquals(listOf("t1" to "first", "t2" to "tool"), sink.toolOpens)
+        assertEquals(1, sink.calls.count { it == "openTool:tool" })
+        assertTrue(sink.calls.contains("json:{\"y\":2}"))
+    }
+
+    @Test
+    fun `id-less streamed call echoed with an id duplicates - pins known limitation finding 4`() = runTest {
+        // KNOWN LIMITATION (pinned): a call STREAMED without an id gets a synth "toolu_<n>" slot;
+        // the trailing consolidated message echoes the SAME call but now WITH a real id. That id is
+        // not in openedToolIds and cannot be matched back to the synth slot, so the echo mints a
+        // SECOND tool_use. Left as-is deliberately — a name+args suppressor would risk dropping a
+        // legitimate distinct call. Reachable only via non-standard vendors (not codex/grok/kimi).
+        val sink = FoldRec()
+        val outcome = ChatStreamTranslator(foldCtx()).driveTurn(
+            listOf(
+                foldEv(
+                    """{"choices":[{"delta":{"tool_calls":[""" +
+                        """{"function":{"name":"run","arguments":"{\"x\":1}"}}]}}]}""",
+                ),
+                foldEv(
+                    """{"choices":[{"message":{"role":"assistant","tool_calls":[""" +
+                        """{"id":"call_real","type":"function","function":{"name":"run","arguments":"{\"x\":1}"}}""" +
+                        """]},"finish_reason":"tool_calls"}]}""",
+                ),
+            ).asFlow(),
+            sink,
+        )
+        assertTrue((outcome as TurnOutcome.Success).hasToolUse)
+        // The duplicate is the pinned (known-wrong) behavior: synth-id open, then a second real-id open.
+        assertEquals(listOf("toolu_1000000" to "run", "call_real" to "run"), sink.toolOpens)
+        assertEquals(2, sink.calls.count { it == "openTool:run" })
+    }
+
+    @Test
+    fun `id-matched echo does not repair under-delivered stream args - pins known limitation finding 5b`() = runTest {
+        // KNOWN LIMITATION (pinned): the stream under-delivers a call's arguments (partial JSON),
+        // then the trailing consolidated message echoes the SAME id with the COMPLETE arguments. The
+        // echo is suppressed wholesale (by id) to keep the common full-delivery echo a no-op, so the
+        // final's complete copy is discarded and the wire keeps only the partial args. Left as-is —
+        // repairing it needs per-block arg tracking, not worth the hot-path risk for a non-standard
+        // vendor (not codex/grok/kimi).
+        val sink = FoldRec()
+        val outcome = ChatStreamTranslator(foldCtx()).driveTurn(
+            listOf(
+                foldEv(
+                    """{"choices":[{"delta":{"tool_calls":[""" +
+                        """{"index":0,"id":"t1","function":{"name":"run","arguments":"{\"x\":"}}]}}]}""",
+                ),
+                foldEv(
+                    """{"choices":[{"message":{"role":"assistant","tool_calls":[""" +
+                        """{"id":"t1","type":"function","function":{"name":"run","arguments":"{\"x\":1}"}}""" +
+                        """]},"finish_reason":"tool_calls"}]}""",
+                ),
+            ).asFlow(),
+            sink,
+        )
+        assertTrue((outcome as TurnOutcome.Success).hasToolUse)
+        assertEquals(listOf("t1" to "run"), sink.toolOpens)
+        // only the partial streamed args reached the wire; the final's complete "{\"x\":1}" is dropped
+        assertEquals(listOf("json:{\"x\":"), sink.calls.filter { it.startsWith("json:") })
+    }
+}

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/Harvested.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/Harvested.kt
@@ -7,16 +7,12 @@ package splice.dialect.responses
 
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import splice.core.turn.Usage
+import splice.core.util.strOrEmpty
 
 public data class Harvested(val text: String, val thinking: String)
-
-// JsonNull-safe (same trap as ResponsesStreamTranslator.str): null text fields must not harvest "null".
-private fun str(el: JsonElement?): String =
-    (el as? JsonPrimitive)?.takeUnless { it is JsonNull }?.content ?: ""
 
 private const val PARA = "\n\n"
 private const val FIELD_TEXT = "text"
@@ -32,8 +28,8 @@ internal fun summaryText(item: JsonObject): String =
         (item["summary"] as? JsonArray ?: return "")
             .joinToString(PARA) { part ->
                 when (part) {
-                    is JsonPrimitive -> str(part)
-                    is JsonObject -> str(part[FIELD_TEXT])
+                    is JsonPrimitive -> strOrEmpty(part)
+                    is JsonObject -> strOrEmpty(part[FIELD_TEXT])
                     else -> ""
                 }
             },
@@ -51,17 +47,17 @@ internal fun reasoningReadableText(item: JsonObject): String =
 
 /** One free-form reasoning field rendered readable, or null when absent/empty. */
 private fun freeFormReasoningText(v: JsonElement?): String? = when (v) {
-    is JsonPrimitive -> str(v).ifEmpty { null }
+    is JsonPrimitive -> strOrEmpty(v).ifEmpty { null }
     is JsonArray -> normalizeParagraphs(
         v.joinToString(PARA) { part ->
             when (part) {
-                is JsonPrimitive -> str(part)
-                is JsonObject -> str(part[FIELD_TEXT]).ifEmpty { str(part[FIELD_CONTENT]) }
+                is JsonPrimitive -> strOrEmpty(part)
+                is JsonObject -> strOrEmpty(part[FIELD_TEXT]).ifEmpty { strOrEmpty(part[FIELD_CONTENT]) }
                 else -> ""
             }
         },
     ).ifEmpty { null }
-    is JsonObject -> str(v[FIELD_TEXT]).ifEmpty { str(v[FIELD_CONTENT]) }.ifEmpty { null }
+    is JsonObject -> strOrEmpty(v[FIELD_TEXT]).ifEmpty { strOrEmpty(v[FIELD_CONTENT]) }.ifEmpty { null }
     else -> null
 }
 
@@ -75,7 +71,7 @@ public fun harvestResponsesOutput(resp: JsonObject): Harvested {
     val thinking = StringBuilder()
     for (el in output) {
         val item = el as? JsonObject ?: continue
-        when (str(item["type"])) {
+        when (strOrEmpty(item["type"])) {
             "reasoning" -> appendReasoningText(thinking, item)
             "message" -> text.append(messageText(item))
             else -> Unit
@@ -98,8 +94,8 @@ private fun messageText(item: JsonObject): String {
     val out = StringBuilder()
     for (c in content) {
         val obj = c as? JsonObject ?: continue
-        val type = str(obj["type"])
-        if (type == "output_text" || type == FIELD_TEXT) out.append(str(obj[FIELD_TEXT]))
+        val type = strOrEmpty(obj["type"])
+        if (type == "output_text" || type == FIELD_TEXT) out.append(strOrEmpty(obj[FIELD_TEXT]))
     }
     return out.toString()
 }

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/Harvested.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/Harvested.kt
@@ -7,14 +7,16 @@ package splice.dialect.responses
 
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import splice.core.turn.Usage
 
 public data class Harvested(val text: String, val thinking: String)
 
+// JsonNull-safe (same trap as ResponsesStreamTranslator.str): null text fields must not harvest "null".
 private fun str(el: JsonElement?): String =
-    (el as? JsonPrimitive)?.content ?: ""
+    (el as? JsonPrimitive)?.takeUnless { it is JsonNull }?.content ?: ""
 
 private const val PARA = "\n\n"
 private const val FIELD_TEXT = "text"
@@ -30,7 +32,7 @@ internal fun summaryText(item: JsonObject): String =
         (item["summary"] as? JsonArray ?: return "")
             .joinToString(PARA) { part ->
                 when (part) {
-                    is JsonPrimitive -> part.content
+                    is JsonPrimitive -> str(part)
                     is JsonObject -> str(part[FIELD_TEXT])
                     else -> ""
                 }
@@ -49,11 +51,11 @@ internal fun reasoningReadableText(item: JsonObject): String =
 
 /** One free-form reasoning field rendered readable, or null when absent/empty. */
 private fun freeFormReasoningText(v: JsonElement?): String? = when (v) {
-    is JsonPrimitive -> v.content.ifEmpty { null }
+    is JsonPrimitive -> str(v).ifEmpty { null }
     is JsonArray -> normalizeParagraphs(
         v.joinToString(PARA) { part ->
             when (part) {
-                is JsonPrimitive -> part.content
+                is JsonPrimitive -> str(part)
                 is JsonObject -> str(part[FIELD_TEXT]).ifEmpty { str(part[FIELD_CONTENT]) }
                 else -> ""
             }

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesRequestBuilder.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesRequestBuilder.kt
@@ -40,6 +40,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import splice.core.turn.ReasoningDisplay
 import splice.core.turn.TurnMeta
+import splice.core.util.str
 import splice.core.wire.AnthropicMessage
 import splice.core.wire.AnthropicRequest
 import splice.core.wire.ContentBlock
@@ -53,6 +54,7 @@ import splice.core.wire.ToolDefinition
 import splice.core.wire.ToolResultBlock
 import splice.core.wire.ToolUseBlock
 import splice.core.wire.UnknownBlock
+import splice.core.wire.openAiToolChoice
 import java.security.MessageDigest
 
 /** The finite quirk surface separating codex / xai / openai-platform on this dialect. */
@@ -156,7 +158,7 @@ public class ResponsesRequestBuilder(private val quirks: ResponsesQuirks) {
         val req = buildRequestObject(body, opts, input, instructions, reasoning)
         // meta.summary reflects what was ACTUALLY sent (spark drops it → "none"), like Node's
         // `req.reasoning?.summary ?? 'none'` — not the computed-but-maybe-dropped value.
-        val sentSummary = (reasoning?.get(FIELD_SUMMARY) as? JsonPrimitive)?.content ?: "none"
+        val sentSummary = reasoning?.get(FIELD_SUMMARY).str() ?: "none"
 
         val meta = TurnMeta(
             compact = opts.compact,
@@ -238,21 +240,7 @@ public class ResponsesRequestBuilder(private val quirks: ResponsesQuirks) {
     private fun toolChoiceFor(emitToolChoice: Boolean, lite: Boolean, body: AnthropicRequest): JsonElement? = when {
         !emitToolChoice -> null
         lite -> JsonPrimitive("auto")
-        else -> toolChoice(body)
-    }
-
-    private fun toolChoice(body: AnthropicRequest): JsonElement {
-        val choice = body.toolChoice
-        return when {
-            choice == null || choice.type == "auto" -> JsonPrimitive("auto")
-            choice.type == "none" -> JsonPrimitive("none")
-            choice.type == "any" -> JsonPrimitive("required")
-            choice.type == "tool" && choice.name != null -> buildJsonObject {
-                put("type", FIELD_FUNCTION)
-                put(FIELD_FUNCTION, buildJsonObject { put("name", choice.name) })
-            }
-            else -> JsonPrimitive("auto")
-        }
+        else -> openAiToolChoice(body.toolChoice)
     }
 
     /** codex-rs parity: 5.6-family models get parallel_tool_calls=false whenever tools ride —
@@ -322,7 +310,7 @@ public class ResponsesRequestBuilder(private val quirks: ResponsesQuirks) {
         (raw["output_config"] as? JsonObject)?.get(FIELD_EFFORT),
         (raw["metadata"] as? JsonObject)?.get(FIELD_EFFORT),
         (raw[FIELD_REASONING] as? JsonObject)?.get(FIELD_EFFORT),
-    ).mapNotNull { (it as? JsonPrimitive)?.content }
+    ).mapNotNull { it.str() }
         .mapNotNull { normalizeEffort(it, quirks.effortLadder) }
         .firstOrNull()
 
@@ -336,7 +324,7 @@ public class ResponsesRequestBuilder(private val quirks: ResponsesQuirks) {
             (raw[FIELD_REASONING] as? JsonObject)?.get(FIELD_SUMMARY),
             raw["reasoning_summary"],
             (raw["output_config"] as? JsonObject)?.get("reasoning_summary"),
-        ).mapNotNull { (it as? JsonPrimitive)?.content }
+        ).mapNotNull { it.str() }
             .mapNotNull { normalizeSummary(it) }
             .firstOrNull()
         // v27 visibility fold (the header's "folds summary to detailed" clause — was unimplemented,

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesRequestBuilder.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesRequestBuilder.kt
@@ -288,7 +288,9 @@ public class ResponsesRequestBuilder(private val quirks: ResponsesQuirks) {
 
     private fun cacheKey(body: AnthropicRequest, opts: BuildOptions): String? = when (quirks.cacheKeyStrategy) {
         CacheKeyStrategy.OFF -> null
-        CacheKeyStrategy.SESSION_ID -> opts.sessionId?.let { "claude-grok:$it" }
+        // Prefix from quirks.providerTag (not a hard-coded "claude-grok:") so TOML cache_key=session-id
+        // on any Responses provider stays in its own cache namespace.
+        CacheKeyStrategy.SESSION_ID -> opts.sessionId?.let { "${quirks.providerTag}:$it" }
         CacheKeyStrategy.FIRST_MESSAGE_HASH -> stablePromptCacheKey(body)
     }
 

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesStreamTranslator.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesStreamTranslator.kt
@@ -20,20 +20,22 @@ package splice.dialect.responses
 import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 import splice.core.index.WireBlockIndex
 import splice.core.turn.ErrorType
 import splice.core.turn.TurnOutcome
 import splice.core.turn.Usage
 import splice.core.turn.isWeakSummaryText
+import splice.core.util.str
+import splice.core.util.strOrEmpty
 import splice.spi.ClassifiedFailure
 import splice.spi.FailureSource
 import splice.spi.StreamTranslator
+import splice.spi.TerminalStates
 import splice.spi.UpstreamFailureClassifier
 import splice.spi.WatchdogFired
 import splice.spi.WireSink
+import splice.spi.terminalPrecedence
 import java.io.IOException
 import java.util.concurrent.CancellationException
 
@@ -106,22 +108,26 @@ public class ResponsesStreamTranslator(private val ctx: StreamTurnContext) : Str
         return terminalOutcome(reducer)
     }
 
-    private fun terminalOutcome(reducer: ResponsesEventReducer): TurnOutcome =
-        reducer.upstreamFailure?.let {
-            // parsed from a response.failed/error event the backend actually sent (G20 provenance)
-            TurnOutcome.Failure(it.type, "ChatGPT backend: ${it.message}", providerReported = true)
-        }
-            ?: if (reducer.finalResponse == null) noCompletionOutcome() else successOutcome(reducer)
+    // Ordering enforced by the shared spi.terminalPrecedence: a COMPLETED response wins over a
+    // late watchdog fire (the watchdog polls the whole enclosing coroutine, which stays suspended
+    // on the socket-EOF read AFTER response.completed was already parsed — discarding that turn
+    // would retry a successful compaction, the exact quota waste the watchdog exists to prevent).
+    private fun terminalOutcome(reducer: ResponsesEventReducer): TurnOutcome = terminalPrecedence(
+        TerminalStates(
+            providerFailure = reducer.upstreamFailure?.let {
+                // parsed from a response.failed/error event the backend actually sent (G20 provenance)
+                TurnOutcome.Failure(it.type, "ChatGPT backend: ${it.message}", providerReported = true)
+            },
+            finished = reducer.finalResponse != null,
+            watchdogFired = ctx.watchdogFired(),
+        ),
+        onFinished = { successOutcome(reducer) },
+        onWatchdog = ::watchdogOutcome,
+        onUnfinished = ::noCompletionOutcome,
+    )
 
-    // A COMPLETED response wins over a late watchdog fire. The watchdog polls the whole
-    // enclosing coroutine, which stays suspended on the socket-EOF read AFTER the terminal
-    // response.completed frame was already parsed; a fire in that window must NOT discard a
-    // fully-received turn (that would retry a successful compaction — the exact quota waste the
-    // watchdog exists to prevent). So the stall/truncation verdicts only apply when there is no
-    // completed response yet (this path).
-    private fun noCompletionOutcome(): TurnOutcome {
-        ctx.watchdogFired()?.let { return watchdogOutcome(it) }
-        return if (ctx.clientGone()) {
+    private fun noCompletionOutcome(): TurnOutcome =
+        if (ctx.clientGone()) {
             TurnOutcome.ClientAbandoned
         } else {
             TurnOutcome.Failure(
@@ -129,7 +135,6 @@ public class ResponsesStreamTranslator(private val ctx: StreamTurnContext) : Str
                 "claudex: upstream stream ended without response.completed (truncated); retry",
             )
         }
-    }
 
     private fun watchdogOutcome(fired: WatchdogFired): TurnOutcome {
         val why = when (fired) {
@@ -217,7 +222,7 @@ private class ResponsesEventReducer(private val ctx: StreamTurnContext) {
     private val seenSummaryPartsByItem = HashMap<Int, MutableSet<String>>()
 
     suspend fun onEvent(evt: JsonObject, sink: WireSink) {
-        when (str(evt["type"])) {
+        when (strOrEmpty(evt["type"])) {
             "response.completed", "response.done", "response.incomplete" -> onTerminal(evt)
             "response.failed", "response.error", "error" -> onFailure(evt)
             else -> onStreamEvent(evt, sink)
@@ -225,7 +230,7 @@ private class ResponsesEventReducer(private val ctx: StreamTurnContext) {
     }
 
     private suspend fun onStreamEvent(evt: JsonObject, sink: WireSink) {
-        when (str(evt["type"])) {
+        when (strOrEmpty(evt["type"])) {
             "response.output_item.added" -> onItemAdded(evt, sink)
             "response.output_item.done" -> onItemDone(evt, sink)
             "response.reasoning_summary_part.added" -> onSummaryPartAdded(evt, sink)
@@ -242,7 +247,7 @@ private class ResponsesEventReducer(private val ctx: StreamTurnContext) {
     private fun onTerminal(evt: JsonObject) {
         val resp = (evt["response"] as? JsonObject) ?: evt
         finalResponse = resp
-        if (str(evt["type"]) == "response.incomplete" || str(resp["status"]) == "incomplete") {
+        if (strOrEmpty(evt["type"]) == "response.incomplete" || strOrEmpty(resp["status"]) == "incomplete") {
             incomplete = true
         }
         val u = usageFrom(resp)
@@ -258,18 +263,21 @@ private class ResponsesEventReducer(private val ctx: StreamTurnContext) {
         val e = (evt["response"] as? JsonObject)?.get("error") as? JsonObject
             ?: evt["error"] as? JsonObject
             ?: evt
-        val code = str(e["code"]).ifEmpty { str(e["type"]) }.ifEmpty { "upstream_failed" }
-        val message = str(e["message"]).ifEmpty { "ChatGPT backend reported failure" }
+        val code = strOrEmpty(e["code"]).ifEmpty { strOrEmpty(e["type"]) }.ifEmpty { "upstream_failed" }
+        val message = strOrEmpty(e["message"]).ifEmpty { "ChatGPT backend reported failure" }
         upstreamFailure = UpstreamFailureClassifier.classify(FailureSource.SSE, "$code $message")
     }
 
     private suspend fun onItemAdded(evt: JsonObject, sink: WireSink) {
         val item = evt["item"] as? JsonObject ?: return
         val oi = intOr(evt[OUTPUT_INDEX]) ?: intOr(item["index"]) ?: blocks.size
-        if (str(item["type"]) == "function_call") {
-            val id = str(item["call_id"]).ifEmpty { str(item["id"]) }
+        if (strOrEmpty(item["type"]) == "function_call") {
+            // A JsonNull call_id/name must not leak onto the wire as the literal string "null" —
+            // strOrEmpty keeps both filtered so the empty-fallback chain below still triggers
+            // (review 2026-07-22 round 3).
+            val id = strOrEmpty(item["call_id"]).ifEmpty { strOrEmpty(item["id"]) }
                 .ifEmpty { "toolu_synth_${toolSynthCounter++}_$oi" }
-            val idx = sink.openTool(id = id, name = str(item["name"]))
+            val idx = sink.openTool(id = id, name = strOrEmpty(item["name"]))
             blocks[oi] = BlockState(idx, sawDelta = false)
             hasToolUse = true
         }
@@ -301,7 +309,7 @@ private class ResponsesEventReducer(private val ctx: StreamTurnContext) {
 
     private suspend fun maybeEmitLateReasoning(item: JsonObject?, oi: Int?, sink: WireSink) {
         if (item == null || oi == null) return
-        if (str(item["type"]) != "reasoning") return
+        if (strOrEmpty(item["type"]) != "reasoning") return
         emitReasoningItemText(item, oi, sink)
     }
 
@@ -357,7 +365,7 @@ private class ResponsesEventReducer(private val ctx: StreamTurnContext) {
     }
 
     private suspend fun onThinkingDelta(evt: JsonObject, sink: WireSink) {
-        val delta = str(evt[DELTA])
+        val delta = strOrEmpty(evt[DELTA])
         if (delta.isEmpty()) return
         // sequential_cutoff restatement dedup: whole parts arrive as single deltas in this mode;
         // an exact repeat of an already-streamed part (>= min length; shorter deltas are plausibly
@@ -384,7 +392,7 @@ private class ResponsesEventReducer(private val ctx: StreamTurnContext) {
     }
 
     private suspend fun onTextDelta(evt: JsonObject, sink: WireSink) {
-        val delta = str(evt[DELTA])
+        val delta = strOrEmpty(evt[DELTA])
         if (delta.isEmpty()) return
         val key = intOr(evt[OUTPUT_INDEX]) ?: 0
         val b = blocks[key] ?: BlockState(sink.openText(), sawDelta = false).also { blocks[key] = it }
@@ -398,9 +406,9 @@ private class ResponsesEventReducer(private val ctx: StreamTurnContext) {
     // harvest `arguments` once before close so the client does not get tool_use with empty input {}.
     private suspend fun onArgs(evt: JsonObject, sink: WireSink) {
         val b = blocks[intOr(evt[OUTPUT_INDEX]) ?: return] ?: return
-        if (str(evt["type"]) == "response.function_call_arguments.done") {
+        if (strOrEmpty(evt["type"]) == "response.function_call_arguments.done") {
             if (!b.sawDelta) {
-                val full = str(evt["arguments"])
+                val full = strOrEmpty(evt["arguments"])
                 if (full.isNotEmpty()) {
                     sink.inputJsonDelta(b.index, full)
                     b.sawDelta = true
@@ -408,7 +416,7 @@ private class ResponsesEventReducer(private val ctx: StreamTurnContext) {
             }
             sink.closeBlock(b.index)
         } else {
-            val delta = str(evt[DELTA])
+            val delta = strOrEmpty(evt[DELTA])
             if (delta.isNotEmpty()) {
                 sink.inputJsonDelta(b.index, delta)
                 b.sawDelta = true
@@ -430,7 +438,7 @@ private class ResponsesEventReducer(private val ctx: StreamTurnContext) {
 /** Gated encrypted-reasoning EMISSION predicate — kept out of the handler so its condition stays flat. */
 private fun shouldEmitReasoning(ctx: StreamTurnContext, item: JsonObject): Boolean =
     ctx.emitEncryptedReasoning.v && !ctx.compact &&
-        str(item["type"]) == "reasoning" && str(item["encrypted_content"]).isNotEmpty()
+        strOrEmpty(item["type"]) == "reasoning" && strOrEmpty(item["encrypted_content"]).isNotEmpty()
 
 /**
  * The terminal object's text replaces the streamed buffer when the stream produced nothing, or
@@ -441,10 +449,4 @@ private fun shouldPreferHarvestedText(current: CharSequence, harvested: String):
     return current.isEmpty() || (isWeakSummaryText(current.toString()) && !isWeakSummaryText(harvested))
 }
 
-// JsonNull IS a JsonPrimitive whose .content is the 4-char string "null" — filter it (Chat /
-// core JsonScalars already do). Else call_id/name/delta:null becomes the literal "null" on wire.
-private fun str(el: JsonElement?): String =
-    (el as? JsonPrimitive)?.takeUnless { it is JsonNull }?.content ?: ""
-
-private fun intOr(el: JsonElement?): Int? =
-    (el as? JsonPrimitive)?.takeUnless { it is JsonNull }?.content?.toIntOrNull()
+private fun intOr(el: JsonElement?): Int? = el.str()?.toIntOrNull()

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesStreamTranslator.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesStreamTranslator.kt
@@ -20,6 +20,7 @@ package splice.dialect.responses
 import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import splice.core.index.WireBlockIndex
@@ -393,13 +394,25 @@ private class ResponsesEventReducer(private val ctx: StreamTurnContext) {
     }
 
     // tool args stream as input_json_delta on the SAME wire block index; the .done frame closes it.
+    // When the backend sends complete args only on .done (no .delta frames — valid for small tools),
+    // harvest `arguments` once before close so the client does not get tool_use with empty input {}.
     private suspend fun onArgs(evt: JsonObject, sink: WireSink) {
         val b = blocks[intOr(evt[OUTPUT_INDEX]) ?: return] ?: return
         if (str(evt["type"]) == "response.function_call_arguments.done") {
+            if (!b.sawDelta) {
+                val full = str(evt["arguments"])
+                if (full.isNotEmpty()) {
+                    sink.inputJsonDelta(b.index, full)
+                    b.sawDelta = true
+                }
+            }
             sink.closeBlock(b.index)
         } else {
             val delta = str(evt[DELTA])
-            if (delta.isNotEmpty()) sink.inputJsonDelta(b.index, delta)
+            if (delta.isNotEmpty()) {
+                sink.inputJsonDelta(b.index, delta)
+                b.sawDelta = true
+            }
         }
     }
 
@@ -428,8 +441,10 @@ private fun shouldPreferHarvestedText(current: CharSequence, harvested: String):
     return current.isEmpty() || (isWeakSummaryText(current.toString()) && !isWeakSummaryText(harvested))
 }
 
+// JsonNull IS a JsonPrimitive whose .content is the 4-char string "null" — filter it (Chat /
+// core JsonScalars already do). Else call_id/name/delta:null becomes the literal "null" on wire.
 private fun str(el: JsonElement?): String =
-    (el as? JsonPrimitive)?.content ?: ""
+    (el as? JsonPrimitive)?.takeUnless { it is JsonNull }?.content ?: ""
 
 private fun intOr(el: JsonElement?): Int? =
-    (el as? JsonPrimitive)?.content?.toIntOrNull()
+    (el as? JsonPrimitive)?.takeUnless { it is JsonNull }?.content?.toIntOrNull()

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesStreamTranslator.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesStreamTranslator.kt
@@ -66,20 +66,49 @@ public data class StreamTurnContext(
     val collectReasoningEnvelopes: Boolean = false,
 )
 
-/** Drop paragraph-parts already streamed this turn (sequential_cutoff recap noise); parts under
- *  the min length always pass (plausibly genuine fragments). No-op unless the quirk is active. */
-private fun dedupSummaryParts(text: String, seen: MutableSet<String>, active: Boolean): String {
-    if (!active || text.isEmpty()) return text
-    return text.split(PART_SEPARATOR)
-        .filter { part -> part.length < SUMMARY_PART_DEDUP_MIN_CHARS || seen.add(part) }
-        .joinToString(PART_SEPARATOR)
-}
-
 private const val PART_SEPARATOR = "\n\n"
 
 // below this length an exact repeat is plausibly a genuine token fragment; whole summary parts
 // (titled sections) are far longer
 private const val SUMMARY_PART_DEDUP_MIN_CHARS = 20
+
+// Per-item recap cursor sentinel: the leading cross-item recap has ended for this item, so every
+// remaining part is genuinely new (only within-item exact repeats are still suppressed).
+private const val RECAP_DONE = -1
+
+// sequential_cutoff restatement dedup. This mode restates summary parts in TWO distinct ways, and
+// one structure conflating them is why this kept oscillating (revert/reapply/rescope):
+//   (A) CROSS-item recap — each NEW reasoning item replays every part emitted so far, IN ORDER, as
+//       a leading prefix, then appends its genuinely-new parts (probed 2026-07-19: part(1,0) ==
+//       part(0,0)). Suppressed by matching the leading run against the ordered emitted list via a
+//       per-item cursor.
+//   (B) WITHIN-item repeat — item.done can restate parts whose deltas then re-arrive, or vice versa
+//       (openai/codex#16801 ordering anomaly, live 2026-07-19). Suppressed by a per-item exact set.
+// A turn-global SET over-suppressed a paragraph two DISTINCT items coincidentally shared
+// (2026-07-20); a per-ITEM set alone under-suppressed the cross-item recap (the duplication
+// staircase). Splitting the two jobs keeps the coincidence (per-item, non-leading) while killing
+// the staircase (ordered leading prefix). State + decision live together here (2026-07-23).
+private class SummaryDedup(private val active: Boolean) {
+    private val emittedParts = mutableListOf<String>()
+    private val recapCursor = HashMap<Int, Int>()
+    private val itemEmitted = HashMap<Int, MutableSet<String>>()
+
+    /** True to SUPPRESS a recap/repeat part of item [oi]; a genuinely-new part returns false and is
+     *  recorded so later items' recaps (A) and this item's own re-arrivals (B) match. Parts under
+     *  the min length always pass and are never recorded (plausibly genuine token fragments). */
+    fun suppress(oi: Int, part: String): Boolean {
+        if (!active || part.length < SUMMARY_PART_DEDUP_MIN_CHARS) return false
+        val cursor = recapCursor.getOrDefault(oi, 0)
+        if (cursor in emittedParts.indices && emittedParts[cursor] == part) {
+            recapCursor[oi] = cursor + 1
+            return true
+        }
+        recapCursor[oi] = RECAP_DONE
+        val fresh = itemEmitted.getOrPut(oi) { HashSet() }.add(part)
+        if (fresh) emittedParts.add(part)
+        return !fresh
+    }
+}
 
 // Mutable per-block cursor. A data class here documents it as pure per-block state; it is only
 // ever stored/looked up by wire index, never compared by value.
@@ -215,11 +244,8 @@ private class ResponsesEventReducer(private val ctx: StreamTurnContext) {
     // earlier one, diverging wire from mirror (audit 2026-07-18); track per item instead.
     private val emittedReasoningKeys = HashSet<Int>()
 
-    // sequential_cutoff restatement dedup, PER reasoning item (keyed by output_index). A turn-global
-    // set silently dropped a genuine paragraph that two DISTINCT reasoning items happened to share
-    // byte-for-byte (2026-07-20) — restatements only recur WITHIN one item's summary stream, so the
-    // set is scoped there. Bounded by the item count per turn.
-    private val seenSummaryPartsByItem = HashMap<Int, MutableSet<String>>()
+    // sequential_cutoff restatement dedup — state + decision encapsulated in SummaryDedup (above).
+    private val summaryDedup = SummaryDedup(ctx.dedupeRepeatedSummaryParts)
 
     suspend fun onEvent(evt: JsonObject, sink: WireSink) {
         when (strOrEmpty(evt["type"])) {
@@ -327,13 +353,18 @@ private class ResponsesEventReducer(private val ctx: StreamTurnContext) {
         if (raw.isEmpty() || streamedByDeltas) return
         if (!emittedReasoningKeys.add(reasoningKey(outputIndex))) return
         // sequential_cutoff recap arrives through THIS path too (completed items restate prior
-        // parts) — same seen-set as the delta path, at part granularity. MUST run AFTER every
-        // early-return above: the backend can deliver item.done BEFORE the item's remaining deltas
-        // (openai/codex#16801 ordering anomaly), and filtering first seeded the seen-set with parts
-        // whose deltas hadn't arrived — suppressing them both late (sawDelta return) and live
-        // (seen-set match): total summary starvation (found live 2026-07-19).
-        val seen = seenSummaryPartsByItem.getOrPut(outputIndex) { HashSet() }
-        val text = dedupSummaryParts(raw, seen, ctx.dedupeRepeatedSummaryParts)
+        // parts) — same ordered recap model as the delta path, at part granularity. MUST run AFTER
+        // every early-return above: the backend can deliver item.done BEFORE the item's remaining
+        // deltas (openai/codex#16801 ordering anomaly), and filtering first would record parts whose
+        // deltas hadn't arrived — suppressing them both late (sawDelta return) and live (recap
+        // match): total summary starvation (found live 2026-07-19).
+        // Late-path recap filter: drop the leading recap run + within-item repeats, keep the rest.
+        val text = if (ctx.dedupeRepeatedSummaryParts) {
+            raw.split(PART_SEPARATOR).filter { part -> !summaryDedup.suppress(outputIndex, part) }
+                .joinToString(PART_SEPARATOR)
+        } else {
+            raw
+        }
         if (text.isEmpty()) return
         appendLateReasoning(existing, outputIndex, text, sink)
     }
@@ -367,13 +398,9 @@ private class ResponsesEventReducer(private val ctx: StreamTurnContext) {
     private suspend fun onThinkingDelta(evt: JsonObject, sink: WireSink) {
         val delta = strOrEmpty(evt[DELTA])
         if (delta.isEmpty()) return
-        // sequential_cutoff restatement dedup: whole parts arrive as single deltas in this mode;
-        // an exact repeat of an already-streamed part (>= min length; shorter deltas are plausibly
-        // genuine token fragments) is upstream recap noise, not new thinking.
-        if (ctx.dedupeRepeatedSummaryParts && delta.length >= SUMMARY_PART_DEDUP_MIN_CHARS) {
-            val oi = intOr(evt[OUTPUT_INDEX]) ?: 0
-            if (!seenSummaryPartsByItem.getOrPut(oi) { HashSet() }.add(delta)) return
-        }
+        // sequential_cutoff: whole parts arrive as single deltas; drop a delta that is either the
+        // continuation of this item's leading cross-item recap or an exact within-item repeat.
+        if (summaryDedup.suppress(intOr(evt[OUTPUT_INDEX]) ?: 0, delta)) return
         val b = ensureThinkingBlock(evt, sink)
         b.sawDelta = true
         thinkingBuf.append(delta)

--- a/gateway/dialect-openai-responses/src/test/kotlin/HarvestedTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/HarvestedTest.kt
@@ -1,0 +1,54 @@
+// NEW (review gap C, 2026-07-23): terminal harvest must survive JSON nulls on the Responses object.
+// A JsonNull free-form reasoning field must NOT suppress the summary fallback; a null output_text
+// must NOT leak the literal string "null" onto the wire; and neither may inject spurious paragraph
+// separators. harvestResponsesOutput is a pure function, so this pins the behavior directly.
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+import splice.dialect.responses.harvestResponsesOutput
+
+class HarvestedTest {
+
+    private fun resp(json: String) = Json.parseToJsonElement(json).jsonObject
+
+    @Test
+    fun `a null free-form reasoning field falls back to the summary parts`() {
+        val h = harvestResponsesOutput(
+            resp(
+                """{"output":[{"type":"reasoning","content":null,
+                   "summary":[{"type":"summary_text","text":"the plan"}]}]}""",
+            ),
+        )
+        assertEquals("the plan", h.thinking)
+        assertFalse(h.thinking.contains("null"), "JsonNull must never render as literal \"null\": ${h.thinking}")
+    }
+
+    @Test
+    fun `a null output_text part is skipped and the real answer is retained`() {
+        val h = harvestResponsesOutput(
+            resp(
+                """{"output":[{"type":"message","content":[
+                   {"type":"output_text","text":null},
+                   {"type":"output_text","text":"answer"}]}]}""",
+            ),
+        )
+        assertEquals("answer", h.text)
+        assertFalse(h.text.contains("null"), "a null text part must not leak \"null\": ${h.text}")
+    }
+
+    @Test
+    fun `two reasoning items join as one paragraph break with no spurious separators`() {
+        // First item: null free-form → summary fallback. Second: empty free-form array → also
+        // summary fallback. They must join with exactly one blank line, no leading/trailing breaks.
+        val h = harvestResponsesOutput(
+            resp(
+                """{"output":[
+                   {"type":"reasoning","content":null,"summary":[{"type":"summary_text","text":"first"}]},
+                   {"type":"reasoning","content":[],"summary":[{"type":"summary_text","text":"second"}]}]}""",
+            ),
+        )
+        assertEquals("first\n\nsecond", h.thinking)
+    }
+}

--- a/gateway/dialect-openai-responses/src/test/kotlin/ResponsesStreamTranslatorTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ResponsesStreamTranslatorTest.kt
@@ -67,6 +67,7 @@ private fun ctx(
     clientGone: Boolean = false,
     fired: WatchdogFired? = null,
     collect: Boolean = false,
+    dedupe: Boolean = false,
 ) = StreamTurnContext(
     compact = compact,
     emitEncryptedReasoning = EmitEncryptedReasoning(emit),
@@ -76,6 +77,7 @@ private fun ctx(
     streamIdleMsForMessage = 180_000,
     upstreamTimeoutMsForMessage = 900_000,
     collectReasoningEnvelopes = collect,
+    dedupeRepeatedSummaryParts = dedupe,
 )
 
 private fun ev(json: String): JsonObject = Json.parseToJsonElement(json).jsonObject
@@ -122,6 +124,88 @@ class ResponsesStreamTranslatorTest {
         assertTrue(sink.calls.contains("think#0:\n\n"))
     }
 
+    // sequential_cutoff (A): each NEW reasoning item restates the running summary as a leading
+    // prefix, then appends one new part. The recap MUST be suppressed — emitting it re-sends every
+    // prior line per item, the duplication staircase (2026-07-23). Parts are >= the dedup min so
+    // the quirk engages; the quirk is on for codex via summaryDelivery="sequential_cutoff".
+    @Test
+    fun `cross-item summary recap is suppressed - each part reaches the wire exactly once`() = runTest {
+        val p0 = "Planning the prioritized review findings"
+        val p1 = "Identifying stale plan conflicts and missing files"
+        val p2 = "Highlighting certification gaps across the runtime"
+        val sink = RecordingSink()
+        val outcome = ResponsesStreamTranslator(ctx(dedupe = true)).driveTurn(
+            listOf(
+                ev("""{"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning"}}"""),
+                ev("""{"type":"response.reasoning_summary_text.delta","output_index":0,"delta":"$p0"}"""),
+                // item 1 recaps p0, then adds p1
+                ev("""{"type":"response.output_item.added","output_index":1,"item":{"type":"reasoning"}}"""),
+                ev("""{"type":"response.reasoning_summary_text.delta","output_index":1,"delta":"$p0"}"""),
+                ev("""{"type":"response.reasoning_summary_text.delta","output_index":1,"delta":"$p1"}"""),
+                // item 2 recaps p0 + p1, then adds p2
+                ev("""{"type":"response.output_item.added","output_index":2,"item":{"type":"reasoning"}}"""),
+                ev("""{"type":"response.reasoning_summary_text.delta","output_index":2,"delta":"$p0"}"""),
+                ev("""{"type":"response.reasoning_summary_text.delta","output_index":2,"delta":"$p1"}"""),
+                ev("""{"type":"response.reasoning_summary_text.delta","output_index":2,"delta":"$p2"}"""),
+                completed,
+            ).asFlow(),
+            sink,
+        )
+        assertTrue(outcome is TurnOutcome.Success)
+        // Every summary part reaches the wire exactly once — no restatement staircase.
+        assertEquals(1, sink.calls.count { it.contains(p0) }, "p0 duplicated: ${sink.calls}")
+        assertEquals(1, sink.calls.count { it.contains(p1) }, "p1 duplicated")
+        assertEquals(1, sink.calls.count { it.contains(p2) }, "p2 duplicated")
+    }
+
+    // Regression guard (2026-07-20): a paragraph two DISTINCT items genuinely share byte-for-byte is
+    // NOT a leading recap of item 2 (item 2's own new part comes first), so it must be KEPT — a
+    // turn-global seen-set wrongly cross-dropped it, causing summary starvation.
+    @Test
+    fun `a paragraph two distinct items coincidentally share is kept, not cross-dropped`() = runTest {
+        val p0 = "Weighing the two candidate migration designs"
+        val shared = "The token write must precede the navigation step"
+        val fresh = "Now reconciling the session store mismatch cleanly"
+        val sink = RecordingSink()
+        val outcome = ResponsesStreamTranslator(ctx(dedupe = true)).driveTurn(
+            listOf(
+                ev("""{"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning"}}"""),
+                ev("""{"type":"response.reasoning_summary_text.delta","output_index":0,"delta":"$p0"}"""),
+                ev("""{"type":"response.reasoning_summary_text.delta","output_index":0,"delta":"$shared"}"""),
+                // item 1: a genuinely-new leading part (NOT a recap of p0), then the same shared paragraph
+                ev("""{"type":"response.output_item.added","output_index":1,"item":{"type":"reasoning"}}"""),
+                ev("""{"type":"response.reasoning_summary_text.delta","output_index":1,"delta":"$fresh"}"""),
+                ev("""{"type":"response.reasoning_summary_text.delta","output_index":1,"delta":"$shared"}"""),
+                completed,
+            ).asFlow(),
+            sink,
+        )
+        assertTrue(outcome is TurnOutcome.Success)
+        assertEquals(1, sink.calls.count { it.contains(p0) })
+        assertEquals(1, sink.calls.count { it.contains(fresh) })
+        // Kept in BOTH items — the coincidence is not a leading cross-item recap.
+        assertEquals(2, sink.calls.count { it.contains(shared) }, "shared paragraph wrongly dropped: ${sink.calls}")
+    }
+
+    // Regression guard (openai/codex#16801, live 2026-07-19): a part restated WITHIN one item (an
+    // exact re-arrival at the same output_index) is suppressed, without affecting other items.
+    @Test
+    fun `an exact within-item part repeat is suppressed`() = runTest {
+        val q0 = "Deferring the atomic publication ordering decision"
+        val sink = RecordingSink()
+        val outcome = ResponsesStreamTranslator(ctx(dedupe = true)).driveTurn(
+            listOf(
+                ev("""{"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning"}}"""),
+                ev("""{"type":"response.reasoning_summary_text.delta","output_index":0,"delta":"$q0"}"""),
+                ev("""{"type":"response.reasoning_summary_text.delta","output_index":0,"delta":"$q0"}"""),
+                completed,
+            ).asFlow(),
+            sink,
+        )
+        assertTrue(outcome is TurnOutcome.Success)
+        assertEquals(1, sink.calls.count { it.contains(q0) }, "within-item repeat leaked: ${sink.calls}")
+    }
+
     @Test
     fun `tool flow - eager open on item added, args stream to same index, done closes`() = runTest {
         val sink = RecordingSink()
@@ -141,6 +225,52 @@ class ResponsesStreamTranslatorTest {
         assertTrue((outcome as TurnOutcome.Success).hasToolUse)
         assertEquals(
             listOf("openTool#0(toolu_1,run)", "json#0:{\"c\":", "json#0:1}", "close#0", "closeAll"),
+            sink.calls,
+        )
+    }
+
+    @Test
+    fun `done-only tool arguments (no deltas) are emitted once before close`() = runTest {
+        // Small tools can arrive with the COMPLETE arguments only on .done and no delta frames —
+        // the !sawDelta branch must harvest them once so the client does not get input {}.
+        val sink = RecordingSink()
+        val outcome = ResponsesStreamTranslator(ctx()).driveTurn(
+            listOf(
+                ev(
+                    """{"type":"response.output_item.added","output_index":1,
+                       "item":{"type":"function_call","call_id":"t1","name":"run"}}""",
+                ),
+                ev("""{"type":"response.function_call_arguments.done","output_index":1,"arguments":"{\"x\":1}"}"""),
+                completed,
+            ).asFlow(),
+            sink,
+        )
+        assertTrue((outcome as TurnOutcome.Success).hasToolUse)
+        assertEquals(listOf("openTool#0(t1,run)", "json#0:{\"x\":1}", "close#0", "closeAll"), sink.calls)
+    }
+
+    @Test
+    fun `done arguments are NOT re-appended when deltas already streamed them`() = runTest {
+        // .done repeats the consolidated arguments; having streamed the fragments (sawDelta), the
+        // translator must NOT append the whole JSON again (that would corrupt the tool input).
+        val sink = RecordingSink()
+        val outcome = ResponsesStreamTranslator(ctx()).driveTurn(
+            listOf(
+                ev(
+                    """{"type":"response.output_item.added","output_index":1,
+                       "item":{"type":"function_call","call_id":"t2","name":"run"}}""",
+                ),
+                ev("""{"type":"response.function_call_arguments.delta","output_index":1,"delta":"{\"y\":"}"""),
+                ev("""{"type":"response.function_call_arguments.delta","output_index":1,"delta":"2}"}"""),
+                ev("""{"type":"response.function_call_arguments.done","output_index":1,"arguments":"{\"y\":2}"}"""),
+                completed,
+            ).asFlow(),
+            sink,
+        )
+        assertTrue((outcome as TurnOutcome.Success).hasToolUse)
+        // Only the two streamed fragments — the consolidated {"y":2} on .done is NOT re-emitted.
+        assertEquals(
+            listOf("openTool#0(t2,run)", "json#0:{\"y\":", "json#0:2}", "close#0", "closeAll"),
             sink.calls,
         )
     }

--- a/gateway/dialect-openai-responses/src/test/kotlin/ResponsesStreamTranslatorTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ResponsesStreamTranslatorTest.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import splice.core.index.WireBlockIndex
@@ -227,6 +228,50 @@ class ResponsesStreamTranslatorTest {
             listOf("openTool#0(toolu_1,run)", "json#0:{\"c\":", "json#0:1}", "close#0", "closeAll"),
             sink.calls,
         )
+    }
+
+    @Test
+    fun `a null call_id falls back to id and a null name opens with an empty name`() = runTest {
+        // The Responses call_id -> id -> synthetic chain is distinct from the Chat null-id path.
+        val sink = RecordingSink()
+        val outcome = ResponsesStreamTranslator(ctx()).driveTurn(
+            listOf(
+                ev(
+                    """{"type":"response.output_item.added","output_index":0,
+                       "item":{"type":"function_call","call_id":null,"id":"resp_abc","name":null}}""",
+                ),
+                ev("""{"type":"response.function_call_arguments.delta","output_index":0,"delta":"{\"a\":1}"}"""),
+                ev("""{"type":"response.function_call_arguments.done","output_index":0}"""),
+                completed,
+            ).asFlow(),
+            sink,
+        )
+        assertTrue((outcome as TurnOutcome.Success).hasToolUse)
+        // call_id JsonNull -> id fallback; name JsonNull -> empty (strOrEmpty filters both).
+        assertEquals("openTool#0(resp_abc,)", sink.calls.first())
+        assertFalse(sink.calls.any { it.contains("null") }, "literal null must never reach the wire: ${sink.calls}")
+        assertTrue(sink.calls.contains("json#0:{\"a\":1}"), "args must route to the resolved tool block")
+    }
+
+    @Test
+    fun `both call_id and id null get a nonempty synthetic id, never the literal null`() = runTest {
+        val sink = RecordingSink()
+        val outcome = ResponsesStreamTranslator(ctx()).driveTurn(
+            listOf(
+                ev(
+                    """{"type":"response.output_item.added","output_index":2,
+                       "item":{"type":"function_call","call_id":null,"id":null,"name":"run"}}""",
+                ),
+                ev("""{"type":"response.function_call_arguments.delta","output_index":2,"delta":"{}"}"""),
+                ev("""{"type":"response.function_call_arguments.done","output_index":2}"""),
+                completed,
+            ).asFlow(),
+            sink,
+        )
+        assertTrue((outcome as TurnOutcome.Success).hasToolUse)
+        val open = sink.calls.first { it.startsWith("openTool") }
+        assertTrue(open.startsWith("openTool#0(toolu_synth"), "expected a synthetic id: $open")
+        assertFalse(open.contains("null"), "synthetic id must be nonempty, never \"null\": $open")
     }
 
     @Test

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/HeadServer.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/HeadServer.kt
@@ -30,6 +30,7 @@ import io.ktor.utils.io.readAvailable
 import io.netty.channel.socket.SocketChannelConfig
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -46,6 +47,7 @@ import splice.core.model.DiscoveryRow
 import splice.core.parse.parseAnthropicBody
 import splice.core.perf.PerfKeys
 import splice.core.perf.TurnPerf
+import splice.core.util.MonoClock
 import splice.core.util.runCatchingCancellable
 import splice.gateway.compact.CompactStats
 import splice.gateway.compact.ShadowClassifier
@@ -72,7 +74,7 @@ public data class HeadDeps(
     val usageStore: UsageStore,
     val perfStats: PerfStats,
     val log: (String) -> Unit,
-    val clock: () -> Long = System::currentTimeMillis,
+    val clock: () -> Long = MonoClock::nowMs,
     val requestMaterializationGate: RequestMaterializationGate = RequestMaterializationGate(),
     val maxRequestBytes: Int = DEFAULT_MAX_REQUEST_BYTES,
     val requestReadTimeoutMs: Long = DEFAULT_REQUEST_READ_TIMEOUT_MS,
@@ -177,14 +179,25 @@ public class HeadServer(
         server = engine
     }
 
-    private fun stopLocked() {
+    private suspend fun stopLocked() {
+        // Drain in-flight turns so clients get honest terminals (sealCancelledTurn) before Netty
+        // tears the engine. Bounded wait — never block restart forever.
+        val deadlineNs = System.nanoTime() + STOP_DRAIN_NS
+        while (gate.snapshot().inflight > 0 && System.nanoTime() < deadlineNs) {
+            delay(STOP_DRAIN_POLL_MS)
+        }
+        if (gate.snapshot().inflight > 0) {
+            log("[${provider.key}] stop: draining timed out with inflight=${gate.snapshot().inflight} — forcing engine stop\n")
+        }
         server?.stop(STOP_GRACE_MS, STOP_TIMEOUT_MS)
         server = null
         deps.usageStore.flushNow()
+        driver.resetHealth()
     }
 
     override fun healthSnapshot(): HeadHealth {
         val counts = driver.healthCounters()
+        val gateSnap = gate.snapshot()
         return HeadHealth(
             ok = server != null,
             running = server != null,
@@ -192,6 +205,9 @@ public class HeadServer(
             version = GATEWAY_VERSION,
             localOriginErrors = counts.localOrigin,
             providerErrors = counts.providerError,
+            gateInflight = gateSnap.inflight,
+            gateQueued = gateSnap.queued,
+            gateLimit = gateSnap.limit,
         )
     }
 
@@ -310,27 +326,34 @@ public class HeadServer(
 
     private suspend fun handleCountTokens(call: ApplicationCall) {
         if (!authorize(call)) return
-        val body = materializeOrRespond(call) { receiveBodyBounded(call, deps.maxRequestBytes) } ?: return
-        val parsed = runCatchingCancellable { parseAnthropicBody(body.text) }.getOrNull()
-        if (parsed == null) {
-            call.respondText(
-                errorBodyJson(INVALID_REQUEST_ERROR, "invalid request body"),
-                ContentType.Application.Json,
-                HttpStatusCode.BadRequest,
-            )
-        } else {
-            // Conservative and Unicode-safe: UTF-8 bytes / 3 overestimates ordinary English while
-            // avoiding the old UTF-16 chars / 4 undercount for CJK and emoji. The complete JSON body
-            // intentionally contributes structural/tool overhead.
-            val estimate =
-                ((body.bytes + TOKEN_ESTIMATE_BYTES - 1) / TOKEN_ESTIMATE_BYTES)
-                    .coerceAtLeast(1)
-                    .toLong()
-            log("[${provider.key}] count_tokens estimate=$estimate (local; no upstream turn)\n")
-            call.respondText(
-                buildJsonObject { put("input_tokens", estimate) }.toString(),
-                ContentType.Application.Json,
-            )
+        // Share the admission gate so a flood of large count_tokens bodies cannot bypass
+        // maxInflight while /v1/messages is capacity-protected.
+        val slot = acquireSlotOrRespond(call) ?: return
+        try {
+            val body = materializeOrRespond(call) { receiveBodyBounded(call, deps.maxRequestBytes) } ?: return
+            val parsed = runCatchingCancellable { parseAnthropicBody(body.text) }.getOrNull()
+            if (parsed == null) {
+                call.respondText(
+                    errorBodyJson(INVALID_REQUEST_ERROR, "invalid request body"),
+                    ContentType.Application.Json,
+                    HttpStatusCode.BadRequest,
+                )
+            } else {
+                // Conservative and Unicode-safe: UTF-8 bytes / 3 overestimates ordinary English while
+                // avoiding the old UTF-16 chars / 4 undercount for CJK and emoji. The complete JSON body
+                // intentionally contributes structural/tool overhead.
+                val estimate =
+                    ((body.bytes + TOKEN_ESTIMATE_BYTES - 1) / TOKEN_ESTIMATE_BYTES)
+                        .coerceAtLeast(1)
+                        .toLong()
+                log("[${provider.key}] count_tokens estimate=$estimate (local; no upstream turn)\n")
+                call.respondText(
+                    buildJsonObject { put("input_tokens", estimate) }.toString(),
+                    ContentType.Application.Json,
+                )
+            }
+        } finally {
+            withContext(NonCancellable) { slot.release() }
         }
     }
 
@@ -399,8 +422,12 @@ public class HeadServer(
     }.toString()
 
     private companion object {
-        const val STOP_GRACE_MS = 100L
-        const val STOP_TIMEOUT_MS = 500L
+        // Grace/timeout for Netty engine.stop after the drain window below.
+        const val STOP_GRACE_MS = 500L
+        const val STOP_TIMEOUT_MS = 2_000L
+        // Wait for in-flight SSE turns to finish (or cancel cleanly) before tearing the engine.
+        const val STOP_DRAIN_NS = 5_000_000_000L // 5s
+        const val STOP_DRAIN_POLL_MS = 50L
         const val TOKEN_ESTIMATE_BYTES = 3
         const val READ_BUFFER_BYTES = 16 * 1024
         const val CONTENT_TOO_LARGE_STATUS = 413
@@ -409,8 +436,9 @@ public class HeadServer(
         // Concurrent long-lived SSE turns per head (2x the 1000-stream design target).
         const val RUNNING_LIMIT = 2048
 
-        // Response-write stall cap — generous: the two-tier watchdog owns liveness enforcement.
-        const val WRITE_TIMEOUT_S = 60
+        // Response-write stall cap — at least as long as default streamIdle (180s) so a slow-but-alive
+        // client is not killed by Netty while the two-tier watchdog still considers the stream healthy.
+        const val WRITE_TIMEOUT_S = 300
 
         // Same numeric convention as UpstreamFailureClassifier's OVERLOADED_STATUS (kept as its
         // own const here to avoid a cross-module const import and satisfy detekt MagicNumber).

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/HeadServer.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/HeadServer.kt
@@ -41,6 +41,7 @@ import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import splice.core.GATEWAY_VERSION
+import splice.core.auth.bearerToken
 import splice.core.head.Head
 import splice.core.head.HeadHealth
 import splice.core.model.DiscoveryRow
@@ -110,6 +111,15 @@ public class HeadServer(
     private var server: EmbeddedServer<NettyApplicationEngine, *>? = null
     private val lifecycle = Mutex()
 
+    // stopLocked flips this BEFORE draining so the drain can converge — with admission open, the
+    // drain window just filled with new turns that were then cancelled anyway (review 2026-07-22).
+    // Convergence needs every path to the gate honoring it: the front-door acceptingOrRespond check
+    // AND the post-acquire re-check inside acquireSlotOrRespond, so a waiter the InflightGate promotes
+    // mid-drain is bounced too rather than starting a turn the engine stop would kill (review 2026-07-22 round 3).
+    // Rejected turns get the 529 capacity shape, so clients retry and land after the restart.
+    @Volatile
+    private var accepting = true
+
     override val key: String get() = provider.key
     override val label: String get() = provider.label
     override val port: Int get() = listenPort
@@ -177,17 +187,22 @@ public class HeadServer(
         }
         engine.start(wait = false)
         server = engine
+        accepting = true
     }
 
     private suspend fun stopLocked() {
-        // Drain in-flight turns so clients get honest terminals (sealCancelledTurn) before Netty
-        // tears the engine. Bounded wait — never block restart forever.
+        // Refuse new turns FIRST so the drain can actually converge, then drain in-flight turns
+        // so clients get honest terminals (driveSealingCancellation's cancellation seal) before
+        // Netty tears the engine. Bounded wait — never block restart forever.
+        accepting = false
         val deadlineNs = System.nanoTime() + STOP_DRAIN_NS
-        while (gate.snapshot().inflight > 0 && System.nanoTime() < deadlineNs) {
+        var inflight = gate.snapshot().inflight
+        while (inflight > 0 && System.nanoTime() < deadlineNs) {
             delay(STOP_DRAIN_POLL_MS)
+            inflight = gate.snapshot().inflight
         }
-        if (gate.snapshot().inflight > 0) {
-            log("[${provider.key}] stop: draining timed out with inflight=${gate.snapshot().inflight} — forcing engine stop\n")
+        if (inflight > 0) {
+            log("[${provider.key}] stop: draining timed out with inflight=$inflight — forcing engine stop\n")
         }
         server?.stop(STOP_GRACE_MS, STOP_TIMEOUT_MS)
         server = null
@@ -244,7 +259,7 @@ public class HeadServer(
     // only admitted calls may enter the process-shared materialization gate and hold raw/parsed/built
     // representations. Body-parse failure is a client 400, not a crash.
     private suspend fun handleMessages(call: ApplicationCall) {
-        if (!authorize(call)) return
+        if (!authorize(call) || !acceptingOrRespond(call)) return
         val perf = TurnPerf(clock)
         val t0 = clock()
         val slot = acquireSlotOrRespond(call) ?: return
@@ -274,20 +289,50 @@ public class HeadServer(
         }
     }
 
-    private suspend fun acquireSlotOrRespond(call: ApplicationCall): InflightGate.Slot? = try {
-        gate.acquire()
-    } catch (_: GatewayAtCapacityException) {
-        log("[${provider.key}] admission rejected: gateway at capacity (queued=${gate.snapshot().queued})\n")
-        call.respondText(
-            errorBodyJson("overloaded_error", "gateway at capacity"),
-            ContentType.Application.Json,
-            HttpStatusCode(GATEWAY_CAPACITY_STATUS, "Gateway At Capacity"),
-        )
-        null
+    /** False (with a 529 on the wire) while stopLocked drains — clients retry and land post-restart. */
+    private suspend fun acceptingOrRespond(call: ApplicationCall): Boolean {
+        if (accepting) return true
+        respondAtCapacity(call, "head is stopping — retry")
+        return false
     }
 
-    private suspend fun <T> materializeOrRespond(call: ApplicationCall, block: suspend () -> T): T? = try {
-        deps.requestMaterializationGate.withLease(block)
+    private suspend fun acquireSlotOrRespond(call: ApplicationCall): InflightGate.Slot? {
+        val slot = try {
+            gate.acquire()
+        } catch (_: GatewayAtCapacityException) {
+            log("[${provider.key}] admission rejected: gateway at capacity (queued=${gate.snapshot().queued})\n")
+            respondAtCapacity(call, "gateway at capacity")
+            return null
+        }
+        // A waiter promoted from the InflightGate queue AFTER stopLocked flipped accepting must not
+        // start an upstream turn the engine stop will kill — bouncing it here (release + 529) lets
+        // the drain actually converge, and every admission path through this helper inherits the
+        // bounce (queued waiters defeated the drain; review 2026-07-22 round 3).
+        if (!accepting) {
+            withContext(NonCancellable) { slot.release() }
+            respondAtCapacity(call, "head is stopping — retry")
+            return null
+        }
+        return slot
+    }
+
+    // fastFail: cheap best-effort endpoints (count_tokens) tryAcquire instead of queueing — a
+    // slow-body flood must not camp the process-shared semaphore real turns materialize through
+    // (review 2026-07-22); contention gets the 529 retry shape instead of a queue slot.
+    private suspend fun <T : Any> materializeOrRespond(
+        call: ApplicationCall,
+        fastFail: Boolean = false,
+        block: suspend () -> T,
+    ): T? = try {
+        if (fastFail) {
+            val leased = deps.requestMaterializationGate.tryWithLease(block)
+            if (leased == null) {
+                respondAtCapacity(call, "gateway busy — retry")
+            }
+            leased
+        } else {
+            deps.requestMaterializationGate.withLease(block)
+        }
     } catch (tooLarge: RequestBodyTooLarge) {
         call.respondText(
             errorBodyJson(INVALID_REQUEST_ERROR, "request body exceeds ${tooLarge.limit} bytes"),
@@ -326,34 +371,34 @@ public class HeadServer(
 
     private suspend fun handleCountTokens(call: ApplicationCall) {
         if (!authorize(call)) return
-        // Share the admission gate so a flood of large count_tokens bodies cannot bypass
-        // maxInflight while /v1/messages is capacity-protected.
-        val slot = acquireSlotOrRespond(call) ?: return
-        try {
-            val body = materializeOrRespond(call) { receiveBodyBounded(call, deps.maxRequestBytes) } ?: return
-            val parsed = runCatchingCancellable { parseAnthropicBody(body.text) }.getOrNull()
-            if (parsed == null) {
-                call.respondText(
-                    errorBodyJson(INVALID_REQUEST_ERROR, "invalid request body"),
-                    ContentType.Application.Json,
-                    HttpStatusCode.BadRequest,
-                )
-            } else {
-                // Conservative and Unicode-safe: UTF-8 bytes / 3 overestimates ordinary English while
-                // avoiding the old UTF-16 chars / 4 undercount for CJK and emoji. The complete JSON body
-                // intentionally contributes structural/tool overhead.
-                val estimate =
-                    ((body.bytes + TOKEN_ESTIMATE_BYTES - 1) / TOKEN_ESTIMATE_BYTES)
-                        .coerceAtLeast(1)
-                        .toLong()
-                log("[${provider.key}] count_tokens estimate=$estimate (local; no upstream turn)\n")
-                call.respondText(
-                    buildJsonObject { put("input_tokens", estimate) }.toString(),
-                    ContentType.Application.Json,
-                )
-            }
-        } finally {
-            withContext(NonCancellable) { slot.release() }
+        // NO turn-gate slot here: count_tokens is a purely LOCAL estimate (no upstream stream),
+        // and queueing it on maxInflight let a saturated head stall or 529 Claude Code's
+        // pre-flight sizing for minutes (review 2026-07-22). Memory stays bounded by the
+        // materialization gate (fastFail: contention 529s instead of queueing, so a count_tokens
+        // flood cannot camp the shared permits) plus the maxRequestBytes cap.
+        val body = materializeOrRespond(call, fastFail = true) {
+            receiveBodyBounded(call, deps.maxRequestBytes)
+        } ?: return
+        val parsed = runCatchingCancellable { parseAnthropicBody(body.text) }.getOrNull()
+        if (parsed == null) {
+            call.respondText(
+                errorBodyJson(INVALID_REQUEST_ERROR, "invalid request body"),
+                ContentType.Application.Json,
+                HttpStatusCode.BadRequest,
+            )
+        } else {
+            // Conservative and Unicode-safe: UTF-8 bytes / 3 overestimates ordinary English while
+            // avoiding the old UTF-16 chars / 4 undercount for CJK and emoji. The complete JSON body
+            // intentionally contributes structural/tool overhead.
+            val estimate =
+                ((body.bytes + TOKEN_ESTIMATE_BYTES - 1) / TOKEN_ESTIMATE_BYTES)
+                    .coerceAtLeast(1)
+                    .toLong()
+            log("[${provider.key}] count_tokens estimate=$estimate (local; no upstream turn)\n")
+            call.respondText(
+                buildJsonObject { put("input_tokens", estimate) }.toString(),
+                ContentType.Application.Json,
+            )
         }
     }
 
@@ -378,11 +423,9 @@ public class HeadServer(
     }
 
     private suspend fun authorize(call: ApplicationCall): Boolean {
-        val bearer = Regex("^Bearer\\s+(.+)$", RegexOption.IGNORE_CASE)
-            .find(call.request.headers[HttpHeaders.Authorization].orEmpty().trim())
-            ?.groupValues
-            ?.get(1)
-            ?.trim()
+        // Scheme parsing shared with MgmtKey.matchesBearer (core bearerToken) — the two planes
+        // drifted on case-sensitivity when each carried its own regex.
+        val bearer = bearerToken(call.request.headers[HttpHeaders.Authorization])
         val presented = bearer ?: call.request.headers["x-api-key"]
         val expectedBytes = deps.inferenceToken.toByteArray(Charsets.UTF_8)
         val presentedBytes = presented?.toByteArray(Charsets.UTF_8)
@@ -410,21 +453,11 @@ public class HeadServer(
         return read
     }
 
-    private fun errorBodyJson(type: String, message: String): String = buildJsonObject {
-        put("type", "error")
-        put(
-            "error",
-            buildJsonObject {
-                put("type", type)
-                put("message", message)
-            },
-        )
-    }.toString()
-
     private companion object {
         // Grace/timeout for Netty engine.stop after the drain window below.
         const val STOP_GRACE_MS = 500L
         const val STOP_TIMEOUT_MS = 2_000L
+
         // Wait for in-flight SSE turns to finish (or cancel cleanly) before tearing the engine.
         const val STOP_DRAIN_NS = 5_000_000_000L // 5s
         const val STOP_DRAIN_POLL_MS = 50L
@@ -436,12 +469,43 @@ public class HeadServer(
         // Concurrent long-lived SSE turns per head (2x the 1000-stream design target).
         const val RUNNING_LIMIT = 2048
 
-        // Response-write stall cap — at least as long as default streamIdle (180s) so a slow-but-alive
-        // client is not killed by Netty while the two-tier watchdog still considers the stream healthy.
-        const val WRITE_TIMEOUT_S = 300
-
-        // Same numeric convention as UpstreamFailureClassifier's OVERLOADED_STATUS (kept as its
-        // own const here to avoid a cross-module const import and satisfy detekt MagicNumber).
-        const val GATEWAY_CAPACITY_STATUS = 529
+        // Response-write stall cap. Netty's WriteTimeoutHandler ticks only while a write is
+        // PENDING — an upstream-idle lull writes nothing (bar the 10s keepalive pings), so this
+        // never races the watchdog's 180s streamIdle. A pending write that cannot complete in 60s
+        // means the client drained ZERO bytes for a full minute (coalesced frames clear in seconds
+        // on even a slow-but-alive pipe): that is a dead reader pinning an admission slot, not a
+        // slow one. The 300s bump quintupled dead-reader slot pinning for no live-client benefit
+        // (review 2026-07-22); 60s already carries 6x headroom over the default-10s load-test
+        // truncations (52/1000 stream tails).
+        const val WRITE_TIMEOUT_S = 60
     }
+}
+
+// Same numeric convention as UpstreamFailureClassifier's OVERLOADED_STATUS (kept as its own const
+// to avoid a cross-module const import and satisfy detekt MagicNumber). File-level private, out of
+// the companion, so the top-level respondAtCapacity below can see it (review 2026-07-22 round 3).
+private const val GATEWAY_CAPACITY_STATUS = 529
+
+// Relocated from a HeadServer member to file-level so the top-level respondAtCapacity shares one
+// body builder; pure JSON shaping with no instance state (review 2026-07-22 round 3).
+private fun errorBodyJson(type: String, message: String): String = buildJsonObject {
+    put("type", "error")
+    put(
+        "error",
+        buildJsonObject {
+            put("type", type)
+            put("message", message)
+        },
+    )
+}.toString()
+
+/** The 529 capacity terminal built once: every admission path must answer IDENTICALLY because
+ *  client retry logic keys on the shape (three hand-built copies drifted; review 2026-07-22 round 3).
+ *  Top-level (not a HeadServer member) so it doesn't grow the class's function budget. */
+private suspend fun respondAtCapacity(call: ApplicationCall, message: String) {
+    call.respondText(
+        errorBodyJson("overloaded_error", message),
+        ContentType.Application.Json,
+        HttpStatusCode(GATEWAY_CAPACITY_STATUS, "Gateway At Capacity"),
+    )
 }

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/HeadServer.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/HeadServer.kt
@@ -137,6 +137,7 @@ public class HeadServer(
         if (server != null) return
         // G20 contract: a control-plane restart promises a fresh diagnostic baseline; the counters
         // live on the long-lived TurnDriver, so reset them here (review 2026-07-19).
+        // restart() is stop-then-start, so this reset alone suffices — a bare stop keeps counters intact.
         driver.resetHealth()
         // G26: local (not a class field) so a control-plane restart (POST /api/heads/:head/restart)
         // re-arms verification instead of going permanently silent after the first restart.
@@ -207,7 +208,6 @@ public class HeadServer(
         server?.stop(STOP_GRACE_MS, STOP_TIMEOUT_MS)
         server = null
         deps.usageStore.flushNow()
-        driver.resetHealth()
     }
 
     override fun healthSnapshot(): HeadHealth {

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/RequestMaterializationGate.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/RequestMaterializationGate.kt
@@ -15,6 +15,21 @@ public class RequestMaterializationGate(maxConcurrent: Int = DEFAULT_MAX_CONCURR
 
     public suspend fun <T> withLease(block: suspend () -> T): T = semaphore.withPermit { block() }
 
+    /** Non-suspending lease attempt — null when every permit is busy. Cheap best-effort endpoints
+     *  (count_tokens) fast-fail on contention instead of queueing unboundedly on the permits real
+     *  turns materialize through (review 2026-07-22: a slow-body count_tokens flood could camp the
+     *  process-shared semaphore and stall every head's turn materialization). Null is exclusively
+     *  the contention signal; the `Any` bound makes a legitimately-null block result unrepresentable
+     *  at compile time (review 2026-07-22 round 3). */
+    public suspend fun <T : Any> tryWithLease(block: suspend () -> T): T? {
+        if (!semaphore.tryAcquire()) return null
+        return try {
+            block()
+        } finally {
+            semaphore.release()
+        }
+    }
+
     public companion object {
         public const val DEFAULT_MAX_CONCURRENT: Int = 16
     }

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnDriver.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnDriver.kt
@@ -149,12 +149,16 @@ internal class TurnDriver(
                 // The 200 + SSE headers are committed once respondTextWriter opens, so any failure
                 // must become an honest `event: error` frame — NOT escape and leave the client an
                 // empty/truncated 200 (the "empty or malformed response (HTTP 200)" class).
-                // catchingTurnFailure rethrows CancellationException (the repo's blessed
-                // pattern — no generic catch in this file); runCatchingCancellable (splice.core.util)
-                // doesn't fit here — its catch list is I/O + (de)serialization for local best-effort
-                // work, not the turn-transport failure classes emitFailure's `when` dispatches on.
+                // catchingTurnFailure rethrows CancellationException after sealing (so a head-stop /
+                // write-timeout cancel still ends with abandon/error, not a truncated 200);
+                // runCatchingCancellable (splice.core.util) doesn't fit here — its catch list is
+                // I/O + (de)serialization for local best-effort work, not the turn-transport
+                // failure classes emitFailure's `when` dispatches on.
                 catchingTurnFailure { driveOneTurn(drive) }
                     .onFailure { e -> emitFailure(drive, e) }
+            } catch (e: CancellationException) {
+                sealCancelledTurn(drive)
+                throw e
             } finally {
                 // Terminal frames force-flush already; this covers abandon / exception paths.
                 channel.coalesced.flush()
@@ -176,8 +180,13 @@ internal class TurnDriver(
             clientGone = AtomicBoolean(false),
         )
         val drive = assembleDrive(TurnInputs(built, slot, t0, perf), terminal, channel)
-        catchingTurnFailure { driveOneTurn(drive, pingClient = false) }
-            .onFailure { e -> emitFailure(drive, e) }
+        try {
+            catchingTurnFailure { driveOneTurn(drive, pingClient = false) }
+                .onFailure { e -> emitFailure(drive, e) }
+        } catch (e: CancellationException) {
+            sealCancelledTurn(drive)
+            throw e
+        }
         call.respondText(
             terminal.responseBody().toString(),
             ContentType.Application.Json,
@@ -356,6 +365,9 @@ internal class TurnDriver(
             clientFrameEmitted = { drive.perf.hasMark(PerfKeys.FIRST_FRAME) },
         ) { resp ->
             drive.slot.touch()
+            // Persist upstream rate-limit headers for /api/usage + statusline soft-warn (Node
+            // codex-proxy wired this; the Kotlin split dropped the call site).
+            usageStore.persistRateLimit { name -> resp.header(name) }
             // Fresh upstream round/attempt: reset the idle tier so this round's (possibly long,
             // silent) prefill is judged against firstByteTimeout, not the short streamIdle a prior
             // round's first byte would otherwise pin it to. totalCap still spans the whole turn.
@@ -524,6 +536,25 @@ internal class TurnDriver(
         health.local()
     }
 
+    /** Seal a cancelled turn that never reached emitFailure (head stop, write-timeout, parent
+     *  cancel). Client-gone → abandon (nothing on the wire); still-connected → honest error so
+     *  Claude Code retries instead of seeing a truncated HTTP 200. */
+    private suspend fun sealCancelledTurn(drive: TurnDrive) {
+        if (drive.emitter.hasEnded) return
+        if (drive.channel.clientGone.get()) {
+            drive.emitter.abandon()
+            telemetry.recordPerf(drive, "client_abort")
+            return
+        }
+        log(telemetry.errTurn("cancelled", drive, ": turn cancelled before terminal"))
+        drive.emitter.emitError(
+            ErrorType.OVERLOADED,
+            "${provider.key}: turn cancelled — retry",
+        )
+        telemetry.recordPerf(drive, "error:cancelled")
+        health.local()
+    }
+
     /** Head restart = fresh diagnostic baseline (the HeadHealth doc's promised behavior; the
      *  counters lived through control-plane restarts before — review 2026-07-19). */
     internal fun resetHealth() = health.reset()
@@ -563,13 +594,18 @@ private inline fun <R> catchingTurnFailure(block: () -> R): Result<R> =
         Result.failure(e)
     } catch (e: UpstreamFailed) {
         Result.failure(e)
+    } catch (e: StreamTornBeforeClient) {
+        // Plain RuntimeException (so translators don't swallow it into a terminal). After
+        // UpstreamClient exhausts MAX_STREAM_REISSUES it rethrows here — must become emitConnReset,
+        // not escape respondTextWriter as a truncated HTTP 200 SSE.
+        Result.failure(e)
     } catch (e: SseFrameTooLargeException) {
         Result.failure(e)
     } catch (e: IOException) {
         Result.failure(e)
     } catch (e: CancellationException) {
         // CancellationException extends IllegalStateException — rethrown BEFORE it so a
-        // cancelled turn actually stops instead of becoming an error frame.
+        // cancelled turn actually stops; stream()/collect() seal the emitter then rethrow.
         throw e
     } catch (e: IllegalArgumentException) {
         // e.g. a URL-parse error from a bad base_url (review 2026-07-19: previously escaped

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnDriver.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnDriver.kt
@@ -138,7 +138,7 @@ internal class TurnDriver(
             val emitter = SseEmitter.create(
                 write = { frame ->
                     channel.writeMutex.withLock {
-                        timedClientWrite(channel.coalesced, frame, perf, channel.clientGone)
+                        timedClientWrite(channel.coalesced, frame, perf, channel.clientGone, clock)
                     }
                 },
                 model = built.meta.originalModel,
@@ -149,20 +149,71 @@ internal class TurnDriver(
                 // The 200 + SSE headers are committed once respondTextWriter opens, so any failure
                 // must become an honest `event: error` frame — NOT escape and leave the client an
                 // empty/truncated 200 (the "empty or malformed response (HTTP 200)" class).
-                // catchingTurnFailure rethrows CancellationException after sealing (so a head-stop /
-                // write-timeout cancel still ends with abandon/error, not a truncated 200);
-                // runCatchingCancellable (splice.core.util) doesn't fit here — its catch list is
-                // I/O + (de)serialization for local best-effort work, not the turn-transport
-                // failure classes emitFailure's `when` dispatches on.
-                catchingTurnFailure { driveOneTurn(drive) }
-                    .onFailure { e -> emitFailure(drive, e) }
-            } catch (e: CancellationException) {
-                sealCancelledTurn(drive)
-                throw e
+                driveSealingCancellation(drive)
             } finally {
                 // Terminal frames force-flush already; this covers abandon / exception paths.
                 channel.coalesced.flush()
             }
+        }
+    }
+
+    /** Drive one turn, emit classified failures, and — if a cancellation lands (head stop,
+     *  write-timeout, parent cancel) — seal the terminal honestly before rethrowing: client-gone
+     *  → abandon (nothing on the wire); still-connected → an honest error frame so Claude Code
+     *  retries instead of seeing a truncated HTTP 200. ONE copy, shared by [stream] and
+     *  [collect], so the sealing contract cannot drift between them.
+     *
+     *  [seal] gates the cancellation seal to the STREAM path only: [collect] passes seal=false —
+     *  it never commits a 200 before its terminal respondText, so a cancelled collect has no
+     *  half-open response to rescue; sealing there only wrote an error body nobody reads while
+     *  polluting localOriginErrors (review 2026-07-22 round 3).
+     *
+     *  catchingTurnFailure rethrows CancellationException (caught HERE, after sealing);
+     *  runCatchingCancellable (splice.core.util) doesn't fit — its catch list is I/O +
+     *  (de)serialization for local best-effort work, not the turn-transport failure classes
+     *  emitFailure dispatches on. */
+    private suspend fun driveSealingCancellation(
+        drive: TurnDrive,
+        pingClient: Boolean = true,
+        seal: Boolean = true,
+    ) {
+        try {
+            catchingTurnFailure { driveOneTurn(drive, pingClient) }
+                .onFailure { e -> emitFailure(drive, e) }
+        } catch (e: CancellationException) {
+            // Flat when (not nested if) so the still-connected try/catch stays at nesting depth 3:
+            // catch → if(seal) → if(clientGone) → try would trip NestedBlockDepth's depth-4 ceiling.
+            when {
+                !seal || drive.emitter.hasEnded -> Unit
+                drive.channel.clientGone.get() -> {
+                    drive.emitter.abandon()
+                    telemetry.recordPerf(drive, "client_abort")
+                }
+                // clientGone flips only on a FAILED write, but Ktor/Netty cancels on
+                // channel-inactive with no write having failed — a user abort mid-lull reaches here
+                // still "connected". Emit FIRST; if the error frame can't reach the wire the cancel
+                // WAS a client disconnect the ping/write path hadn't flagged, so reclassify it as an
+                // abandon, not an error:cancelled (review 2026-07-22 round 3).
+                else ->
+                    try {
+                        drive.emitter.emitError(
+                            ErrorType.OVERLOADED,
+                            "${provider.key}: turn cancelled — retry",
+                        )
+                        log(telemetry.errTurn("cancelled", drive, ": turn cancelled before terminal"))
+                        telemetry.recordPerf(drive, "error:cancelled")
+                        health.local()
+                    } catch (io: IOException) {
+                        // emitError's error frame could not reach the wire — the cancel WAS a client
+                        // disconnect the ping/write path hadn't flagged. Reclassify as a benign
+                        // abandon (emitError already sealed on IOException; the set is idempotent),
+                        // NOT an error:cancelled — no health bump (review 2026-07-22 round 3).
+                        log("[${provider.key}] turn cancelled + error frame unwritable (${io.message}) — client gone\n")
+                        drive.emitter.abandon()
+                        telemetry.recordPerf(drive, "client_abort")
+                    }
+            }
+            throw e
         }
     }
 
@@ -180,13 +231,10 @@ internal class TurnDriver(
             clientGone = AtomicBoolean(false),
         )
         val drive = assembleDrive(TurnInputs(built, slot, t0, perf), terminal, channel)
-        try {
-            catchingTurnFailure { driveOneTurn(drive, pingClient = false) }
-                .onFailure { e -> emitFailure(drive, e) }
-        } catch (e: CancellationException) {
-            sealCancelledTurn(drive)
-            throw e
-        }
+        // collect never commits a 200 before its terminal respondText — a cancelled collect is a
+        // native connection abort client-side, and sealing there only wrote an error body nobody
+        // reads while polluting localOriginErrors (review 2026-07-22 round 3).
+        driveSealingCancellation(drive, pingClient = false, seal = false)
         call.respondText(
             terminal.responseBody().toString(),
             ContentType.Application.Json,
@@ -225,30 +273,6 @@ internal class TurnDriver(
             turnHeaders = built.extraHeaders,
             channel = channel,
         )
-    }
-
-    /** Client-side write instrumented: frame counts/bytes, first-frame/first-delta marks, and the
-     *  summed write+flush time (a slow reader shows up as write_ms, not as fake stream time).
-     *  A failed write flips [clientGone] BEFORE rethrowing — the translator's terminal decision
-     *  reads it to classify the ending as ClientAbandoned instead of upstream truncation. */
-    private fun timedClientWrite(
-        coalesced: ImmediateSseWriter,
-        frame: String,
-        perf: TurnPerf,
-        clientGone: AtomicBoolean,
-    ) {
-        val t = clock()
-        try {
-            coalesced.write(frame)
-        } catch (e: IOException) {
-            clientGone.set(true)
-            throw e
-        }
-        perf.add(PerfKeys.WRITE_MS, clock() - t)
-        perf.add(PerfKeys.FRAMES_OUT, 1)
-        perf.add(PerfKeys.BYTES_OUT, frame.length.toLong())
-        perf.markOnce(PerfKeys.FIRST_FRAME)
-        if (frame.startsWith(DELTA_FRAME_PREFIX)) perf.markOnce(PerfKeys.FIRST_DELTA)
     }
 
     /** One honest error frame per failure class; anything that is not a known turn failure and
@@ -536,25 +560,6 @@ internal class TurnDriver(
         health.local()
     }
 
-    /** Seal a cancelled turn that never reached emitFailure (head stop, write-timeout, parent
-     *  cancel). Client-gone → abandon (nothing on the wire); still-connected → honest error so
-     *  Claude Code retries instead of seeing a truncated HTTP 200. */
-    private suspend fun sealCancelledTurn(drive: TurnDrive) {
-        if (drive.emitter.hasEnded) return
-        if (drive.channel.clientGone.get()) {
-            drive.emitter.abandon()
-            telemetry.recordPerf(drive, "client_abort")
-            return
-        }
-        log(telemetry.errTurn("cancelled", drive, ": turn cancelled before terminal"))
-        drive.emitter.emitError(
-            ErrorType.OVERLOADED,
-            "${provider.key}: turn cancelled — retry",
-        )
-        telemetry.recordPerf(drive, "error:cancelled")
-        health.local()
-    }
-
     /** Head restart = fresh diagnostic baseline (the HeadHealth doc's promised behavior; the
      *  counters lived through control-plane restarts before — review 2026-07-19). */
     internal fun resetHealth() = health.reset()
@@ -564,10 +569,6 @@ internal class TurnDriver(
 
         // G2: cap the raw pre-JSON body buffered for zero-event classification (~1KB).
         const val ZERO_EVENT_SNIPPET_CHARS = 1024
-
-        // first_delta detection reads the frame prefix — the emitter's event name, not a literal
-        // stop-reason (L3 walls stay intact; this only OBSERVES the already-built frame).
-        const val DELTA_FRAME_PREFIX = "event: content_block_delta"
 
         // SSE comment keepalive: pure transport, invisible to SSE parsers (spec: lines starting
         // with ':' are comments) — exists ONLY so a dead client fails a write promptly.
@@ -580,6 +581,36 @@ internal class TurnDriver(
  *  command (review 2026-07-19: two paths still hardcoded "claudex login" on non-codex heads). */
 private fun Provider.loginHint(): String =
     if (loginCommand.isNotEmpty()) " — run: $loginCommand" else ""
+
+// first_delta detection reads the frame prefix — the emitter's event name, not a literal
+// stop-reason (L3 walls stay intact; this only OBSERVES the already-built frame).
+private const val DELTA_FRAME_PREFIX = "event: content_block_delta"
+
+/** Client-side write instrumented: frame counts/bytes, first-frame/first-delta marks, and the
+ *  summed write+flush time (a slow reader shows up as write_ms, not as fake stream time).
+ *  A failed write flips [clientGone] BEFORE rethrowing — the translator's terminal decision
+ *  reads it to classify the ending as ClientAbandoned instead of upstream truncation.
+ *  Top-level (not a TurnDriver method) so it doesn't grow the class's function budget. */
+private fun timedClientWrite(
+    coalesced: ImmediateSseWriter,
+    frame: String,
+    perf: TurnPerf,
+    clientGone: AtomicBoolean,
+    clock: () -> Long,
+) {
+    val t = clock()
+    try {
+        coalesced.write(frame)
+    } catch (e: IOException) {
+        clientGone.set(true)
+        throw e
+    }
+    perf.add(PerfKeys.WRITE_MS, clock() - t)
+    perf.add(PerfKeys.FRAMES_OUT, 1)
+    perf.add(PerfKeys.BYTES_OUT, frame.length.toLong())
+    perf.markOnce(PerfKeys.FIRST_FRAME)
+    if (frame.startsWith(DELTA_FRAME_PREFIX)) perf.markOnce(PerfKeys.FIRST_DELTA)
+}
 
 /** The per-turn error boundary — captures exactly the failure classes [TurnDriver.emitFailure]
  *  dispatches on: the custom transport signals, I/O, and the two documented gateway-bug classes

--- a/gateway/gateway/src/main/kotlin/splice/gateway/usage/UsageHud.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/usage/UsageHud.kt
@@ -24,6 +24,7 @@ import splice.core.util.runCatchingCancellable
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 private const val FIVE_HOURS_MS: Long = 5 * 60 * 60 * 1000
 private const val FULL_PCT = 100.0
@@ -113,6 +114,15 @@ public data class UsageState(
     val ratelimit: RateLimitState?,
 )
 
+/** RateLimitState field mapping, single-sourced so [UsageStore.readRateLimit]'s pending-payload
+ *  and on-disk paths cannot drift (review 2026-07-22 round 3). */
+private fun rateLimitStateFrom(obj: JsonObject): RateLimitState = RateLimitState(
+    limitTokens = num(obj["limit_tokens"]),
+    remainingTokens = num(obj["remaining_tokens"]),
+    resetTokens = (obj["reset_tokens"] as? JsonPrimitive)?.takeIf { it.isString }?.content,
+    updatedAt = num(obj["updated_at"]),
+)
+
 /** 5h output-token window + ratelimit header persistence — the HUD contract files. */
 public class UsageStore(
     private val usageFile: Path,
@@ -141,11 +151,15 @@ public class UsageStore(
             while (ring.size > MAX_RING_ENTRIES) ring.removeFirst()
             mutationVersion += 1
         }
-        schedulePersist()
+        scheduleCoalesced(writeScheduled) { flushScheduled() }
     }
 
     /** Parses x-ratelimit-limit-tokens / -remaining-tokens / -reset-tokens; no-op without a limit. */
     // best-effort by design: header/write failures are swallowed; cancellation propagates.
+    // Coalesced onto the same 1s lane as the usage ring: these headers arrive on EVERY successful
+    // upstream round, and a per-round atomic rewrite of this tiny latest-wins file was pure churn
+    // (review 2026-07-22). flushNow() forces the pending payload out synchronously; readRateLimit()
+    // serves it straight from memory instead (review 2026-07-22 round 3).
     public fun persistRateLimit(header: (String) -> String?) {
         runCatchingCancellable {
             val limit = header("x-ratelimit-limit-tokens")?.toLongOrNull() ?: return
@@ -159,13 +173,35 @@ public class UsageStore(
                 if (reset != null) put("reset_tokens", reset) else put("reset_tokens", null as String?)
                 put("updated_at", clock())
             }
-            val encoded = payload.toString() + "\n"
-            AsyncFileIo.submit {
-                runCatchingCancellable {
-                    synchronized(writeLock) {
-                        SecureFile.writeAtomic0600(ratelimitFile, encoded)
-                    }
-                }
+            pendingRateLimit.set(payload.toString() + "\n")
+            scheduleCoalesced(rlWriteScheduled) { flushRateLimit() }
+        }
+    }
+
+    /**
+     * CAS-guarded debounce shared by the usage-ring and ratelimit lanes: [flag] gates a single
+     * in-flight [flush] submission. Rolling [flag] back when [AsyncFileIo.submit] rejects is the
+     * load-bearing subtlety here — a missed rollback wedges the lane forever (review 2026-07-22
+     * round 3).
+     */
+    private fun scheduleCoalesced(flag: AtomicBoolean, flush: () -> Unit) {
+        if (!flag.compareAndSet(false, true)) return
+        if (!AsyncFileIo.submit(USAGE_FLUSH_DELAY_MS, flush)) {
+            flag.set(false)
+        }
+    }
+
+    /** Write the newest pending ratelimit payload, if any — flag cleared BEFORE the payload is
+     *  consumed so a concurrent persistRateLimit always lands in a (re)scheduled flush, and the
+     *  payload is consumed INSIDE writeLock so two racing flushers (the 1s lane vs a synchronous
+     *  flushNow) serialize consume+write as one unit — consuming outside the lock let a
+     *  descheduled flusher commit an OLDER payload over a newer one (review 2026-07-22). */
+    private fun flushRateLimit() {
+        rlWriteScheduled.set(false)
+        runCatchingCancellable {
+            synchronized(writeLock) {
+                val encoded = pendingRateLimit.getAndSet(null) ?: return@synchronized
+                SecureFile.writeAtomic0600(ratelimitFile, encoded)
             }
         }
     }
@@ -191,21 +227,26 @@ public class UsageStore(
             ring.toList() to mutationVersion
         }
         persistSnapshot(snapshot, version)
+        flushRateLimit()
     }
 
     // best-effort by design: a missing/corrupt ratelimit file reads as null; cancellation propagates.
+    // The pending payload IS the newest state, byte-identical to what the flush would write, so a
+    // non-null pending is served straight from memory — no flush, no drain, no file I/O. The inline
+    // flush this replaces had re-added, on the read path, the churn coalescing removed from the
+    // round path (review 2026-07-22 round 3).
     public fun readRateLimit(): RateLimitState? = runCatchingCancellable {
-        AsyncFileIo.drain()
-        if (!Files.exists(ratelimitFile)) {
-            null
+        val pending = pendingRateLimit.get()
+        if (pending != null) {
+            rateLimitStateFrom(json.parseToJsonElement(pending).jsonObject)
         } else {
-            val obj = json.parseToJsonElement(Files.readString(ratelimitFile)).jsonObject
-            RateLimitState(
-                limitTokens = num(obj["limit_tokens"]),
-                remainingTokens = num(obj["remaining_tokens"]),
-                resetTokens = (obj["reset_tokens"] as? JsonPrimitive)?.takeIf { it.isString }?.content,
-                updatedAt = num(obj["updated_at"]),
-            )
+            // Settle the coalesced lane first so a read never lags a just-arrived header by the 1s window.
+            AsyncFileIo.drain()
+            if (!Files.exists(ratelimitFile)) {
+                null
+            } else {
+                rateLimitStateFrom(json.parseToJsonElement(Files.readString(ratelimitFile)).jsonObject)
+            }
         }
     }.getOrNull()
 
@@ -252,6 +293,10 @@ public class UsageStore(
     private var persistedVersion = -1L
     private val writeScheduled = AtomicBoolean(false)
 
+    // Latest-wins pending ratelimit payload; consumed by the coalesced lane, flushNow, or a read.
+    private val pendingRateLimit = AtomicReference<String?>(null)
+    private val rlWriteScheduled = AtomicBoolean(false)
+
     init {
         // Load/trim the bounded legacy ring while the head is assembled, not on the first
         // completed turn. Every append on the turn path is then memory-only plus an async enqueue.
@@ -263,19 +308,12 @@ public class UsageStore(
         put(OUTPUT_TOKENS, outputTokens)
     }
 
-    private fun schedulePersist() {
-        if (!writeScheduled.compareAndSet(false, true)) return
-        if (!AsyncFileIo.submit(USAGE_FLUSH_DELAY_MS) { flushScheduled() }) {
-            writeScheduled.set(false)
-        }
-    }
-
     private fun flushScheduled() {
         val (snapshot, version) = synchronized(ringLock) { cachedRing.toList() to mutationVersion }
         persistSnapshot(snapshot, version)
         writeScheduled.set(false)
         val changed = synchronized(ringLock) { mutationVersion > persistedVersion }
-        if (changed) schedulePersist()
+        if (changed) scheduleCoalesced(writeScheduled) { flushScheduled() }
     }
 
     private fun persistSnapshot(snapshot: List<JsonObject>, version: Long) {

--- a/gateway/gateway/src/main/kotlin/splice/gateway/usage/UsageHud.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/usage/UsageHud.kt
@@ -123,6 +123,11 @@ private fun rateLimitStateFrom(obj: JsonObject): RateLimitState = RateLimitState
     updatedAt = num(obj["updated_at"]),
 )
 
+/** Pending ratelimit payload paired with its already-parsed state, so readRateLimit() — polled
+ *  every /statusline tick and every /api/usage request — serves [parsed] straight from memory
+ *  instead of re-running json.parseToJsonElement on [encoded] per call (review 2026-07-22). */
+private data class PendingRateLimit(val encoded: String, val parsed: RateLimitState)
+
 /** 5h output-token window + ratelimit header persistence — the HUD contract files. */
 public class UsageStore(
     private val usageFile: Path,
@@ -173,7 +178,8 @@ public class UsageStore(
                 if (reset != null) put("reset_tokens", reset) else put("reset_tokens", null as String?)
                 put("updated_at", clock())
             }
-            pendingRateLimit.set(payload.toString() + "\n")
+            // Parse once here (not in readRateLimit) — see PendingRateLimit.
+            pendingRateLimit.set(PendingRateLimit(payload.toString() + "\n", rateLimitStateFrom(payload)))
             scheduleCoalesced(rlWriteScheduled) { flushRateLimit() }
         }
     }
@@ -200,7 +206,7 @@ public class UsageStore(
         rlWriteScheduled.set(false)
         runCatchingCancellable {
             synchronized(writeLock) {
-                val encoded = pendingRateLimit.getAndSet(null) ?: return@synchronized
+                val encoded = pendingRateLimit.getAndSet(null)?.encoded ?: return@synchronized
                 SecureFile.writeAtomic0600(ratelimitFile, encoded)
             }
         }
@@ -232,13 +238,14 @@ public class UsageStore(
 
     // best-effort by design: a missing/corrupt ratelimit file reads as null; cancellation propagates.
     // The pending payload IS the newest state, byte-identical to what the flush would write, so a
-    // non-null pending is served straight from memory — no flush, no drain, no file I/O. The inline
-    // flush this replaces had re-added, on the read path, the churn coalescing removed from the
-    // round path (review 2026-07-22 round 3).
+    // non-null pending is served straight from memory — no flush, no drain, no file I/O, and (already
+    // parsed once in persistRateLimit) no re-parse of the same JSON on every /statusline tick and
+    // /api/usage poll (review 2026-07-22). The inline flush this replaces had re-added, on the read
+    // path, the churn coalescing removed from the round path (review 2026-07-22 round 3).
     public fun readRateLimit(): RateLimitState? = runCatchingCancellable {
         val pending = pendingRateLimit.get()
         if (pending != null) {
-            rateLimitStateFrom(json.parseToJsonElement(pending).jsonObject)
+            pending.parsed
         } else {
             // Settle the coalesced lane first so a read never lags a just-arrived header by the 1s window.
             AsyncFileIo.drain()
@@ -294,7 +301,7 @@ public class UsageStore(
     private val writeScheduled = AtomicBoolean(false)
 
     // Latest-wins pending ratelimit payload; consumed by the coalesced lane, flushNow, or a read.
-    private val pendingRateLimit = AtomicReference<String?>(null)
+    private val pendingRateLimit = AtomicReference<PendingRateLimit?>(null)
     private val rlWriteScheduled = AtomicBoolean(false)
 
     init {

--- a/gateway/gateway/src/main/kotlin/splice/gateway/wire/CollectingTerminal.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/wire/CollectingTerminal.kt
@@ -34,6 +34,8 @@ public class CollectingTerminal(
     private val blocks = mutableListOf<Blk>()
     private val ended = AtomicBoolean(false)
 
+    override val hasEnded: Boolean get() = ended.get()
+
     private var body: JsonObject? = null
     private var status = DEFAULT_ERROR_STATUS
 

--- a/gateway/gateway/src/main/kotlin/splice/gateway/wire/SseEmitter.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/wire/SseEmitter.kt
@@ -22,7 +22,7 @@ import splice.core.index.WireBlockIndex
 import splice.core.turn.ErrorType
 import splice.core.turn.Usage
 import java.util.concurrent.CancellationException
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 /** Builds the (non-standard) usage payload Claude Code reads from gateways — injected so the
  *  emitter stays hud-agnostic; the real builder lands with the usage port (P3-USE). */
@@ -46,11 +46,15 @@ public class SseEmitter internal constructor(
     private val messageId: String,
 ) : TurnTerminal {
 
+    // Sole-terminal state machine: OPEN → ENDING (claim) → ENDED (frames succeeded, or abandon).
+    // ANY mid-terminal write failure — IOException or a cancellation landing between the claim
+    // and the last frame — releases the claim back to OPEN so emitError can still seal honestly;
+    // a stranded ENDING was the truncated-200 hole (review 2026-07-22). One AtomicReference so
+    // an illegal ended-without-ending combination is unrepresentable.
+    private enum class SealState { OPEN, ENDING, ENDED }
+    private val seal = AtomicReference(SealState.OPEN)
+
     private var started = false
-    private val ended = AtomicBoolean(false)
-    // Claims the sole-terminal right; ended is set only AFTER frames succeed (or abandon).
-    // Mid-terminal write failure releases the claim so emitError can still seal honestly.
-    private val ending = AtomicBoolean(false)
     private var nextBlockIndex = 0
     private val open = LinkedHashSet<Int>()
 
@@ -58,7 +62,7 @@ public class SseEmitter internal constructor(
     private val frameBuf = StringBuilder(FRAME_BUF_CAPACITY)
 
     public val hasStarted: Boolean get() = started
-    override val hasEnded: Boolean get() = ended.get()
+    override val hasEnded: Boolean get() = seal.get() == SealState.ENDED
 
     private suspend fun frame(event: String, data: JsonObject) {
         frameBuf.setLength(0)
@@ -214,7 +218,8 @@ public class SseEmitter internal constructor(
 
     /** The ONLY clean ending — derives stop_reason internally (L3). */
     override suspend fun emitTerminal(hasToolUse: Boolean, incomplete: Boolean, usage: Usage) {
-        if (ended.get() || !ending.compareAndSet(false, true)) return
+        if (!seal.compareAndSet(SealState.OPEN, SealState.ENDING)) return
+        var sealed = false
         try {
             ensureStart()
             frame(
@@ -229,17 +234,21 @@ public class SseEmitter internal constructor(
                 },
             )
             frame("message_stop", buildJsonObject { put(TYPE, "message_stop") })
-            ended.set(true)
-        } catch (e: Throwable) {
-            if (e is CancellationException) throw e
-            ending.set(false)
-            throw e
+            seal.set(SealState.ENDED)
+            sealed = true
+        } finally {
+            // Release the claim on EVERY failure — cancellation included: a head-stop cancel
+            // mid-frame must leave the emitter sealable, or the cancellation seal's emitError
+            // (TurnDriver.driveSealingCancellation) no-ops and the client gets a truncated 200
+            // (the stranded-ENDING hole, review 2026-07-22).
+            if (!sealed) seal.set(SealState.OPEN)
         }
     }
 
     /** The ONLY failure ending — an SSE error event lets Claude Code retry honestly. */
     override suspend fun emitError(type: ErrorType, message: String) {
-        if (ended.get() || !ending.compareAndSet(false, true)) return
+        if (!seal.compareAndSet(SealState.OPEN, SealState.ENDING)) return
+        var cancelled = false
         try {
             frame(
                 "error",
@@ -251,19 +260,21 @@ public class SseEmitter internal constructor(
                     }
                 },
             )
-            ended.set(true)
-        } catch (e: Throwable) {
-            if (e is CancellationException) throw e
-            // Error frame itself failed (client gone) — still seal so retries don't double-end.
-            ended.set(true)
+        } catch (e: CancellationException) {
+            // Cancelled before the frame went out — release so a later seal can still retry.
+            cancelled = true
+            seal.set(SealState.OPEN)
             throw e
+        } finally {
+            // Frame delivered → sealed; frame FAILED (client gone, IOException) → still sealed so
+            // retries don't double-end. Only a cancellation releases the claim instead.
+            if (!cancelled) seal.set(SealState.ENDED)
         }
     }
 
     /** Client vanished mid-stream — nothing to emit, just seal the emitter. */
     override fun abandon() {
-        ending.set(true)
-        ended.set(true)
+        seal.set(SealState.ENDED)
     }
 
     public companion object {

--- a/gateway/gateway/src/main/kotlin/splice/gateway/wire/SseEmitter.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/wire/SseEmitter.kt
@@ -47,10 +47,11 @@ public class SseEmitter internal constructor(
 ) : TurnTerminal {
 
     // Sole-terminal state machine: OPEN → ENDING (claim) → ENDED (frames succeeded, or abandon).
-    // ANY mid-terminal write failure — IOException or a cancellation landing between the claim
-    // and the last frame — releases the claim back to OPEN so emitError can still seal honestly;
-    // a stranded ENDING was the truncated-200 hole (review 2026-07-22). One AtomicReference so
-    // an illegal ended-without-ending combination is unrepresentable.
+    // A cancellation landing between the claim and the last frame releases the claim back to OPEN
+    // so the cancellation seal's emitError can still seal honestly (a stranded ENDING was the
+    // truncated-200 hole, review 2026-07-22); an IOException — client gone — stays ENDED so a
+    // follow-up emitError cleanly no-ops instead of re-attempting a doomed write. One
+    // AtomicReference so an illegal ended-without-ending combination is unrepresentable.
     private enum class SealState { OPEN, ENDING, ENDED }
     private val seal = AtomicReference(SealState.OPEN)
 
@@ -219,7 +220,7 @@ public class SseEmitter internal constructor(
     /** The ONLY clean ending — derives stop_reason internally (L3). */
     override suspend fun emitTerminal(hasToolUse: Boolean, incomplete: Boolean, usage: Usage) {
         if (!seal.compareAndSet(SealState.OPEN, SealState.ENDING)) return
-        var sealed = false
+        var cancelled = false
         try {
             ensureStart()
             frame(
@@ -234,14 +235,17 @@ public class SseEmitter internal constructor(
                 },
             )
             frame("message_stop", buildJsonObject { put(TYPE, "message_stop") })
-            seal.set(SealState.ENDED)
-            sealed = true
+        } catch (e: CancellationException) {
+            // Cancelled mid-frame — release so the cancellation seal's emitError
+            // (TurnDriver.driveSealingCancellation) can still seal honestly; a stranded ENDING
+            // was the truncated-200 hole (review 2026-07-22).
+            cancelled = true
+            seal.set(SealState.OPEN)
+            throw e
         } finally {
-            // Release the claim on EVERY failure — cancellation included: a head-stop cancel
-            // mid-frame must leave the emitter sealable, or the cancellation seal's emitError
-            // (TurnDriver.driveSealingCancellation) no-ops and the client gets a truncated 200
-            // (the stranded-ENDING hole, review 2026-07-22).
-            if (!sealed) seal.set(SealState.OPEN)
+            // Frames delivered → sealed ENDED; frames FAILED (client gone, IOException) → still
+            // ENDED so a follow-up emitError cleanly no-ops. Only a cancellation releases instead.
+            if (!cancelled) seal.set(SealState.ENDED)
         }
     }
 

--- a/gateway/gateway/src/main/kotlin/splice/gateway/wire/SseEmitter.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/wire/SseEmitter.kt
@@ -21,6 +21,7 @@ import kotlinx.serialization.json.putJsonObject
 import splice.core.index.WireBlockIndex
 import splice.core.turn.ErrorType
 import splice.core.turn.Usage
+import java.util.concurrent.CancellationException
 import java.util.concurrent.atomic.AtomicBoolean
 
 /** Builds the (non-standard) usage payload Claude Code reads from gateways — injected so the
@@ -47,6 +48,9 @@ public class SseEmitter internal constructor(
 
     private var started = false
     private val ended = AtomicBoolean(false)
+    // Claims the sole-terminal right; ended is set only AFTER frames succeed (or abandon).
+    // Mid-terminal write failure releases the claim so emitError can still seal honestly.
+    private val ending = AtomicBoolean(false)
     private var nextBlockIndex = 0
     private val open = LinkedHashSet<Int>()
 
@@ -54,7 +58,7 @@ public class SseEmitter internal constructor(
     private val frameBuf = StringBuilder(FRAME_BUF_CAPACITY)
 
     public val hasStarted: Boolean get() = started
-    public val hasEnded: Boolean get() = ended.get()
+    override val hasEnded: Boolean get() = ended.get()
 
     private suspend fun frame(event: String, data: JsonObject) {
         frameBuf.setLength(0)
@@ -210,39 +214,55 @@ public class SseEmitter internal constructor(
 
     /** The ONLY clean ending — derives stop_reason internally (L3). */
     override suspend fun emitTerminal(hasToolUse: Boolean, incomplete: Boolean, usage: Usage) {
-        if (!ended.compareAndSet(false, true)) return
-        ensureStart()
-        frame(
-            "message_delta",
-            buildJsonObject {
-                put(TYPE, "message_delta")
-                putJsonObject("delta") {
-                    put("stop_reason", deriveStopReason(hasToolUse, incomplete))
-                    put("stop_sequence", null as String?)
-                }
-                put("usage", usagePayload(usage))
-            },
-        )
-        frame("message_stop", buildJsonObject { put(TYPE, "message_stop") })
+        if (ended.get() || !ending.compareAndSet(false, true)) return
+        try {
+            ensureStart()
+            frame(
+                "message_delta",
+                buildJsonObject {
+                    put(TYPE, "message_delta")
+                    putJsonObject("delta") {
+                        put("stop_reason", deriveStopReason(hasToolUse, incomplete))
+                        put("stop_sequence", null as String?)
+                    }
+                    put("usage", usagePayload(usage))
+                },
+            )
+            frame("message_stop", buildJsonObject { put(TYPE, "message_stop") })
+            ended.set(true)
+        } catch (e: Throwable) {
+            if (e is CancellationException) throw e
+            ending.set(false)
+            throw e
+        }
     }
 
     /** The ONLY failure ending — an SSE error event lets Claude Code retry honestly. */
     override suspend fun emitError(type: ErrorType, message: String) {
-        if (!ended.compareAndSet(false, true)) return
-        frame(
-            "error",
-            buildJsonObject {
-                put(TYPE, "error")
-                putJsonObject("error") {
-                    put(TYPE, type.wireName)
-                    put(MESSAGE, message)
-                }
-            },
-        )
+        if (ended.get() || !ending.compareAndSet(false, true)) return
+        try {
+            frame(
+                "error",
+                buildJsonObject {
+                    put(TYPE, "error")
+                    putJsonObject("error") {
+                        put(TYPE, type.wireName)
+                        put(MESSAGE, message)
+                    }
+                },
+            )
+            ended.set(true)
+        } catch (e: Throwable) {
+            if (e is CancellationException) throw e
+            // Error frame itself failed (client gone) — still seal so retries don't double-end.
+            ended.set(true)
+            throw e
+        }
     }
 
     /** Client vanished mid-stream — nothing to emit, just seal the emitter. */
     override fun abandon() {
+        ending.set(true)
         ended.set(true)
     }
 

--- a/gateway/gateway/src/main/kotlin/splice/gateway/wire/TurnTerminal.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/wire/TurnTerminal.kt
@@ -11,7 +11,11 @@ import splice.core.turn.Usage
 import splice.spi.WireSink
 
 public interface TurnTerminal : WireSink {
-    /** True after emitTerminal / emitError / abandon — used to seal cancelled turns honestly. */
+    /** True once this turn's ending is SETTLED — a terminal or error durably reached the wire,
+     *  abandon sealed it, or a failed error write made retrying pointless. NOT merely "attempted":
+     *  implementations keep it false after a cancelled/failed terminal so the cancellation seal
+     *  (TurnDriver.driveSealingCancellation) can still end the turn honestly (stranded-terminal /
+     *  truncated-200 fix, review 2026-07-22 round 3). */
     public val hasEnded: Boolean
 
     /** The ONLY clean ending — implementors derive the stop_reason literal internally (L3). */

--- a/gateway/gateway/src/main/kotlin/splice/gateway/wire/TurnTerminal.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/wire/TurnTerminal.kt
@@ -11,6 +11,9 @@ import splice.core.turn.Usage
 import splice.spi.WireSink
 
 public interface TurnTerminal : WireSink {
+    /** True after emitTerminal / emitError / abandon — used to seal cancelled turns honestly. */
+    public val hasEnded: Boolean
+
     /** The ONLY clean ending — implementors derive the stop_reason literal internally (L3). */
     public suspend fun emitTerminal(hasToolUse: Boolean, incomplete: Boolean, usage: Usage)
 

--- a/gateway/gateway/src/test/kotlin/SseEmitterTest.kt
+++ b/gateway/gateway/src/test/kotlin/SseEmitterTest.kt
@@ -11,6 +11,7 @@ import splice.core.turn.ErrorType
 import splice.core.turn.Usage
 import splice.gateway.wire.SseEmitter
 import splice.gateway.wire.TerminalMessage
+import java.util.concurrent.CancellationException
 
 class SseEmitterTest {
 
@@ -169,5 +170,38 @@ class SseEmitterTest {
             ),
         )
         assertEquals("\"max_tokens\"", msg["stop_reason"].toString())
+    }
+
+    @Test
+    fun `cancellation mid-terminal releases the claim so emitError can still seal`() = runTest {
+        // The stranded-ENDING hole (review 2026-07-22): a head-stop cancel lands while the
+        // terminal frames are being written; the follow-up cancellation-seal emitError
+        // (TurnDriver.driveSealingCancellation) must still put an honest error frame on the
+        // wire — not no-op against a held claim and leave the client a truncated 200.
+        val frames = mutableListOf<String>()
+        var failOnce = true
+        val emitter = SseEmitter.create(
+            write = { frame ->
+                if (failOnce && frame.startsWith("event: message_delta")) {
+                    failOnce = false
+                    throw CancellationException("head stop mid-terminal")
+                }
+                frames.add(frame)
+            },
+            model = "m",
+            usagePayload = { buildJsonObject { put("input_tokens", 0) } },
+            messageId = "msg_fixed",
+        )
+        var cancelled: CancellationException? = null
+        try {
+            emitter.emitTerminal(hasToolUse = false, incomplete = false, usage = Usage(1, 2))
+        } catch (e: CancellationException) {
+            cancelled = e
+        }
+        assertTrue(cancelled != null, "mid-terminal cancellation must propagate")
+        assertTrue(!emitter.hasEnded, "a cancelled terminal must not read as ended")
+        emitter.emitError(ErrorType.OVERLOADED, "turn cancelled — retry")
+        assertTrue(emitter.hasEnded, "the seal after a cancelled terminal must land")
+        assertTrue(frames.any { it.startsWith("event: error") && it.contains("turn cancelled") })
     }
 }

--- a/gateway/gateway/src/test/kotlin/SseEmitterTest.kt
+++ b/gateway/gateway/src/test/kotlin/SseEmitterTest.kt
@@ -11,6 +11,7 @@ import splice.core.turn.ErrorType
 import splice.core.turn.Usage
 import splice.gateway.wire.SseEmitter
 import splice.gateway.wire.TerminalMessage
+import java.io.IOException
 import java.util.concurrent.CancellationException
 
 class SseEmitterTest {
@@ -203,5 +204,37 @@ class SseEmitterTest {
         emitter.emitError(ErrorType.OVERLOADED, "turn cancelled — retry")
         assertTrue(emitter.hasEnded, "the seal after a cancelled terminal must land")
         assertTrue(frames.any { it.startsWith("event: error") && it.contains("turn cancelled") })
+    }
+
+    @Test
+    fun `IOException mid-terminal stays sealed ENDED so a follow-up emitError no-ops`() = runTest {
+        // The branch-introduced regression: a client disconnecting on the second terminal frame
+        // (message_stop) threw IOException; the old finally reverted the seal to OPEN, so the
+        // downstream emitConnReset → emitError re-attempted a doomed write that threw again and
+        // escaped its recordPerf/health telemetry. Client-gone must stay ENDED (unlike a
+        // cancellation, which releases), leaving a follow-up emitError a clean no-op.
+        val frames = mutableListOf<String>()
+        val emitter = SseEmitter.create(
+            write = { frame ->
+                if (frame.startsWith("event: message_stop")) {
+                    throw IOException("client gone mid-terminal")
+                }
+                frames.add(frame)
+            },
+            model = "m",
+            usagePayload = { buildJsonObject { put("input_tokens", 0) } },
+            messageId = "msg_fixed",
+        )
+        var thrown: IOException? = null
+        try {
+            emitter.emitTerminal(hasToolUse = false, incomplete = false, usage = Usage(1, 2))
+        } catch (e: IOException) {
+            thrown = e
+        }
+        assertTrue(thrown != null, "a client-gone IOException mid-terminal must propagate")
+        assertTrue(emitter.hasEnded, "a client-gone terminal stays sealed ENDED")
+        val before = frames.size
+        emitter.emitError(ErrorType.API_ERROR, "conn reset")
+        assertEquals(before, frames.size) // emitError no-ops: nothing new on the wire
     }
 }

--- a/gateway/gateway/src/test/kotlin/UsageTest.kt
+++ b/gateway/gateway/src/test/kotlin/UsageTest.kt
@@ -99,7 +99,7 @@ class UsageTest {
     }
 
     @Test
-    fun `usage store - 5h window prunes, sums, and ratelimit round-trips`(@TempDir tmp: Path) {
+    fun `usage store - 5h window prunes, sums, and same-instance ratelimit round-trips`(@TempDir tmp: Path) {
         var now = 10_000_000_000L
         val store = UsageStore(tmp.resolve("codex-usage.json"), tmp.resolve("codex-ratelimit.json"), clock = { now })
         store.appendOutputTokens(100)
@@ -128,6 +128,35 @@ class UsageTest {
         // absent limit header -> no-op (file unchanged)
         store.persistRateLimit { null }
         assertEquals(5000, store.readRateLimit()!!.limitTokens)
+    }
+
+    @Test
+    fun `ratelimit persistence is durable across a fresh store and coalesces to the final value`(@TempDir tmp: Path) {
+        // review gap J (core): the round-trip above reads from the SAME instance, so pending in-memory
+        // state could satisfy it without anything reaching disk. Prove a FRESH store reads the persisted
+        // headers, and that a burst of writes with no explicit flush between them coalesces to the LAST
+        // value on disk (latest-wins). The scheduler/file-lane race bullets need an injectable seam
+        // UsageStore does not expose (process-global AsyncFileIo) and remain out of scope here.
+        val usageFile = tmp.resolve("usage.json")
+        val rateFile = tmp.resolve("ratelimit.json")
+        fun headers(limit: String, remaining: String, reset: String): (String) -> String? = { name ->
+            mapOf(
+                "x-ratelimit-limit-tokens" to limit,
+                "x-ratelimit-remaining-tokens" to remaining,
+                "x-ratelimit-reset-tokens" to reset,
+            )[name]
+        }
+        val store = UsageStore(usageFile, rateFile)
+        // A burst of successive updates before any explicit flush — latest must win.
+        store.persistRateLimit(headers("5000", "4000", "6m0s"))
+        store.persistRateLimit(headers("5000", "2500", "4m0s"))
+        store.persistRateLimit(headers("5000", "900", "2m0s"))
+        store.flushNow()
+
+        val fresh = UsageStore(usageFile, rateFile).readRateLimit()!!
+        assertEquals(5000, fresh.limitTokens)
+        assertEquals(900, fresh.remainingTokens, "a burst must coalesce to the final value, on disk")
+        assertEquals("2m0s", fresh.resetTokens)
     }
 
     @Test

--- a/gateway/gateway/src/test/kotlin/head/HeadServerCapacityTest.kt
+++ b/gateway/gateway/src/test/kotlin/head/HeadServerCapacityTest.kt
@@ -170,4 +170,27 @@ class HeadServerCapacityTest {
         // both held requests before the test returns, so @AfterAll teardown is clean.
         listOf(first, second).forEach { it.await() }
     }
+
+    @Test
+    fun `count_tokens answers promptly and calls no upstream while the turn gate is saturated`() = runBlocking {
+        // count_tokens is a local estimate off the turn gate: even with the one inflight slot held,
+        // it must return 200 immediately, never touch upstream, and never occupy the gate.
+        val held = async(Dispatchers.IO) { idleTurn() }
+        assertTrue(waitFor(5_000) { gate.snapshot().inflight == 1 }, "expected the held turn to occupy the slot")
+        val upstreamBefore = mock.upstreamBodies.size
+
+        val resp = client.post("http://127.0.0.1:$port/v1/messages/count_tokens") {
+            header("Content-Type", "application/json")
+            setBody(
+                """{"model":"claude-codex--gpt-5.6-sol",
+                    "messages":[{"role":"user","content":"estimate this locally"}]}""",
+            )
+        }
+        assertEquals(200, resp.status.value)
+        assertTrue(resp.bodyAsText().contains("input_tokens"), "expected a local token estimate")
+        assertEquals(upstreamBefore, mock.upstreamBodies.size, "count_tokens must not call upstream")
+        assertEquals(1, gate.snapshot().inflight, "count_tokens must not occupy the turn gate")
+
+        held.await()
+    }
 }

--- a/gateway/gateway/src/test/kotlin/head/HeadServerReviewTest.kt
+++ b/gateway/gateway/src/test/kotlin/head/HeadServerReviewTest.kt
@@ -1,0 +1,276 @@
+// NEW (review 2026-07-23): HTTP-level integration coverage the PR review flagged as missing —
+//   E: a waiter promoted from the InflightGate queue DURING a stop/restart drain is bounced with
+//      the 529 "head is stopping — retry" shape (never starts a doomed upstream turn);
+//   G: count_tokens fast-fails 529 "gateway busy — retry" when the materialization gate is saturated
+//      (proves the HTTP route is wired to tryWithLease, not just the primitive);
+//   I: upstream x-ratelimit-* headers survive to durable UsageStore state through TurnDriver.
+// Each test builds an ISOLATED head so it can stop/restart/hold without disturbing a shared one.
+package head
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import mock.MockChatGptUpstream
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import splice.core.auth.AuthDescription
+import splice.core.auth.Credentials
+import splice.core.auth.RefreshableAuthProvider
+import splice.core.model.ModelCatalog
+import splice.core.model.ModelEntry
+import splice.core.turn.ReasoningDisplay
+import splice.core.turn.WatchdogBudget
+import splice.gateway.compact.CompactStats
+import splice.gateway.compact.ShadowClassifier
+import splice.gateway.head.HeadDeps
+import splice.gateway.head.HeadServer
+import splice.gateway.head.RequestMaterializationGate
+import splice.gateway.perf.PerfStats
+import splice.gateway.usage.UsageStore
+import splice.provider.codex.CodexProvider
+import splice.spi.InflightGate
+import splice.spi.ProviderTuning
+import splice.spi.UpstreamClient
+import java.net.ServerSocket
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.time.Duration.Companion.seconds
+
+private class ReviewFakeAuth : RefreshableAuthProvider {
+    override suspend fun credentials(): Credentials = Credentials.Bearer("tok-rev", "acct-rev")
+    override suspend fun refresh(): Credentials = credentials()
+    override suspend fun describe(): AuthDescription = AuthDescription(true, "fake")
+}
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class HeadServerReviewTest {
+
+    private val mock = MockChatGptUpstream()
+    private val client = HttpClient(CIO) { defaultRequest { bearerAuth("test-inference-token") } }
+    private lateinit var tmp: Path
+
+    private val catalog = ModelCatalog(
+        discoveryPrefix = "claude-codex--",
+        models = listOf(ModelEntry("gpt-5.6-sol", "Sol", contextWindow = 272_000)),
+        defaultContextWindow = 272_000,
+    )
+
+    @BeforeAll
+    fun setUp() {
+        tmp = Files.createTempDirectory("head-review")
+    }
+
+    @AfterAll
+    fun tearDown() {
+        client.close()
+        mock.stop()
+    }
+
+    private fun buildHead(
+        port: Int,
+        gate: InflightGate,
+        matGate: RequestMaterializationGate,
+        ratelimitFile: Path,
+    ): HeadServer {
+        val provider = CodexProvider(
+            tuning = ProviderTuning(
+                key = "codex",
+                label = "claudex",
+                catalog = catalog,
+                pinnedModel = "gpt-5.6-sol",
+                auth = ReviewFakeAuth(),
+                baseUrl = mock.baseUrl,
+                watchdog = WatchdogBudget(10.seconds, 10.seconds, 30.seconds),
+                loginCommand = "claudex login",
+            ),
+            showReasoning = ReasoningDisplay.TEXT,
+            replayReasoning = false,
+            configEffort = "high",
+            configSummary = "detailed",
+        )
+        return HeadServer(
+            provider = provider,
+            listenPort = port,
+            deps = HeadDeps(
+                upstream = UpstreamClient(firstByteTimeoutMs = 5_000, totalTimeoutMs = 30_000, maxRetries = 2),
+                inferenceToken = "test-inference-token",
+                gate = gate,
+                shadow = ShadowClassifier(log = {}),
+                compactStats = CompactStats(tmp.resolve("compact-$port.jsonl")),
+                usageStore = UsageStore(tmp.resolve("usage-$port.json"), ratelimitFile),
+                perfStats = PerfStats(tmp.resolve("perf-$port.jsonl")),
+                log = {},
+                requestMaterializationGate = matGate,
+            ),
+        )
+    }
+
+    private fun freshPort(): Int = ServerSocket(0).use { it.localPort }
+
+    private suspend fun waitFor(capMs: Long, cond: () -> Boolean): Boolean {
+        val deadline = System.currentTimeMillis() + capMs
+        while (System.currentTimeMillis() < deadline) {
+            if (cond()) return true
+            delay(50)
+        }
+        return cond()
+    }
+
+    private suspend fun turn(port: Int, scenario: String): HttpResponse =
+        client.post("http://127.0.0.1:$port/v1/messages") {
+            header("Content-Type", "application/json")
+            setBody(
+                """{"model":"claude-codex--gpt-5.6-sol","stream":true,"max_tokens":64,
+                    "system":"You are a test. SCENARIO:$scenario",
+                    "messages":[{"role":"user","content":"go"}]}""",
+            )
+        }
+
+    private suspend fun countTokens(port: Int): HttpResponse =
+        client.post("http://127.0.0.1:$port/v1/messages/count_tokens") {
+            header("Content-Type", "application/json")
+            setBody("""{"model":"claude-codex--gpt-5.6-sol","messages":[{"role":"user","content":"estimate"}]}""")
+        }
+
+    @Test
+    fun `a waiter promoted during the stop drain is bounced with 529 head-is-stopping`() = runBlocking {
+        val gate = InflightGate(maxInflight = { 1 }, maxQueued = { 1 })
+        val port = freshPort()
+        val head = buildHead(port, gate, RequestMaterializationGate(), tmp.resolve("rl-e.json"))
+        head.start()
+        Thread.sleep(700)
+        try {
+            // req1 holds the one inflight slot until we release the mock latch.
+            val req1 = async(Dispatchers.IO) { turn(port, "hold").bodyAsText() }
+            assertTrue(waitFor(5_000) { gate.snapshot().inflight == 1 }, "req1 should hold the slot")
+            // req2 passes the accepting front-door (still accepting), then queues on the full gate.
+            val req2 = async(Dispatchers.IO) { turn(port, "basic") }
+            assertTrue(waitFor(5_000) { gate.snapshot().queued == 1 }, "req2 should fill the queue")
+
+            // Restart flips accepting=false and drains; give it a beat to set the flag, THEN release
+            // req1 so req2 is promoted DURING the drain — it must be bounced, not run.
+            val restart = async(Dispatchers.IO) { head.restart() }
+            delay(400)
+            mock.holdRelease.countDown()
+
+            val resp = req2.await()
+            assertEquals(529, resp.status.value)
+            val body = resp.bodyAsText()
+            assertTrue(body.contains("overloaded_error"), "expected overloaded_error in: $body")
+            assertTrue(body.contains("head is stopping"), "expected 'head is stopping — retry' in: $body")
+
+            req1.await()
+            restart.await()
+        } finally {
+            head.stop()
+        }
+    }
+
+    @Test
+    fun `count_tokens 529s with the busy shape when the materialization gate is saturated`() = runBlocking {
+        val matGate = RequestMaterializationGate(maxConcurrent = 1)
+        val port = freshPort()
+        val head = buildHead(port, InflightGate(maxInflight = { 4 }), matGate, tmp.resolve("rl-g.json"))
+        head.start()
+        Thread.sleep(700)
+        try {
+            // Hold the sole materialization permit so count_tokens' fast-fail lease is contended.
+            val acquired = CompletableDeferred<Unit>()
+            val release = CompletableDeferred<Unit>()
+            val holding = async(Dispatchers.IO) {
+                matGate.withLease {
+                    acquired.complete(Unit)
+                    release.await()
+                }
+            }
+            acquired.await()
+
+            val resp = countTokens(port)
+            assertEquals(529, resp.status.value)
+            val body = resp.bodyAsText()
+            assertTrue(body.contains("overloaded_error"), "expected overloaded_error in: $body")
+            assertTrue(body.contains("gateway busy"), "expected 'gateway busy — retry' in: $body")
+
+            release.complete(Unit)
+            holding.await()
+            // Permit free again → count_tokens succeeds.
+            assertEquals(200, countTokens(port).status.value)
+        } finally {
+            head.stop()
+        }
+    }
+
+    @Test
+    fun `upstream rate-limit headers survive to durable UsageStore state`() = runBlocking {
+        val ratelimitFile = tmp.resolve("rl-i.json")
+        val port = freshPort()
+        val head = buildHead(port, InflightGate(maxInflight = { 4 }), RequestMaterializationGate(), ratelimitFile)
+        head.start()
+        Thread.sleep(700)
+        try {
+            // A successful turn whose response carries x-ratelimit-* headers.
+            assertEquals(200, turn(port, "ratelimit").status.value)
+            // head.stop() flushes pending rate-limit state durably to the file.
+        } finally {
+            head.stop()
+        }
+        // A FRESH store reading the same file must see the persisted headers — proves the TurnDriver
+        // call site, not just persistRateLimit() in isolation.
+        val reread = UsageStore(tmp.resolve("usage-reread.json"), ratelimitFile).readRateLimit()
+        assertNotNull(reread, "rate-limit state should be durable across a fresh store")
+        assertEquals(5000, reread!!.limitTokens)
+        assertEquals(1200, reread.remainingTokens)
+        assertEquals("6m0s", reread.resetTokens)
+    }
+
+    @Test
+    fun `a stream torn before any client frame ends as one honest error, not a truncated 200`() =
+        runBlocking {
+            val port = freshPort()
+            val head = buildHead(
+                port,
+                InflightGate(maxInflight = { 4 }),
+                RequestMaterializationGate(),
+                tmp.resolve("rl-h.json"),
+            )
+            head.start()
+            Thread.sleep(700)
+            try {
+                val before = mock.upstreamBodies.count { it.first == "tear" }
+                val resp = turn(port, "tear")
+                val body = resp.bodyAsText()
+                // The 200 + SSE headers are already committed once respondTextWriter opens, so the
+                // upstream tear MUST become an honest `event: error` frame (StreamTornBeforeClient ->
+                // emitConnReset in TurnDriver), never an escaped/truncated 200 with no terminal.
+                assertEquals(200, resp.status.value)
+                assertTrue(body.contains("event: error"), "expected an error event in: $body")
+                assertTrue(body.contains("overloaded_error"), "expected overloaded_error in: $body")
+                assertEquals(1, body.split("event: error").size - 1, "exactly one error event: $body")
+                assertTrue(!body.contains("message_stop"), "a torn turn must NOT emit message_stop: $body")
+                // Upstream was hit (the request handed off before tearing). NB: this premature-EOF
+                // tear is not classed as a retryable transport reset, so it does not consume the
+                // stream-reissue budget — a real connection RST (which the in-process mock cannot
+                // force) would reissue up to MAX_STREAM_REISSUES; the honest-terminal mapping under
+                // test here is identical either way.
+                assertTrue(mock.upstreamBodies.count { it.first == "tear" } > before, "upstream was attempted")
+            } finally {
+                head.stop()
+            }
+        }
+}

--- a/gateway/gateway/src/test/kotlin/head/RequestMaterializationGateTest.kt
+++ b/gateway/gateway/src/test/kotlin/head/RequestMaterializationGateTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import splice.gateway.head.RequestMaterializationGate
 
@@ -53,5 +54,31 @@ class RequestMaterializationGateTest {
         second.await()
 
         assertEquals(listOf("first-enter", "first-exit", "second-enter"), order)
+    }
+
+    @Test
+    fun `tryWithLease fast-fails on a held permit and runs once it is free`() = runTest(UnconfinedTestDispatcher()) {
+        // count_tokens contract (review 2026-07-22): on contention the caller 529s instead of
+        // queueing, so a slow-body flood cannot camp the permits real turns materialize through.
+        val gate = RequestMaterializationGate(maxConcurrent = 1)
+        val firstEntered = CompletableDeferred<Unit>()
+        val releaseFirst = CompletableDeferred<Unit>()
+
+        val holder = async {
+            gate.withLease {
+                firstEntered.complete(Unit)
+                releaseFirst.await()
+            }
+        }
+        firstEntered.await()
+
+        var ran = false
+        assertNull(gate.tryWithLease { ran = true }, "a held permit must fast-fail, not queue")
+        assertFalse(ran, "the contended block must never run")
+
+        releaseFirst.complete(Unit)
+        holder.await()
+
+        assertEquals("ok", gate.tryWithLease { "ok" })
     }
 }

--- a/gateway/gateway/src/testFixtures/kotlin/mock/MockChatGptUpstream.kt
+++ b/gateway/gateway/src/testFixtures/kotlin/mock/MockChatGptUpstream.kt
@@ -27,6 +27,11 @@ class MockChatGptUpstream {
     val abortedScenarios = CopyOnWriteArrayList<String>()
     val refreshCalls = AtomicInteger(0)
 
+    // The "hold" scenario blocks after its first delta until the test releases this latch — a
+    // deterministic replacement for the timer-based "idle" hold when a test must occupy a slot and
+    // then free it on command (review 2026-07-23).
+    val holdRelease = java.util.concurrent.CountDownLatch(1)
+
     private val server: HttpServer = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
     private val pool = Executors.newCachedThreadPool()
 
@@ -82,14 +87,35 @@ class MockChatGptUpstream {
             return
         }
 
+        if (scenario == "tear") {
+            // 200 committed, then a PARTIAL frame and an early socket drop: promising more bytes
+            // (fixed Content-Length) than we deliver makes the client's read fail with a premature
+            // EOF (IOException) BEFORE any complete client frame — the StreamTornBeforeClient path.
+            ex.responseHeaders.add("Content-Type", "text/event-stream")
+            ex.sendResponseHeaders(200, 4096)
+            runCatching {
+                ex.responseBody.write("data: {\"type\":\"resp".toByteArray())
+                ex.responseBody.flush()
+            }.discard("tear: drop mid-frame")
+            ex.close()
+            return
+        }
+        if (scenario == "ratelimit") {
+            // Upstream token-budget headers TurnDriver.persistRateLimit harvests into UsageStore.
+            ex.responseHeaders.add("x-ratelimit-limit-tokens", "5000")
+            ex.responseHeaders.add("x-ratelimit-remaining-tokens", "1200")
+            ex.responseHeaders.add("x-ratelimit-reset-tokens", "6m0s")
+        }
         ex.responseHeaders.add("Content-Type", "text/event-stream")
         ex.sendResponseHeaders(200, 0)
         try {
             streamScenario(scenario, ex, body)
         } catch (abort: IOException) {
-            // a broken pipe mid-stream is the drip scenario's EXPECTED client-abort exit
-            if (scenario == "drip") abortedScenarios.add("drip")
-            check(scenario == "drip") { "unexpected mid-stream I/O failure in scenario '$scenario': ${abort.message}" }
+            // a broken pipe mid-stream is the drip/hold scenarios' EXPECTED client-abort exit
+            if (scenario == "drip" || scenario == "hold") abortedScenarios.add(scenario)
+            check(scenario == "drip" || scenario == "hold") {
+                "unexpected mid-stream I/O failure in scenario '$scenario': ${abort.message}"
+            }
         } finally {
             runCatching { ex.responseBody.close() }.discard("test-server teardown")
             runCatching { ex.close() }.discard("test-server teardown")
@@ -199,6 +225,17 @@ class MockChatGptUpstream {
                 sse(ex, """{"type":"response.output_item.added","output_index":0,"item":{"type":"message"}}""")
                 sse(ex, """{"type":"response.output_text.delta","output_index":0,"delta":"partial"}""")
                 Thread.sleep(5_000)
+            }
+            "hold" -> {
+                sse(ex, """{"type":"response.output_item.added","output_index":0,"item":{"type":"message"}}""")
+                sse(ex, """{"type":"response.output_text.delta","output_index":0,"delta":"held"}""")
+                holdRelease.await() // block until the test releases, then finish cleanly
+                sse(ex, """{"type":"response.output_item.done","output_index":0}""")
+                sse(
+                    ex,
+                    """{"type":"response.completed","response":{"id":"rhold","status":"completed",""" +
+                        """"output":[],"usage":{"input_tokens":1,"output_tokens":1}}}""",
+                )
             }
             "zero_event_auth" -> {
                 ex.responseBody.write(

--- a/gateway/provider-codex/src/main/kotlin/splice/provider/codex/CodexAuthProvider.kt
+++ b/gateway/provider-codex/src/main/kotlin/splice/provider/codex/CodexAuthProvider.kt
@@ -13,6 +13,7 @@ package splice.provider.codex
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
@@ -61,6 +62,13 @@ public class CodexAuthProvider(
     private val json = Json { ignoreUnknownKeys = true }
     private val singleFlight = SingleFlight<Credentials?>()
     private val invalidGrantLatch = InvalidGrantLatch()
+
+    init {
+        // Lifecycle ownership: when prefetchScope ends (Daemon.stop cancels probeScope), cancel the
+        // shared refresh so it cannot persist a token after shutdown. Per-request cancellation is
+        // unaffected — it only cancels that caller's await, never the SingleFlight scope.
+        prefetchScope.coroutineContext[Job]?.invokeOnCompletion { singleFlight.close() }
+    }
 
     @Volatile
     private var cache: Cache? = null

--- a/gateway/provider-grok/src/main/kotlin/splice/provider/grok/GrokAuthProvider.kt
+++ b/gateway/provider-grok/src/main/kotlin/splice/provider/grok/GrokAuthProvider.kt
@@ -23,6 +23,7 @@ package splice.provider.grok
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
@@ -63,14 +64,24 @@ public class GrokAuthProvider(
     private val nowIso: () -> String = { Instant.ofEpochMilli(System.currentTimeMillis()).toString() },
     /** POST grant_type=refresh_token to auth.x.ai's token URL; returns the classified attempt. */
     private val refreshCall: suspend (refreshToken: String) -> RefreshAttempt<GrokRefreshedTokens>,
-    // Injectable so the daemon can tie prefetch to probeScope (Daemon.stop cancels it). Default
-    // keeps unit tests self-contained; production MUST pass the daemon lifecycle scope.
+    // Injectable so the daemon runs the prefetch LAUNCH on probeScope and tests stay self-contained.
+    // SingleFlight isolates the shared refresh from any single request's await cancellation (a peer
+    // awaiting it must not be killed); the init block below ties that shared refresh to THIS scope's
+    // lifetime, so Daemon.stop (probeScope.cancel) cancels an in-flight refresh instead of letting
+    // it write the token file post-shutdown (review 2026-07-23).
     private val prefetchScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob()),
 ) : RefreshableAuthProvider {
 
     private val json = Json { ignoreUnknownKeys = true }
     private val singleFlight = SingleFlight<Credentials?>()
     private val invalidGrantLatch = InvalidGrantLatch()
+
+    init {
+        // Lifecycle ownership: when prefetchScope ends (Daemon.stop cancels probeScope), cancel the
+        // shared refresh so it cannot persist a token after shutdown. Per-request cancellation is
+        // unaffected — it only cancels that caller's await, never the SingleFlight scope.
+        prefetchScope.coroutineContext[Job]?.invokeOnCompletion { singleFlight.close() }
+    }
 
     @Volatile
     private var cache: Cache? = null

--- a/gateway/provider-grok/src/main/kotlin/splice/provider/grok/GrokAuthProvider.kt
+++ b/gateway/provider-grok/src/main/kotlin/splice/provider/grok/GrokAuthProvider.kt
@@ -63,16 +63,14 @@ public class GrokAuthProvider(
     private val nowIso: () -> String = { Instant.ofEpochMilli(System.currentTimeMillis()).toString() },
     /** POST grant_type=refresh_token to auth.x.ai's token URL; returns the classified attempt. */
     private val refreshCall: suspend (refreshToken: String) -> RefreshAttempt<GrokRefreshedTokens>,
+    // Injectable so the daemon can tie prefetch to probeScope (Daemon.stop cancels it). Default
+    // keeps unit tests self-contained; production MUST pass the daemon lifecycle scope.
+    private val prefetchScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob()),
 ) : RefreshableAuthProvider {
 
     private val json = Json { ignoreUnknownKeys = true }
     private val singleFlight = SingleFlight<Credentials?>()
     private val invalidGrantLatch = InvalidGrantLatch()
-
-    // This is the injection seam: an owned background scope, decoupled from any single request's
-    // coroutine, for the G17 async-prefetch
-    // tier. Mirrors SingleFlight's own internal scope (same PORT-OF pattern, SingleFlight.kt:36).
-    private val prefetchScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
     @Volatile
     private var cache: Cache? = null

--- a/gateway/provider-kimi/src/main/kotlin/splice/provider/kimi/KimiAuthProvider.kt
+++ b/gateway/provider-kimi/src/main/kotlin/splice/provider/kimi/KimiAuthProvider.kt
@@ -11,6 +11,7 @@
 package splice.provider.kimi
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import splice.core.auth.AuthDescription
@@ -51,6 +52,13 @@ public class KimiAuthProvider(
     private val json = Json { ignoreUnknownKeys = true }
     private val singleFlight = SingleFlight<Credentials?>()
     private val invalidGrantLatch = InvalidGrantLatch()
+
+    init {
+        // Lifecycle ownership: when prefetchScope ends (Daemon.stop cancels probeScope), cancel the
+        // shared refresh so it cannot persist a token after shutdown. Per-request cancellation is
+        // unaffected — it only cancels that caller's await, never the SingleFlight scope.
+        prefetchScope?.coroutineContext?.get(Job)?.invokeOnCompletion { singleFlight.close() }
+    }
 
     @Volatile
     private var cache: Cache? = null

--- a/gateway/provider-spi/src/main/kotlin/splice/spi/InflightGate.kt
+++ b/gateway/provider-spi/src/main/kotlin/splice/spi/InflightGate.kt
@@ -12,6 +12,7 @@ package splice.spi
 
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.suspendCancellableCoroutine
+import splice.core.util.MonoClock
 import java.util.ArrayDeque
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
@@ -21,7 +22,8 @@ import kotlin.coroutines.resumeWithException
 public class InflightGate(
     private val maxInflight: () -> Int,
     private val maxQueued: () -> Int = { 0 },
-    private val clock: () -> Long = System::currentTimeMillis,
+    // Default is monotonic — wall-clock jumps must not invent idle timeouts or freeze slots.
+    private val clock: () -> Long = MonoClock::nowMs,
 ) {
     private val lock = Any()
     private var inflight = 0
@@ -88,7 +90,9 @@ public class InflightGate(
             // flag then double-resumes the continuation ("Already resumed" ISE — caught by the
             // cancel-racing-admission hammer test on CI). Only the local flag is race-free.
             if (admittedNow) {
-                cont.resume(Unit)
+                // Same undelivered-handler as release(): a waiter cancelled between inflight++ and
+                // delivery must return the permit or the head permanently loses one capacity slot.
+                cont.resume(Unit) { _, _, _ -> release() }
                 return@suspendCancellableCoroutine
             }
             if (rejected) {

--- a/gateway/provider-spi/src/main/kotlin/splice/spi/SingleFlight.kt
+++ b/gateway/provider-spi/src/main/kotlin/splice/spi/SingleFlight.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlin.coroutines.CoroutineContext
@@ -44,5 +45,12 @@ public class SingleFlight<T>(
         }
         // A caller's cancellation cancels THIS await only — the shared block keeps running in `scope`.
         return shared.await()
+    }
+
+    /** Cancel the shared refresh scope. For a LIFECYCLE owner (e.g. daemon stop) to stop an
+     *  in-flight refresh — distinct from a single caller's await cancellation, which never touches
+     *  the scope. Idempotent; after close a new wave would need a new SingleFlight. */
+    public fun close() {
+        scope.cancel()
     }
 }

--- a/gateway/provider-spi/src/main/kotlin/splice/spi/TerminalStates.kt
+++ b/gateway/provider-spi/src/main/kotlin/splice/spi/TerminalStates.kt
@@ -1,0 +1,31 @@
+// NEW: the ONE terminal-outcome precedence for every stream translator:
+//   provider-reported failure > finished success > late watchdog fire > unfinished (client-gone / truncated).
+// A FINISHED turn beats a late watchdog fire: the poller watches the whole coroutine, which can
+// sit on the socket-EOF read AFTER the terminal frame already arrived — preferring the watchdog
+// there discards a delivered turn and retries a successful generation, the exact quota waste the
+// watchdog exists to prevent. All three dialects carried this chain in a different control
+// structure, synced only by "parity" comments (and Passthrough drifted, discarding successful
+// kimi turns); the ordering now lives here and translators supply only their states
+// (review 2026-07-22).
+package splice.spi
+
+import splice.core.turn.TurnOutcome
+
+/** The dialect-reported turn states the precedence ranks (grouped: one cohesive argument). */
+public data class TerminalStates(
+    val providerFailure: TurnOutcome?,
+    val finished: Boolean,
+    val watchdogFired: WatchdogFired?,
+)
+
+public fun terminalPrecedence(
+    states: TerminalStates,
+    onFinished: () -> TurnOutcome,
+    onWatchdog: (WatchdogFired) -> TurnOutcome,
+    onUnfinished: () -> TurnOutcome,
+): TurnOutcome = when {
+    states.providerFailure != null -> states.providerFailure
+    states.finished -> onFinished()
+    states.watchdogFired != null -> onWatchdog(states.watchdogFired)
+    else -> onUnfinished()
+}

--- a/gateway/provider-spi/src/main/kotlin/splice/spi/UpstreamClient.kt
+++ b/gateway/provider-spi/src/main/kotlin/splice/spi/UpstreamClient.kt
@@ -36,6 +36,7 @@ import splice.core.auth.RefreshableAuthProvider
 import splice.core.perf.PerfKeys
 import splice.core.perf.TurnPerf
 import splice.core.perf.timedOr
+import splice.core.util.MonoClock
 import splice.core.util.runCatchingCancellable
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
@@ -64,7 +65,10 @@ public class UpstreamClient(
         val jittered = (base * Random.nextDouble(JITTER_LO, JITTER_HI)).toLong()
         delay(jittered)
     },
-    private val clock: () -> Long = System::currentTimeMillis,
+    // Default is monotonic — a wall-clock jump must not abort a healthy retry loop (forward) or
+    // extend its deadline (backward). Same base as TurnWatchdog/InflightGate: two authorities
+    // enforce cfg.upstreamTimeoutMs and MUST NOT split-brain across clock bases (review 2026-07-22).
+    private val clock: () -> Long = MonoClock::nowMs,
 ) {
     // Shared rate-limit cooldown (one UpstreamClient per head = per upstream account). Armed by any
     // attempt that observes a 429; while armed, every post() fails fast with a synthesized 429 and

--- a/gateway/provider-spi/src/main/kotlin/splice/spi/Watchdog.kt
+++ b/gateway/provider-spi/src/main/kotlin/splice/spi/Watchdog.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import splice.core.turn.WatchdogBudget
+import splice.core.util.MonoClock
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
@@ -28,7 +29,8 @@ public sealed class WatchdogFired {
 
 public class TurnWatchdog(
     private val budget: WatchdogBudget,
-    private val clock: () -> Long = System::currentTimeMillis,
+    // Default is monotonic — sleep/wake/NTP must not invent stalls or freeze totalCap.
+    private val clock: () -> Long = MonoClock::nowMs,
 ) {
     private val sawFirstByte = AtomicBoolean(false)
     private val firedRef = AtomicReference<WatchdogFired?>(null)

--- a/gateway/provider-spi/src/test/kotlin/SingleFlightTest.kt
+++ b/gateway/provider-spi/src/test/kotlin/SingleFlightTest.kt
@@ -3,9 +3,11 @@
 // refresh; and N followers coalesce onto ONE run (the re-election design regressed this to one run
 // per follower). UnconfinedTestDispatcher = eager execution so callers actually coalesce before the
 // gate opens.
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -132,5 +134,31 @@ class SingleFlightTest {
         assertEquals(1, sf.run { runs.incrementAndGet() }) // wave 1
         assertEquals(2, sf.run { runs.incrementAndGet() }) // wave 2 — fresh, not the cached 1
         assertEquals(2, runs.get())
+    }
+
+    @Test
+    fun `close cancels an in-flight refresh so a lifecycle owner can stop it`() = runTest(UnconfinedTestDispatcher()) {
+        // Distinct from a single caller's await cancellation: a LIFECYCLE owner (daemon stop) must
+        // be able to cancel the shared refresh so it cannot complete/persist after shutdown.
+        val sf = SingleFlight<Int>(UnconfinedTestDispatcher(testScheduler))
+        val started = CompletableDeferred<Unit>()
+        var blockCancelled = false
+        // A CancellationException in a child launch is that child's own cancellation and does not
+        // fail the parent, so join() returns normally once close() cancels the shared refresh.
+        val waiter = launch {
+            sf.run {
+                started.complete(Unit)
+                try {
+                    awaitCancellation()
+                } catch (e: CancellationException) {
+                    blockCancelled = true
+                    throw e
+                }
+            }
+        }
+        started.await()
+        sf.close()
+        waiter.join()
+        assertTrue(blockCancelled, "close() must cancel the in-flight refresh block")
     }
 }


### PR DESCRIPTION
## What

Closes the findings from a full-stack adversarial review of the gateway, across **three** review passes. Round 1 (`e8bdee5`, already on the branch) fixed the initial 15 findings; the two follow-up commits close the second-order gaps that re-review surfaced in those fixes.

**Do not merge yet** — a separate review agent will run over this branch first.

## Review method

Each pass was a multi-angle review (line-by-line, removed-behavior, cross-file, language-pitfall, wrapper/proxy, plus cleanup/altitude/conventions angles) → adversarial per-finding verification (each verifier instructed to *refute* the finding) → gap sweep. Round 3 was implemented via a fenced multi-agent workflow and every fix was independently re-verified for closure and self-introduced regressions.

## Findings closed

### Correctness
| Area | Fix |
|---|---|
| Chat tool_calls double-harvest | final-message harvest is gap-fill only; a name-only-in-final entry merges into its pending slot by id |
| SseEmitter stranded seal | single tri-state (OPEN/ENDING/ENDED); the claim releases on any mid-terminal failure so the cancellation seal can still end honestly |
| count_tokens starvation | off the turn gate; fast-fail materialization lease bounds memory instead |
| Write-timeout slot pinning | `WRITE_TIMEOUT_S` 300→60 (a pending write blocked 60s is a dead reader, not a slow one) |
| MonoClock split-brain | `UpstreamClient` retry deadline moved onto the monotonic clock with the watchdog/gate |
| Drain never converges | queue-promoted waiters are bounced (release + 529) during the stop drain |
| Stream seal misclassification | emit-first; an unwritable error frame reclassifies to `client_abort`, not a local-origin error |
| Collect-path health pollution | the cancellation seal is stream-only |
| readyHeads degraded boot | `/health` exposes `failedHeads`; protocol is `readyHeads + failedHeads == heads` |
| Text final-fold tail loss | prefix-aware fold shared by the reasoning and text channels |

### Cleanup / hardening
- Single-sourced helpers: `strOrEmpty`, `openAiToolChoice`, `bearerToken`, `terminalPrecedence`, `respondAtCapacity`, one `scheduleCoalesced` debounce lane.
- `tryWithLease<T : Any>` so `null` is unambiguously the contention signal.
- Traceless daemon-stop failures now funnel to the log via a `CoroutineExceptionHandler`.
- Rate-limit reads served from memory; per-round file-write churn coalesced.
- `TurnTerminal.hasEnded` KDoc corrected to the settled contract.

## Verification

`bash checks/gate.sh` is green: clean gradle build, all Kotlin unit tests (incl. new regression tests for the seal, tool-name merge, prefix fold, and materialization fast-fail), detekt, ast-grep walls, webui, and OSS-readiness checks.

**Not covered:** the live e2e / provider tier (needs upstream credentials) — no automated pass here exercises a real upstream turn.

## Base

Branch is 1 commit ahead of `main` (before this push) with 0 behind, verified against a fresh `origin/main` fetch — merges cleanly, no rebase needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
