### PR TITLE
ci: dependabot ignores kotlin until CodeQL supports 2.4.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,10 @@ updates:
     directory: "/gateway"
     schedule:
       interval: "weekly"
+    ignore:
+      # kotlin 2.4.x is blocked by CodeQL's Kotlin extractor (KotlinVersionTooRecentError,
+      # see #18/#37) — a required check. Unignore when CodeQL supports 2.4.x.
+      - dependency-name: "org.jetbrains.kotlin*"
     groups:
       gradle-minor-patch:
         applies-to: version-updates


### PR DESCRIPTION
The gradle minor-patch group kept re-including kotlin 2.4.10, which fails the required `codeql-java-kotlin` check (`KotlinVersionTooRecentError` — #18's documented deferral, re-confirmed on #37) and additionally needs regenerated Gradle dependency-verification metadata. This ignores `org.jetbrains.kotlin*` in the gradle ecosystem until CodeQL supports 2.4.x; the config change triggers Dependabot to recreate the group without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)