### PR TITLE
ci: dependabot ignores plugin-react majors until the webui tree is coherent

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # plugin-react majors need a coherent webui tree first (phantom root vite 6 +
+      # ts7/typescript-eslint peer conflict, frozen by npm ci) — see issue #43. Unignore
+      # after the lockfile regeneration lands.
+      - dependency-name: "@vitejs/plugin-react"
+        update-types: ["version-update:semver-major"]
     groups:
       npm-minor-patch:
         applies-to: version-updates


### PR DESCRIPTION
Companion to #43 (webui dependency-tree incoherence, found resolving #29). Ignores `@vitejs/plugin-react` majors only; minors/patches keep flowing through the npm group. Unignore when #43's lockfile regeneration lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)