### PR TITLE
feat(responses): deferred tool surface with cache-stable gateway-answered tool_search

### DIFF
--- a/gateway/app/src/main/kotlin/splice/app/Daemon.kt
+++ b/gateway/app/src/main/kotlin/splice/app/Daemon.kt
@@ -37,6 +37,7 @@ import splice.core.model.ModelCatalog
 import splice.core.topology.Dialect
 import splice.core.topology.HeadConfig
 import splice.core.topology.ProviderConfig
+import splice.core.topology.ToolSurfaceConfig
 import splice.core.topology.Topology
 import splice.core.topology.catalogFor
 import splice.core.topology.configOverrides
@@ -48,8 +49,10 @@ import splice.dialect.chat.ChatQuirks
 import splice.dialect.chat.withReasoningEffortToml
 import splice.dialect.responses.FoldConfig
 import splice.dialect.responses.ResponsesQuirks
+import splice.dialect.responses.ToolDeferralPolicy
 import splice.dialect.responses.withReasoningCacheToml
 import splice.dialect.responses.withToml
+import splice.dialect.responses.withToolSurfaceToml
 import splice.gateway.compact.CompactStats
 import splice.gateway.compact.ShadowClassifier
 import splice.gateway.head.HeadDeps
@@ -212,6 +215,35 @@ private fun resolveProviderConfig(key: String, provider: ProviderConfig, cfg: Sp
  *  Top-level (not a Daemon member): the class sits at detekt's TooManyFunctions ceiling. */
 private fun ProviderConfig.chatQuirks(base: ChatQuirks): ChatQuirks =
     base.withReasoningEffortToml(quirks.reasoningEffort)
+
+/** TOML table -> dialect policy. Null (absent table, enabled=false, or the daemon-wide kill
+ *  switch) = feature off. The mapping lives HERE, at the assembly point, so the dialect never
+ *  imports a topology config type — the same reason withToml takes primitives. Top-level (not a
+ *  Daemon member): the class sits at detekt's TooManyFunctions ceiling.
+ *
+ *  Clamped (review 2026-07-24): ToolSurfaceConfig does no validation of its own, so an operator
+ *  TOML typo (e.g. `search_limit = 0`) reached `coerceIn(1, policy.searchLimit)` in
+ *  ResponsesToolSearchController unclamped and THREW — a client-visible failed turn on every
+ *  round that searched, the one place this feature's own NEVER-BELOW-STATUS-QUO law broke.
+ *  Clamping here (like every other numeric knob — ConfigService.normalize) makes a bad value
+ *  un-armable instead of a live crash. */
+private fun toolDeferralPolicy(t: ToolSurfaceConfig?, globalOff: Boolean): ToolDeferralPolicy? = when {
+    t == null -> null
+    !t.enabled -> null
+    globalOff -> null
+    else -> ToolDeferralPolicy(
+        deferPrefixes = t.deferPrefixes,
+        defer = t.defer.toSet(),
+        eager = t.eager.toSet(),
+        minDeferred = t.minDeferred.coerceAtLeast(MIN_TOOL_SURFACE_FLOOR),
+        searchLimit = t.searchLimit.coerceIn(MIN_TOOL_SURFACE_FLOOR, MAX_TOOL_SEARCH_LIMIT),
+        searchRounds = t.searchRounds.coerceIn(MIN_TOOL_SURFACE_FLOOR, MAX_TOOL_SEARCH_ROUNDS),
+    )
+}
+
+private const val MIN_TOOL_SURFACE_FLOOR = 1
+private const val MAX_TOOL_SEARCH_LIMIT = 50
+private const val MAX_TOOL_SEARCH_ROUNDS = 5
 
 public class Daemon(
     private val topology: Topology,
@@ -453,13 +485,17 @@ public class Daemon(
 
     /** Overlay the head's TOML [providers.*.quirks] onto a provider's base quirk profile. */
     // quirks.effortCeiling is intentionally not passed: the effort ladder clamps per provider.
-    private fun ProviderConfig.responsesQuirks(base: ResponsesQuirks): ResponsesQuirks = base.withToml(
+    private fun ProviderConfig.responsesQuirks(
+        base: ResponsesQuirks,
+        cfg: SpliceConfig,
+    ): ResponsesQuirks = base.withToml(
         store = quirks.store,
         cacheKey = quirks.cacheKey,
         summaryField = quirks.summaryField,
         compactEffort = quirks.compactEffort,
         toolChoice = quirks.toolChoice,
     ).withReasoningCacheToml(quirks.reasoningCache)
+        .withToolSurfaceToml(toolDeferralPolicy(quirks.toolSurface, cfg.toolSurfaceOff))
 
     private fun responsesProvider(ctx: ProviderBuild, label: String): Wired {
         val key = ctx.key
@@ -494,7 +530,7 @@ public class Daemon(
                         replayReasoning = cfg.replayReasoning,
                         configEffort = cfg.effort,
                         configSummary = cfg.summary,
-                        quirks = providerCfg.responsesQuirks(CodexProvider.defaultQuirks()),
+                        quirks = providerCfg.responsesQuirks(CodexProvider.defaultQuirks(), cfg),
                         // Reasoning-continuation folding (codex 518n-2) — codex head ONLY; grok/openai
                         // never receive a fold config, so they stay pure passthrough.
                         foldConfig = foldConfigFrom(cfg),
@@ -540,7 +576,7 @@ public class Daemon(
                 replayReasoning = cfg.replayReasoning,
                 configEffort = cfg.effort,
                 configSummary = cfg.summary,
-                quirks = providerCfg.responsesQuirks(GrokProvider.defaultQuirks()),
+                quirks = providerCfg.responsesQuirks(GrokProvider.defaultQuirks(), cfg),
             ),
             auth,
         )
@@ -578,7 +614,7 @@ public class Daemon(
                 replayReasoning = cfg.replayReasoning,
                 configEffort = cfg.effort,
                 configSummary = cfg.summary,
-                quirks = providerCfg.responsesQuirks(GrokProvider.defaultQuirks()),
+                quirks = providerCfg.responsesQuirks(GrokProvider.defaultQuirks(), cfg),
             )
         } else {
             OpenAiResponsesProvider(
@@ -587,7 +623,7 @@ public class Daemon(
                 replayReasoning = cfg.replayReasoning,
                 configEffort = cfg.effort,
                 configSummary = cfg.summary,
-                quirks = providerCfg.responsesQuirks(OpenAiResponsesProvider.defaultQuirks()),
+                quirks = providerCfg.responsesQuirks(OpenAiResponsesProvider.defaultQuirks(), cfg),
             )
         }
         return Wired(provider, auth)

--- a/gateway/core/src/main/kotlin/splice/core/config/ConfigService.kt
+++ b/gateway/core/src/main/kotlin/splice/core/config/ConfigService.kt
@@ -223,6 +223,10 @@ public class ConfigService(
         out[Knob.CONTEXT_WINDOW_OVERRIDE.key] = positiveLong(out, Knob.CONTEXT_WINDOW_OVERRIDE)
         out[Knob.USAGE_WARN_PCT.key] = (num(out, Knob.USAGE_WARN_PCT) ?: 0L).coerceIn(0L, 100L)
         out[Knob.USAGE_WARN_TOKENS_5H.key] = clampLong(out, Knob.USAGE_WARN_TOKENS_5H, floor = 0L)
+        // anything that is not exactly "off" is "auto" — an unknown value must never silently arm
+        // a feature (the r3 invalid-env-value lesson).
+        out[Knob.TOOL_SURFACE.key] =
+            if (str(out, Knob.TOOL_SURFACE)?.trim()?.lowercase() == "off") "off" else "auto"
         return out
     }
 
@@ -325,6 +329,7 @@ public class SpliceConfig internal constructor(private val m: Map<String, Any?>)
     public val controlPort: Int get() = long(Knob.CONTROL_PORT).toInt()
     public val usageWarnPct: Int get() = long(Knob.USAGE_WARN_PCT).toInt()
     public val usageWarnTokens5h: Long get() = long(Knob.USAGE_WARN_TOKENS_5H)
+    public val toolSurfaceOff: Boolean get() = string(Knob.TOOL_SURFACE) == "off"
 
     // Colon-separated absolute paths → list; relative segments are dropped (trust boundary).
     public val statuslineGitRoots: List<String>

--- a/gateway/core/src/main/kotlin/splice/core/config/Knob.kt
+++ b/gateway/core/src/main/kotlin/splice/core/config/Knob.kt
@@ -126,6 +126,12 @@ public enum class Knob(
         restartRequired = true,
     ),
 
+    // Daemon-wide tool-surface kill switch. ONE-WAY OFF ONLY: "off" forces every head back to the
+    // full eager tool array without editing TOML; any other value honours each provider's own
+    // [providers.*.quirks.tool_surface] table. It can never turn the feature ON — forcing it on
+    // globally would arm tool_search for grok/openai heads whose backends do not serve it.
+    TOOL_SURFACE("toolSurface", KnobKind.STRING, listOf("CLAUDEX_TOOL_SURFACE"), "auto", restartRequired = true),
+
     // Per-head admission (each head is a different backend/account). Bounded by default since the
     // 2026-07-19 storm: unlimited (0) let ~650 concurrent streams OOM the 1G heap. Default 100
     // (was 48) leaves headroom for multi-agent fleets without reopening the unlimited storm.

--- a/gateway/core/src/main/kotlin/splice/core/perf/TurnPerf.kt
+++ b/gateway/core/src/main/kotlin/splice/core/perf/TurnPerf.kt
@@ -45,6 +45,12 @@ public object PerfKeys {
     /** Concurrent turns in flight on this head at admission — the live-concurrency gauge. */
     public const val INFLIGHT: String = "inflight"
 
+    // Tool-surface deferral (responses-lite tool_search) — the expected-delta instrument (#959):
+    // a deploy where TOOLS_DEFERRED stays 0 is a false landing, not a quiet success.
+    public const val TOOLS_EAGER: String = "tools_eager"
+    public const val TOOLS_DEFERRED: String = "tools_deferred"
+    public const val SEARCH_ROUNDS: String = "search_rounds"
+
     /** Mark keys in pipeline order — the aggregation and the log line render in THIS order. */
     public val markOrder: List<String> = listOf(
         RECV, PARSE, BUILD, GATE, HEADERS, FIRST_BYTE, FIRST_FRAME, FIRST_DELTA,

--- a/gateway/core/src/main/kotlin/splice/core/topology/Topology.kt
+++ b/gateway/core/src/main/kotlin/splice/core/topology/Topology.kt
@@ -115,6 +115,22 @@ public data class QuirksConfig(
      *  backends read them). null keeps the provider's own default (true); set false for strict
      *  OpenAI-compatible vendors (Fireworks — issue #21) that 400 on unrecognized fields. */
     @SerialName("reasoning_effort") val reasoningEffort: Boolean? = null,
+    /** openai-responses only: the deferred tool surface (tool_search) for responses-lite turns.
+     *  ABSENT TABLE = feature off — the reasoning_cache nullable-overlay idiom (Topology.kt:109-113). */
+    @SerialName("tool_surface") val toolSurface: ToolSurfaceConfig? = null,
+)
+
+/** openai-responses only: the deferred tool surface (tool_search) for responses-lite turns.
+ *  ABSENT TABLE = feature off — the reasoning_cache nullable-overlay idiom (Topology.kt:109-113). */
+@Serializable
+public data class ToolSurfaceConfig(
+    val enabled: Boolean = true,
+    @SerialName("defer_prefixes") val deferPrefixes: List<String> = listOf("mcp__"),
+    val defer: List<String> = emptyList(),
+    val eager: List<String> = emptyList(),
+    @SerialName("min_deferred") val minDeferred: Int = 8,
+    @SerialName("search_limit") val searchLimit: Int = 8,
+    @SerialName("search_rounds") val searchRounds: Int = 3,
 )
 
 @Serializable

--- a/gateway/core/src/main/kotlin/splice/core/turn/Turn.kt
+++ b/gateway/core/src/main/kotlin/splice/core/turn/Turn.kt
@@ -3,6 +3,7 @@
 // (tool_use > max_tokens > end_turn) is sealed inside the gateway's SseEmitter (L3-as-types).
 package splice.core.turn
 
+import kotlinx.serialization.json.JsonObject
 import kotlin.time.Duration
 
 public data class Usage(
@@ -35,6 +36,20 @@ public enum class ErrorType(public val wireName: String) {
     OVERLOADED("overloaded_error"),
 }
 
+/** A hosted tool call the round addressed to the GATEWAY (Responses `execution:"client"`), never
+ *  to Claude Code. Value-typed id so a call_id can never be confused with a tool_use id. */
+@JvmInline
+public value class ToolSearchCallId(public val v: String)
+
+public data class ToolSearchCall(
+    val callId: ToolSearchCallId,
+    val query: String,
+    val limit: Int?,
+    /** The item VERBATIM as the backend sent it — echoed into the continuation's input so the
+     *  history item is the backend's own shape, never a re-authored guess. */
+    val raw: JsonObject,
+)
+
 public sealed class TurnOutcome {
     /** Buffers ride the outcome (pinned P2-MACH slot): the gateway pipeline runs
      *  promote-to-text -> honesty gates -> mirror -> terminal AFTER the machine returns. */
@@ -50,6 +65,10 @@ public sealed class TurnOutcome {
          *  otherwise (opaque handles — the gateway forwards them to the provider's fold controller,
          *  never reads them). */
         val reasoningEnvelopes: List<String> = emptyList(),
+        /** tool_search_call items THIS round emitted. Non-empty only on a responses turn with
+         *  deferral active; the gateway never reads their contents — it hands them to the turn's
+         *  ToolSearchController (the same opaque-forwarding rule as reasoningEnvelopes). */
+        val toolSearches: List<ToolSearchCall> = emptyList(),
     ) : TurnOutcome()
 
     public data class Failure(
@@ -107,6 +126,11 @@ public data class TurnMeta(
      *  gateway reasoning cache so concurrent conversations on one head can never cross-inject
      *  (review 2026-07-24, RC-2's eli-risk-8 keying). Null (chat/passthrough) = one shared scope. */
     val conversationKey: String? = null,
+    /** Tool-surface partition sizes for THIS turn's request; null when deferral was not in play.
+     *  Non-null stamps the perf counters even at zero — a deploy where tools_deferred stays 0 is a
+     *  false landing, and it must be visible in one grep of the perf JSONL. */
+    val toolsEager: Int? = null,
+    val toolsDeferred: Int? = null,
 )
 
 /** The two-tier watchdog knobs (v35 doctrine): before first byte the idle limit is

--- a/gateway/core/src/test/kotlin/ConfigServiceTest.kt
+++ b/gateway/core/src/test/kotlin/ConfigServiceTest.kt
@@ -139,6 +139,23 @@ class ConfigServiceTest {
         assertEquals(512, nonFinite.maxQueued)
     }
 
+    // The r3 invalid-env-value lesson: an unrecognized value must never silently ARM a feature.
+    // TOOL_SURFACE normalizes to exactly "off" or "auto" — nothing else.
+    @Test
+    fun `toolSurface knob normalizes to exactly off or auto, never an unrecognized value`() {
+        assertEquals("auto", service().getConfig().asMap()["toolSurface"])
+        listOf("off", "OFF", " off ").forEach { raw ->
+            val cfg = service(env = mapOf("CLAUDEX_TOOL_SURFACE" to raw)).getConfig()
+            assertEquals("off", cfg.asMap()["toolSurface"])
+            assertTrue(cfg.toolSurfaceOff)
+        }
+        listOf("on", "true", "garbage").forEach { raw ->
+            val cfg = service(env = mapOf("CLAUDEX_TOOL_SURFACE" to raw)).getConfig()
+            assertEquals("auto", cfg.asMap()["toolSurface"])
+            assertEquals(false, cfg.toolSurfaceOff)
+        }
+    }
+
     @Test
     fun `maxQueued env alias applies`() {
         val svc = service(env = mapOf("CLAUDEX_MAX_QUEUED" to "50"))

--- a/gateway/core/src/test/kotlin/TopologyConfigOverridesTest.kt
+++ b/gateway/core/src/test/kotlin/TopologyConfigOverridesTest.kt
@@ -1,4 +1,5 @@
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import splice.core.config.ConfigService
 import splice.core.config.StatePaths
@@ -8,6 +9,8 @@ import splice.core.topology.DaemonConfig
 import splice.core.topology.Dialect
 import splice.core.topology.HeadConfig
 import splice.core.topology.ProviderConfig
+import splice.core.topology.QuirksConfig
+import splice.core.topology.ToolSurfaceConfig
 import splice.core.topology.Topology
 import splice.core.topology.catalogFor
 import splice.core.topology.configOverrides
@@ -76,5 +79,38 @@ class TopologyConfigOverridesTest {
         val catalog = provider.catalogFor(head, contextWindowOverride = 333_000)
         assertEquals(333_000, catalog.contextWindowFor("toml-codex"))
         assertEquals(333_000, catalog.contextWindowFor("future-model"))
+    }
+
+    // [providers.*.quirks.tool_surface] — the nullable-overlay idiom (Topology.kt): an absent
+    // table parses to null, and a present table carries every field through untouched. The
+    // TOML->ToolDeferralPolicy mapping itself (toolDeferralPolicy, incl. the enabled=false and
+    // daemon-wide-off cases) lives in :app's Daemon.kt and cannot be reached from :core — this
+    // pins the shape :app's mapper reads.
+    @Test
+    fun `tool_surface quirks table - absent parses null, present carries every field`() {
+        val absent = topology.providers.getValue("codex").quirks.toolSurface
+        assertNull(absent)
+
+        val withTable = topology.providers.getValue("codex").copy(
+            quirks = QuirksConfig(
+                toolSurface = ToolSurfaceConfig(
+                    enabled = true,
+                    deferPrefixes = listOf("mcp__"),
+                    defer = listOf("Task"),
+                    eager = listOf("mcp__exa__web_search_exa"),
+                    minDeferred = 6,
+                    searchLimit = 5,
+                    searchRounds = 2,
+                ),
+            ),
+        )
+        val table = withTable.quirks.toolSurface!!
+        assertEquals(true, table.enabled)
+        assertEquals(listOf("mcp__"), table.deferPrefixes)
+        assertEquals(listOf("Task"), table.defer)
+        assertEquals(listOf("mcp__exa__web_search_exa"), table.eager)
+        assertEquals(6, table.minDeferred)
+        assertEquals(5, table.searchLimit)
+        assertEquals(2, table.searchRounds)
     }
 }

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/Harvested.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/Harvested.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import splice.core.turn.ToolSearchCall
 import splice.core.turn.Usage
 import splice.core.util.strOrEmpty
 
@@ -99,6 +100,21 @@ private fun messageText(item: JsonObject): String {
     }
     return out.toString()
 }
+
+/** tool_search_call items on the completed response object — the same walk [harvestResponsesOutput]
+ *  performs, filtered to tool_search_call, reusing [parseToolSearchCall] (ResponsesStreamTranslator.kt)
+ *  so there is ONE parser, not two (the v29 copies-drift law). Recovers a round the live
+ *  output_item.done capture missed (delivered ONLY on the terminal object, no per-item events). */
+internal fun harvestToolSearchCalls(resp: JsonObject?): List<ToolSearchCall> {
+    val output = resp?.get("output") as? JsonArray ?: return emptyList()
+    return output.asSequence()
+        .filterIsInstance<JsonObject>()
+        .filter { strOrEmpty(it["type"]) == TYPE_TOOL_SEARCH_CALL }
+        .mapNotNull(::parseToolSearchCall)
+        .toList()
+}
+
+private const val TYPE_TOOL_SEARCH_CALL = "tool_search_call"
 
 /** Usage extraction: input/output plus the prompt-cache read (input_tokens_details.cached_tokens,
  *  with the flat cache_read_input_tokens as the fallback) — so the real cache hit rate is visible. */

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesProvider.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesProvider.kt
@@ -76,9 +76,17 @@ public abstract class ResponsesProvider(
                         null
                     }
                 },
+                // The provider's capability latch, read at build time: false = a shape-400 already
+                // closed it this daemon lifetime; build the full status-quo request instead.
+                toolSurfaceOpen = toolSurfaceLatch.open,
             ),
         )
-        return BuiltTurn(built.req, built.meta, perTurnHeaders(sessionId) + liteHeaders(built.meta))
+        return BuiltTurn(
+            built.req,
+            built.meta,
+            perTurnHeaders(sessionId) + liteHeaders(built.meta),
+            toolSearch = built.toolSearch,
+        )
     }
 
     /** codex-rs sends this marker header for responses-lite (5.6-family) turns; compact turns keep
@@ -137,13 +145,21 @@ public abstract class ResponsesProvider(
     // cache per provider instance; capture and lookup wire in via buildTurn/streamTranslator.
     private val reasoningCache: ReasoningCache = ReasoningCache()
 
+    // The tool-surface capability latch (§1.3/§5.3): one AtomicBoolean per provider instance,
+    // moving in exactly one direction — toward status quo. Read at build time (buildTurn), closed
+    // by amendBodyOnFailure on a shape-400.
+    private val toolSurfaceLatch = ToolSurfaceLatch()
+
     /** RC-4: a 400 rejecting stale encrypted reasoning strips the injected items and retries
-     *  once (NEVER-BELOW-STATUS-QUO law); every other failure keeps the plain retry plan.
+     *  once (NEVER-BELOW-STATUS-QUO law); every other failure keeps the plain retry plan. A 400
+     *  rejecting the tool-surface shape strips the tool_search entry, retries once, and closes the
+     *  latch so every LATER turn on this provider instance builds the full status-quo request.
      *  Keyed off the SAME classifier as the retry plan's GIVE_UP (review 2026-07-24: a narrower
      *  literal match here let any upstream wording drift skip the recovery entirely). */
-    final override fun amendBodyOnFailure(status: Int, responseText: String, bodyJson: String): String? {
-        if (!UpstreamClient.isEncryptedContentError(status, responseText)) return null
-        return stripStaleReasoning(bodyJson, reasoningCache)
+    final override fun amendBodyOnFailure(status: Int, responseText: String, bodyJson: String): String? = when {
+        UpstreamClient.isEncryptedContentError(status, responseText) -> stripStaleReasoning(bodyJson, reasoningCache)
+        isToolSurfaceRejection(status, responseText) -> dropToolSearchTool(bodyJson)?.also { toolSurfaceLatch.close() }
+        else -> null
     }
 
     // The controller is stateless — one cached instance serves every turn (a per-call

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesProvider.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesProvider.kt
@@ -155,11 +155,32 @@ public abstract class ResponsesProvider(
      *  rejecting the tool-surface shape strips the tool_search entry, retries once, and closes the
      *  latch so every LATER turn on this provider instance builds the full status-quo request.
      *  Keyed off the SAME classifier as the retry plan's GIVE_UP (review 2026-07-24: a narrower
-     *  literal match here let any upstream wording drift skip the recovery entirely). */
+     *  literal match here let any upstream wording drift skip the recovery entirely).
+     *  Honesty gap (review 2026-07-25, [ToolSurfaceLatch]'s KDoc has the full account): the amend
+     *  return value here is eager-only for THIS turn — this function only ever sees
+     *  (status, responseText, bodyJson), never the [ToolPartition] that would let it re-attach the
+     *  deferred tools' schemas, so the recovery turn runs one turn below full status quo before
+     *  the latch restores every later turn. [logToolSurfaceLatchClosed] makes that one-time degrade
+     *  observable instead of silent. */
     final override fun amendBodyOnFailure(status: Int, responseText: String, bodyJson: String): String? = when {
         UpstreamClient.isEncryptedContentError(status, responseText) -> stripStaleReasoning(bodyJson, reasoningCache)
-        isToolSurfaceRejection(status, responseText) -> dropToolSearchTool(bodyJson)?.also { toolSurfaceLatch.close() }
+        isToolSurfaceRejection(status, responseText) -> dropToolSearchTool(bodyJson)?.also {
+            if (toolSurfaceLatch.close()) logToolSurfaceLatchClosed()
+        }
         else -> null
+    }
+
+    /** The latch's one observable signal — stderr, the same `[tag] message` idiom
+     *  ApiKeyAuthProvider.kt uses for standalone diagnostics (no injected logger reaches this
+     *  module; see [ToolSurfaceLatch]). Guarded by [ToolSurfaceLatch.close]'s CAS return, so this
+     *  fires EXACTLY ONCE per provider instance — never once per turn, since every turn after the
+     *  close reads the latch already-closed and never re-enters this branch. */
+    private fun logToolSurfaceLatchClosed() {
+        System.err.println(
+            "[${quirks.providerTag}] tool-surface latch closed: backend rejected the tool_search " +
+                "shape; this turn recovered eager-only (one turn below status quo), every later turn " +
+                "on this provider instance builds the full eager surface.",
+        )
     }
 
     // The controller is stateless — one cached instance serves every turn (a per-call

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesRequestBuilder.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesRequestBuilder.kt
@@ -55,6 +55,7 @@ import splice.core.wire.ToolResultBlock
 import splice.core.wire.ToolUseBlock
 import splice.core.wire.UnknownBlock
 import splice.core.wire.openAiToolChoice
+import splice.spi.ToolSearchController
 import java.security.MessageDigest
 
 /** The finite quirk surface separating codex / xai / openai-platform on this dialect. */
@@ -77,11 +78,23 @@ public data class ResponsesQuirks(
     val responsesLiteModelRegex: Regex? = Regex("gpt-5\\.6", RegexOption.IGNORE_CASE),
     val compactEffortPin: String? = null, // null = inherit session effort (the cache law)
     val emitToolChoice: Boolean = false,
+    /** Passes through a tool's own `strict == true` as `"strict": true`; false (the default,
+     *  and the only value that has ever mattered — Claude Code's ToolDefinition.strict is always
+     *  null) omits the field entirely. Distinct from [forceStrictFalse] below (review 2026-07-24:
+     *  conflating the two silently changed grok's live wire bytes when this feature landed). */
     val emitStrict: Boolean = false,
+    /** codex-rs parity: hard-sets `strict:false` on EVERY function tool object regardless of the
+     *  tool's own value (responses_api.rs:29-32; OpenCode does the same, marked "Codex parity").
+     *  false (the default) leaves [emitStrict]'s pass-through behavior as the only effect, exactly
+     *  today's behavior. Only CodexProvider sets this true. */
+    val forceStrictFalse: Boolean = false,
     /** RC-5 (reasoning-cache 2026-07-24): gateway-held reasoning continuity for tool
      *  round-trips (codex parity — repeated tool calls / duplicated reasoning without it).
      *  Off restores the pre-cache amnesia behavior exactly. */
     val reasoningCache: Boolean = true,
+    /** Deferred tool surface (tool_search) for responses-lite turns. NULL = off, and off is the
+     *  shipped default for every provider — the request is byte-identical to today. */
+    val toolSurface: ToolDeferralPolicy? = null,
     /** stream_options.reasoning_summary_delivery, sent only when a summary is requested. The
      *  ChatGPT backend serves ~2.3x more titled summary sections with "sequential_cutoff"
      *  (probed 2026-07-19: 30 parts/1546ch vs 14/646 on the same prompt) — the same value
@@ -123,7 +136,29 @@ public fun ResponsesQuirks.withReasoningCacheToml(reasoningCache: Boolean?): Res
 
 public enum class EffortLadder { CODEX, GROK }
 
-public data class BuiltRequest(val req: JsonObject, val meta: TurnMeta)
+public data class BuiltRequest(val req: JsonObject, val meta: TurnMeta, val toolSearch: ToolSearchController? = null)
+
+/** [buildRequestObject]'s internal return — the request bytes plus the tool-surface facts only
+ *  the builder knows (the partition sizes for TurnMeta, the search controller for BuiltRequest).
+ *  Keeping these OFF buildRequestObject's parameter list is why it stays under LongParameterList's
+ *  function threshold instead of growing a 6th argument. */
+internal data class BuiltBody(
+    val req: JsonObject,
+    val toolSearch: ToolSearchController?,
+    val toolsEager: Int?,
+    val toolsDeferred: Int?,
+)
+
+/** The pieces [ResponsesRequestBuilder.build] computes before the DTO is assembled, bundled as one
+ *  argument — the INPUT-side sibling of [BuiltBody], and for the same reason: `partition` was the
+ *  6th parameter that tripped LongParameterList (review 2026-07-25). Bundling, not dropping: every
+ *  field is still read verbatim by buildRequestObject. */
+internal data class RequestParts(
+    val input: JsonArray,
+    val instructions: String,
+    val reasoning: JsonObject?,
+    val partition: ToolPartition?,
+)
 
 public data class BuildOptions(
     public val compact: Boolean,
@@ -150,6 +185,9 @@ public data class BuildOptions(
      *  ordered envelopes of the turn that emitted it. Null = miss = today's behavior exactly.
      *  Wired by the provider; the default keeps unwired builds byte-identical. */
     public val reasoningLookup: (String) -> List<String>? = { null },
+    /** The provider's tool-surface capability latch, read at build time. False = the backend
+     *  rejected the shape on this daemon lifetime; build the full status-quo request. */
+    public val toolSurfaceOpen: Boolean = true,
 ) {
     /** Per-REQUEST rs_-id dedup across BOTH injection paths (cache + legacy client replay):
      *  upstream 400s a duplicated reasoning id, and one turn's entry is shared by all its
@@ -159,6 +197,13 @@ public data class BuildOptions(
      *  sharing dedup state between two requests — here every instance, copies included,
      *  initializes its own fresh set, and equals/hashCode never see it. */
     public val injectedReasoningIds: MutableSet<String> = mutableSetOf()
+
+    /** Per-REQUEST dedup for the declaration-replay injection (CHANGE 2, cache-prefix stability
+     *  2026-07-25): a deferred tool's schema is declared AT MOST ONCE per request, immediately
+     *  before the FIRST function_call in this turn's input that uses it. Same must-be-a-body-
+     *  property law as [injectedReasoningIds] just above (a constructor default would be ALIASED
+     *  by copy() — defaults are not re-evaluated — silently sharing dedup state between requests). */
+    public val injectedToolDeclarationNames: MutableSet<String> = mutableSetOf()
 }
 
 public class ResponsesRequestBuilder(private val quirks: ResponsesQuirks) {
@@ -166,9 +211,16 @@ public class ResponsesRequestBuilder(private val quirks: ResponsesQuirks) {
     private val inputBuilder = ResponsesInputBuilder(quirks)
 
     public fun build(body: AnthropicRequest, raw: JsonObject, opts: BuildOptions): BuiltRequest {
+        // Partition FIRST, before the message walk: it is a pure function of (body.tools, policy)
+        // ONLY (ToolSurface.kt header) and the declaration-replay injection below needs to know,
+        // per ToolUseBlock, whether that tool is THIS request's deferred set — moving it earlier
+        // costs nothing (buildRequestObject no longer recomputes it) and keeps position 0 of the
+        // wire input untouched by anything the walk discovers.
+        val partition = if (!opts.compact && body.tools.isNotEmpty()) quirks.partitionTools(body, opts) else null
+        val declareByName = declarationCandidates(body, partition)
         val input = buildJsonArray {
             for (msg in body.messages) {
-                inputBuilder.appendMessage(this, msg, opts)
+                inputBuilder.appendMessage(this, msg, opts, declareByName)
             }
         }
         val instructions = compactAwareInstructions(body.system, opts.compact)
@@ -176,7 +228,7 @@ public class ResponsesRequestBuilder(private val quirks: ResponsesQuirks) {
         val summary = resolveSummary(raw, opts, effort)
         val reasoning = reasoningBlock(effort, summary, opts)
 
-        val req = buildRequestObject(body, opts, input, instructions, reasoning)
+        val built = buildRequestObject(body, opts, RequestParts(input, instructions, reasoning, partition))
         // meta.summary reflects what was ACTUALLY sent (spark drops it → "none"), like Node's
         // `req.reasoning?.summary ?? 'none'` — not the computed-but-maybe-dropped value.
         val sentSummary = reasoning?.get(FIELD_SUMMARY).str() ?: "none"
@@ -194,22 +246,19 @@ public class ResponsesRequestBuilder(private val quirks: ResponsesQuirks) {
             // The reasoning cache's conversation scope — the SAME derivation the provider's
             // lookup closure uses, so capture (which only sees TurnMeta) and injection agree.
             conversationKey = stablePromptCacheKey(body),
+            toolsEager = built.toolsEager,
+            toolsDeferred = built.toolsDeferred,
         )
-        return BuiltRequest(req, meta)
+        return BuiltRequest(built.req, meta, built.toolSearch)
     }
 
-    private fun buildRequestObject(
-        body: AnthropicRequest,
-        opts: BuildOptions,
-        input: JsonArray,
-        instructions: String,
-        reasoning: JsonObject?,
-    ): JsonObject {
+    private fun buildRequestObject(body: AnthropicRequest, opts: BuildOptions, parts: RequestParts): BuiltBody {
         // TIER-1 (#924): the request is a CLOSED DTO, not a hand-assembled JsonObject. A Chat-only
         // knob (stream_options.include_usage — the codex-breaking incident) cannot be added without a
         // field on ResponsesRequest, a reviewable type change. Byte-identical to the old put() set
         // (ResponsesRequestBuilderTest pins it): fields in declaration order, null optionals omitted.
-        val tools = if (!opts.compact && body.tools.isNotEmpty()) toolsArray(body) else null
+        val searchLimit = quirks.toolSurface?.searchLimit ?: DEFAULT_SEARCH_LIMIT
+        val tools = parts.partition?.let { toolsSection(it, quirks.emitStrict, quirks.forceStrictFalse, searchLimit) }
         val lite = quirks.isLite(opts)
         // Lite turns carry tools as an additional_tools input item, not top-level `tools`; without
         // an explicit tool_choice the backend never enables function-calling from them (the model
@@ -219,7 +268,7 @@ public class ResponsesRequestBuilder(private val quirks: ResponsesQuirks) {
         val emitToolChoice = tools != null && (quirks.emitToolChoice || lite)
         val include =
             if (!opts.compact && opts.includeEncryptedReasoning.v) listOf(ENCRYPTED_CONTENT_INCLUDE) else null
-        val shape = wireShape(lite, input, instructions, tools)
+        val shape = wireShape(lite, parts.input, parts.instructions, tools)
         val dto = ResponsesRequest(
             model = opts.upstreamModel,
             input = shape.input,
@@ -231,32 +280,53 @@ public class ResponsesRequestBuilder(private val quirks: ResponsesQuirks) {
             tools = shape.tools,
             toolChoice = toolChoiceFor(emitToolChoice, lite, body),
             parallelToolCalls = parallelToolCallsFor(emitToolChoice, body, opts),
-            reasoning = reasoning,
-            streamOptions = summaryDeliveryOptions(reasoning),
+            reasoning = parts.reasoning,
+            streamOptions = summaryDeliveryOptions(parts.reasoning),
         )
-        return responsesRequestJson.encodeToJsonElement(ResponsesRequest.serializer(), dto) as JsonObject
+        val req = responsesRequestJson.encodeToJsonElement(ResponsesRequest.serializer(), dto) as JsonObject
+        // Stamped only when a policy is actually CONFIGURED for this provider (quirks.toolSurface
+        // != null) — never for every provider globally just because tools rode this turn. A
+        // configured-but-not-triggering turn (wrong model, latch closed, below the floor) still
+        // stamps 0, which is the real "why no deferral happened" signal the perf JSONL needs.
+        val surfaceInPlay = parts.partition?.takeIf { quirks.toolSurface != null }
+        return BuiltBody(
+            req = req,
+            toolSearch = toolSearchControllerFor(parts.partition, opts),
+            toolsEager = surfaceInPlay?.eager?.size,
+            toolsDeferred = surfaceInPlay?.deferred?.size,
+        )
     }
 
     // ── tools ────────────────────────────────────────────────────────────────
 
-    private fun toolsArray(body: AnthropicRequest) = buildJsonArray {
-        for (t in body.tools) add(toolObject(t))
+    /** Non-null only when this request actually deferred something — a bare partition (deferral
+     *  off, non-lite, below the floor) yields an empty deferred list, so [ToolPartition.deferring]
+     *  is the single source both this and [toolsSection] read. */
+    private fun toolSearchControllerFor(partition: ToolPartition?, opts: BuildOptions): ToolSearchController? {
+        val policy = quirks.toolSurface ?: return null
+        if (partition == null || !partition.deferring) return null
+        return ResponsesToolSearchController(
+            index = ToolSearchIndex(partition.deferred),
+            policy = policy,
+            emitStrict = quirks.emitStrict,
+            forceStrictFalse = quirks.forceStrictFalse,
+            decodeReasoningEnvelope = opts.decodeReasoningEnvelope,
+        )
     }
 
-    private fun toolObject(t: ToolDefinition): JsonObject = buildJsonObject {
-        put("type", FIELD_FUNCTION)
-        put("name", t.name)
-        put("description", t.description ?: "")
-        // Both Node references send `properties:{}` on a bare object schema; some strict
-        // validators reject an object schema without it (audit 2026-07-18).
-        put(
-            "parameters",
-            t.inputSchema ?: buildJsonObject {
-                put("type", "object")
-                put("properties", buildJsonObject { })
-            },
-        )
-        if (quirks.emitStrict && t.strict == true) put("strict", true)
+    /** The declaration-replay input for CHANGE 2 (cache-prefix stability, 2026-07-25): every
+     *  DEFERRED tool this turn's transcript already named via a ToolUseBlock, keyed by name so
+     *  [ResponsesInputBuilder] can hand its full schema straight to the injector without a second
+     *  body.tools lookup. [warmToolNames] used to gate the (now-removed) always-eager promotion in
+     *  ToolSurface.kt; it feeds this instead — see that file's header. A tool warm but NOT in this
+     *  map (eager, or dropped from body.tools since it was last used) gets no declaration on
+     *  purpose: eager tools are already declared via tools[] every turn, and a dropped tool has no
+     *  schema to declare — the degrade-to-status-quo path [appendToolUse] documents. */
+    private fun declarationCandidates(body: AnthropicRequest, partition: ToolPartition?): Map<String, ToolDefinition> {
+        val deferred = partition?.deferred
+        if (deferred.isNullOrEmpty()) return emptyMap()
+        val warm = warmToolNames(body)
+        return deferred.filter { it.name in warm }.associateBy { it.name }
     }
 
     /** Lite pins "auto" (the only value codex-rs validated against additional_tools — client.rs:896);
@@ -415,9 +485,10 @@ private class ResponsesInputBuilder(private val quirks: ResponsesQuirks) {
         sink: JsonArrayBuilder,
         msg: AnthropicMessage,
         opts: BuildOptions,
+        declareByName: Map<String, ToolDefinition>,
     ) {
         for (block in msg.content) {
-            appendBlock(sink, msg.role, block, opts)
+            appendBlock(sink, msg.role, block, opts, declareByName)
         }
     }
 
@@ -426,13 +497,14 @@ private class ResponsesInputBuilder(private val quirks: ResponsesQuirks) {
         role: String,
         block: ContentBlock,
         opts: BuildOptions,
+        declareByName: Map<String, ToolDefinition>,
     ) {
         when (block) {
             is TextBlock -> sink.add(roleText(role, block.text))
             is ImageBlock -> appendImage(sink, block, opts)
             is DocumentBlock -> appendDocument(sink, block, opts)
             is RedactedThinkingBlock -> appendRedactedThinking(sink, block, opts)
-            is ToolUseBlock -> appendToolUse(sink, block, opts)
+            is ToolUseBlock -> appendToolUse(sink, block, opts, declareByName)
             is ToolResultBlock -> appendToolResult(sink, block, opts)
             is ThinkingBlock -> Unit // visible thinking never rides back upstream
             is UnknownBlock -> Unit // unknown client blocks are dropped, never crash
@@ -477,8 +549,20 @@ private class ResponsesInputBuilder(private val quirks: ResponsesQuirks) {
         sink: JsonArrayBuilder,
         block: ToolUseBlock,
         opts: BuildOptions,
+        declareByName: Map<String, ToolDefinition>,
     ) {
         if (opts.compact) return
+        // CHANGE 2 (cache-prefix stability, 2026-07-25): a DEFERRED tool this block names gets its
+        // full schema declared IN HISTORY, ONCE per request, immediately before this function_call
+        // — the model then knows it from tool_search_output, never from a moving tools[] entry
+        // (ToolSurface.kt header). Absent from declareByName means the tool is either already eager
+        // (declared normally, nothing to add) or was dropped from body.tools entirely since it was
+        // last used (no schema exists to declare) — either way this is a no-op and the function_call
+        // rides exactly like an eager tool's: degrade to status quo, never crash, never an
+        // undeclared tool_search reference.
+        declareByName[block.name]?.let { tool ->
+            if (opts.injectedToolDeclarationNames.add(tool.name)) appendToolDeclaration(sink, tool)
+        }
         // RC-3: reinject the turn's cached reasoning ONCE, immediately before its FIRST
         // function_call — the API rejects both an orphaned reasoning item and a function_call
         // whose reasoning was dropped (the replay_reasoning=false amnesia class this fixes).
@@ -494,6 +578,26 @@ private class ResponsesInputBuilder(private val quirks: ResponsesQuirks) {
                 put("arguments", block.input.toString())
             },
         )
+    }
+
+    /** The synthetic pair CHANGE 2 injects for a deferred tool a ToolUseBlock already named: a
+     *  tool_search_call, then the tool_search_output carrying its FULL schema — the exact shape
+     *  [ResponsesToolSearchController] emits for a REAL within-turn search, reused via
+     *  [toolSearchOutputItem] (ResponsesToolSearch.kt) and never re-authored as a second shape. The
+     *  call_id is a pure function of the tool NAME alone ([stableToolSearchCallId]) — no transcript
+     *  position, no counters, no randomness — so the whole pair is byte-identical on every turn
+     *  that replays this tool's declaration, which is the property this feature exists to buy. */
+    private fun appendToolDeclaration(sink: JsonArrayBuilder, tool: ToolDefinition) {
+        val callId = stableToolSearchCallId(tool.name)
+        sink.add(
+            buildJsonObject {
+                put("type", "tool_search_call")
+                put("call_id", callId)
+                put("execution", "client")
+                put("arguments", buildJsonObject { put("query", tool.name) }.toString())
+            },
+        )
+        sink.add(toolSearchOutputItem(callId, listOf(tool), quirks.emitStrict, quirks.forceStrictFalse))
     }
 
     private fun appendImage(sink: JsonArrayBuilder, block: ImageBlock, opts: BuildOptions) {
@@ -587,7 +691,6 @@ private const val FIELD_CONTENT = "content"
 private const val FIELD_EFFORT = "effort"
 private const val FIELD_SUMMARY = "summary"
 private const val FIELD_REASONING = "reasoning"
-private const val FIELD_FUNCTION = "function"
 
 // Data-URL pieces for base64 image parts (capacity math uses their lengths — no magic numbers).
 private const val DATA_URL_PREFIX = "data:"
@@ -628,6 +731,28 @@ private val HEX_DIGITS = "0123456789abcdef".toCharArray()
 
 // MessageDigest is not thread-safe; a ThreadLocal avoids the provider lookup per turn without sharing.
 private val SHA256 = ThreadLocal.withInitial { MessageDigest.getInstance("SHA-256") }
+
+/** CHANGE 2's call_id (cache-prefix stability, 2026-07-25): a pure function of the tool NAME
+ *  alone — same sha256-hex-prefix idiom as [stablePromptCacheKey] just above, so a deferred
+ *  tool's declaration pair carries the identical call_id on every turn it is replayed on (no
+ *  transcript position, no counters, no randomness — any of those would reintroduce the exact
+ *  cache bust this feature exists to fix). */
+internal fun stableToolSearchCallId(toolName: String): String {
+    val md = SHA256.get()
+    md.reset()
+    val digest = md.digest(toolName.toByteArray(Charsets.UTF_8))
+    val hexChars = CharArray(CALL_ID_HEX_LEN)
+    var hi = 0
+    for (i in 0 until CALL_ID_HEX_LEN / 2) {
+        val b = digest[i].toInt() and BYTE_MASK
+        hexChars[hi++] = HEX_DIGITS[b ushr NIBBLE_BITS]
+        hexChars[hi++] = HEX_DIGITS[b and NIBBLE_MASK]
+    }
+    return CALL_ID_PREFIX + String(hexChars)
+}
+
+private const val CALL_ID_PREFIX = "ts_decl_"
+private const val CALL_ID_HEX_LEN = 24
 
 // the alias table IS the contract
 public fun normalizeEffort(raw: String?, ladder: EffortLadder): String? {

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesStreamTranslator.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesStreamTranslator.kt
@@ -19,10 +19,14 @@ package splice.dialect.responses
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import splice.core.index.WireBlockIndex
 import splice.core.turn.ErrorType
+import splice.core.turn.ToolSearchCall
+import splice.core.turn.ToolSearchCallId
 import splice.core.turn.TurnOutcome
 import splice.core.turn.Usage
 import splice.core.turn.isWeakSummaryText
@@ -252,6 +256,10 @@ public class ResponsesStreamTranslator(private val ctx: StreamTurnContext) : Str
         bodyText = reducer.textBuf.toString(),
         emittedText = reducer.emittedText,
         reasoningEnvelopes = reducer.reasoningEnvelopes.toList(),
+        // The harvest fallback runs ONLY when the streamed list is empty (needs no dedup): a round
+        // that emitted only a search call and was missed by the live capture would otherwise
+        // produce a client-visible empty turn through the honesty gate — the worst available failure.
+        toolSearches = reducer.toolSearches.ifEmpty { harvestToolSearchCalls(reducer.finalResponse) },
     )
 
     private fun harvestFallback(reducer: ResponsesEventReducer) {
@@ -277,7 +285,7 @@ public class ResponsesStreamTranslator(private val ctx: StreamTurnContext) : Str
  * upstream event family — the ported shape of stream.mjs's runStreamTurn; the translator drives
  * it and reads the accumulated state to render the terminal outcome.
  */
-private class ResponsesEventReducer(private val ctx: StreamTurnContext) {
+private class ResponsesEventReducer(val ctx: StreamTurnContext) {
 
     // Int keys: message/tool blocks use the upstream output_index directly; reasoning blocks
     // use REASONING_KEY_BASE + output_index so the two families never collide and we never
@@ -309,6 +317,10 @@ private class ResponsesEventReducer(private val ctx: StreamTurnContext) {
 
     // Reasoning-cache capture (RC-1): the round's REAL upstream function_call ids, in order.
     val turnToolIds = mutableListOf<String>()
+
+    // tool_search_call items this round emitted (deferred tool surface) — populated only when the
+    // gateway declared deferral this turn; empty otherwise (pre-deferral behaviour intact).
+    val toolSearches = mutableListOf<ToolSearchCall>()
 
     // Late-reasoning items already emitted, keyed by their reasoning block index. Substring
     // dedup on thinkingBuf dropped a DISTINCT item whose text happened to be a substring of an
@@ -388,27 +400,25 @@ private class ResponsesEventReducer(private val ctx: StreamTurnContext) {
         // avoids empty thinking widgets when a reasoning item carries no summary
     }
 
+    // Split into onItemDone + 2 file-level extensions below (detekt 2026-07-24: CyclomaticComplexMethod
+    // 11 -> the class already sits at TooManyFunctions' 14-member ceiling, so the extraction is a
+    // top-level extension on this class instead of a new member — see closeOpenBlocks/emitReplayedReasoning).
     private suspend fun onItemDone(evt: JsonObject, sink: WireSink) {
         val item = evt["item"] as? JsonObject
+        // tool_search_call has no open wire block and must not touch hasToolUse/turnToolIds — a
+        // synthetic/foreign id there would mis-key the reasoning cache (a known prior bug class).
+        if (item != null && strOrEmpty(item["type"]) == TOOL_SEARCH_CALL) {
+            captureToolSearch(this, item)
+            return
+        }
         val oi = intOr(evt[OUTPUT_INDEX]) ?: intOr(item?.get("index"))
         // Some backends only attach readable reasoning on the completed item (no per-token
         // summary deltas). Surface that text NOW so Claude Code's thinking UI fills live,
         // not only via the end-of-turn harvest fallback.
         maybeEmitLateReasoning(item, oi, sink)
-        if (oi != null) {
-            blocks[oi]?.let { sink.closeBlock(it.index) }
-            blocks[reasoningKey(oi)]?.let { sink.closeBlock(it.index) }
-            toolSalvage.closedClean(oi)
-        }
+        closeOpenBlocks(oi, sink)
         if (item == null) return
-        // Replay (gated): emit the encrypted reasoning IN POSITION — right after its summary closes
-        // and before the tool_use it preceded — so the round-trip preserves cache order. The SAME
-        // envelope also feeds fold replay (collectReasoningEnvelopes, independent of the emit flag).
-        // encodeReasoningEnvelope is non-null ONLY for a reasoning item carrying id +
-        // encrypted_content — so it doubles as the "is this a replayable reasoning item?" filter.
-        val envelope = ctx.encodeReasoningEnvelope(item) ?: return
-        if (shouldEmitReasoning(ctx, item)) sink.addRedactedThinking(envelope)
-        if (ctx.collectReasoningEnvelopes) reasoningEnvelopes.add(envelope)
+        emitReplayedReasoning(item, sink)
     }
 
     private suspend fun maybeEmitLateReasoning(item: JsonObject?, oi: Int?, sink: WireSink) {
@@ -535,12 +545,34 @@ private class ResponsesEventReducer(private val ctx: StreamTurnContext) {
         const val OUTPUT_INDEX = "output_index"
         const val DELTA = "delta"
         const val INCOMPLETE_REASON_MAX_TOKENS = "max_output_tokens"
-
-        // Leave the positive int space for message/tool output_index; reasoning lives above.
-        const val REASONING_KEY_BASE = 1_000_000
-
-        fun reasoningKey(outputIndex: Int): Int = REASONING_KEY_BASE + outputIndex
+        const val TOOL_SEARCH_CALL = "tool_search_call"
     }
+}
+
+// Leave the positive int space for message/tool output_index; reasoning lives above. Top-level
+// (not the reducer's companion, detekt 2026-07-24): onItemDone's extraction below needs it
+// unqualified from outside the class, and a private-companion member is invisible there.
+private const val REASONING_KEY_BASE = 1_000_000
+
+private fun reasoningKey(outputIndex: Int): Int = REASONING_KEY_BASE + outputIndex
+
+/** onItemDone's block-closing half (extraction, detekt 2026-07-24): close both the tool/message
+ *  block and any reasoning block at this output_index, and clear the salvage-open marker. A
+ *  top-level extension, not a reducer member — the class is already at TooManyFunctions' ceiling. */
+private suspend fun ResponsesEventReducer.closeOpenBlocks(oi: Int?, sink: WireSink) {
+    if (oi == null) return
+    blocks[oi]?.let { sink.closeBlock(it.index) }
+    blocks[reasoningKey(oi)]?.let { sink.closeBlock(it.index) }
+    toolSalvage.closedClean(oi)
+}
+
+/** onItemDone's replay half (extraction, detekt 2026-07-24): emit the encrypted reasoning IN
+ *  POSITION (gated) and collect its envelope for fold/re-anchor replay — see onItemDone's own
+ *  comment for why this rides right after the summary closes. */
+private suspend fun ResponsesEventReducer.emitReplayedReasoning(item: JsonObject, sink: WireSink) {
+    val envelope = ctx.encodeReasoningEnvelope(item) ?: return
+    if (shouldEmitReasoning(ctx, item)) sink.addRedactedThinking(envelope)
+    if (ctx.collectReasoningEnvelopes) reasoningEnvelopes.add(envelope)
 }
 
 /** Gated encrypted-reasoning EMISSION predicate — kept out of the handler so its condition stays flat. */
@@ -587,3 +619,54 @@ private fun accumulateUsage(reducer: ResponsesEventReducer, resp: JsonObject) {
     if (u.cachedTokens > 0) reducer.cachedTokens = u.cachedTokens
     if (u.reasoningTokens > 0) reducer.reasoningTokens = u.reasoningTokens
 }
+
+/** tool_search_call capture (file-level: the reducer sits at its TooManyFunctions budget, the
+ *  same accumulateUsage precedent). Deliberately does NOT touch hasToolUse/blocks/toolSalvage/
+ *  turnToolIds — a search call opens no wire block and is not a tool dispatch. */
+private fun captureToolSearch(reducer: ResponsesEventReducer, item: JsonObject) {
+    parseToolSearchCall(item)?.let { reducer.toolSearches.add(it) }
+}
+
+/** Parses one tool_search_call item into a [ToolSearchCall], or null when it should be skipped
+ *  (server-executed — execution:"server" means the backend already answered, protocol/src/
+ *  models.rs:3693-3728 — or carries no call_id). The ONE parser shared by the live capture above
+ *  and the terminal-object harvest fallback ([harvestToolSearchCalls] in Harvested.kt) — never two
+ *  hand-rolled readers of the same shape (the v29 copies-drift law). */
+internal fun parseToolSearchCall(item: JsonObject): ToolSearchCall? {
+    val execution = strOrEmpty(item["execution"])
+    if (execution.isNotEmpty() && execution != TOOL_SEARCH_EXECUTION_CLIENT) return null
+    // NB: no `id` fallback here (unlike function_call's onItemAdded) — call.raw is echoed
+    // VERBATIM into the continuation, so a synthesized id would produce a tool_search_output
+    // keyed by a value the echoed call itself doesn't carry: an unpairable item the backend
+    // 400s (review 2026-07-24). Skipping is the spec behavior and matches codex-rs's own
+    // catch-all (a client-execution call always carries call_id; this is defensive-only).
+    val callId = strOrEmpty(item["call_id"])
+    if (callId.isEmpty()) return null
+    val (query, limit) = parseToolSearchArguments(item["arguments"])
+    return ToolSearchCall(callId = ToolSearchCallId(callId), query = query, limit = limit, raw = item)
+}
+
+/** `arguments` is a real JSON object on this item type (unlike function_call, where it is a
+ *  string) — a string is accepted defensively and parsed. Unparseable/absent arguments yield
+ *  query="" (answered exhaustively downstream) rather than dropping the call. */
+private fun parseToolSearchArguments(arguments: JsonElement?): Pair<String, Int?> {
+    val obj = when (arguments) {
+        is JsonObject -> arguments
+        is JsonPrimitive -> parseArgumentsString(strOrEmpty(arguments))
+        else -> null
+    } ?: return "" to null
+    return strOrEmpty(obj["query"]) to intOr(obj["limit"])
+}
+
+private fun parseArgumentsString(text: String): JsonObject? {
+    if (text.isEmpty()) return null
+    return try {
+        Json.parseToJsonElement(text) as? JsonObject
+    } catch (ignored: SerializationException) {
+        // malformed tool_search_call arguments: fall through to query="" (answered exhaustively
+        // downstream), matching this file's own precedent at driveTurn's catch list above.
+        null
+    }
+}
+
+private const val TOOL_SEARCH_EXECUTION_CLIENT = "client"

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesToolSearch.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesToolSearch.kt
@@ -1,0 +1,183 @@
+// NEW: the gateway-side ANSWER to a Responses tool_search call. The tool declares
+// execution:"client" (codex core/src/tools/handlers/tool_search_spec.rs:68-76), so the model emits
+// a distinct tool_search_call item (protocol/src/models.rs:878-892) and waits for a distinct
+// tool_search_output item (:695-701) — NOT a function_call/function_call_output pair, and NOT
+// something Claude Code can be asked to run. splice answers it locally and re-POSTs inside the same
+// client turn, through the SAME append-only continuationRequest fold/re-anchor already use.
+// Invariants:
+//   - the search call NEVER becomes a client-visible block: no WireSink verb is reachable from here
+//     and the controller returns a request BODY, so L3 is untouched by construction;
+//   - APPEND-ONLY: only `input` grows (closed-DTO continuationRequest), so the prompt-cache prefix
+//     and every other request field survive the extra round;
+//   - THE LOOP CANNOT WEDGE: the final permitted round answers with the ENTIRE deferred set, so a
+//     further search is pointless; capability at the cap is exactly today's full surface;
+//   - PER-TURN ONLY: this object holds the turn's deferred inventory and nothing else. There is no
+//     cache, no TTL, no keyed store — a restart cannot lose anything that exists.
+package splice.dialect.responses
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import splice.core.turn.ToolSearchCall
+import splice.core.util.str
+import splice.core.wire.ToolDefinition
+import splice.spi.ToolSearchController
+import splice.spi.ToolSearchRound
+
+/** Deterministic field-weighted lexical ranking over the deferred set. NOT BM25: over ≤100
+ *  two-line documents its saturation and length-normalisation terms are noise and pure tuning
+ *  surface. The CORPUS is the parity-relevant part and is a direct port of codex-rs
+ *  default_tool_search_text (tools/src/tool_search.rs:67-94): name, name with '_'→space,
+ *  description, top-level schema property names and their descriptions. */
+internal class ToolSearchIndex(private val deferred: List<ToolDefinition>) {
+
+    private data class Doc(val tool: ToolDefinition, val name: String, val description: String, val properties: String)
+
+    private val docs: List<Doc> = deferred.map { t ->
+        Doc(
+            tool = t,
+            name = "${t.name} ${t.name.replace('_', ' ')}".lowercase(),
+            description = t.description.orEmpty().lowercase(),
+            properties = propertyCorpus(t).lowercase(),
+        )
+    }
+
+    /** The full deferred set, in input order — the exhaustive answer for the final permitted round. */
+    fun all(): List<ToolDefinition> = deferred
+
+    /** Terms are whitespace-split, matched by substring per field, weighted, summed; ties break by
+     *  name so [limit] and equal-score ordering are both deterministic across identical calls. */
+    fun search(query: String, limit: Int): List<ToolDefinition> {
+        val terms = query.lowercase().split(QUERY_SPLIT).filter { it.isNotEmpty() }
+        if (terms.isEmpty()) return emptyList()
+        return docs.asSequence()
+            .map { it to score(it, terms) }
+            .filter { (_, s) -> s > 0 }
+            .sortedWith(compareByDescending<Pair<Doc, Int>> { it.second }.thenBy { it.first.tool.name })
+            .take(limit)
+            .map { it.first.tool }
+            .toList()
+    }
+
+    private fun score(doc: Doc, terms: List<String>): Int = terms.sumOf { term ->
+        fieldHit(doc.name, term, NAME_WEIGHT) + fieldHit(doc.description, term, DESCRIPTION_WEIGHT) +
+            fieldHit(doc.properties, term, PROPERTY_WEIGHT)
+    }
+
+    private fun fieldHit(field: String, term: String, weight: Int): Int = if (field.contains(term)) weight else 0
+
+    private companion object {
+        val QUERY_SPLIT = Regex("\\s+")
+        const val NAME_WEIGHT = 3
+        const val DESCRIPTION_WEIGHT = 2
+        const val PROPERTY_WEIGHT = 1
+    }
+}
+
+/** Top-level schema property names + their descriptions, space-joined — the "structured schema
+ *  property names and their descriptions" leg of the codex-rs corpus (tool_search.rs:67-94). */
+private fun propertyCorpus(t: ToolDefinition): String {
+    val props = t.inputSchema?.get(FIELD_PROPERTIES) as? JsonObject ?: return ""
+    return props.entries.joinToString(" ") { (name, schema) ->
+        "$name ${(schema as? JsonObject)?.get(FIELD_DESCRIPTION).str().orEmpty()}"
+    }
+}
+
+/** Per-TURN answering policy. Holds the turn's deferred inventory and nothing else; allocated by
+ *  the request builder, garbage-collected with the turn. No cross-turn state exists anywhere. */
+internal class ResponsesToolSearchController(
+    private val index: ToolSearchIndex,
+    private val policy: ToolDeferralPolicy,
+    private val emitStrict: Boolean,
+    private val forceStrictFalse: Boolean,
+    private val decodeReasoningEnvelope: (String) -> JsonObject?,
+) : ToolSearchController {
+
+    override fun continuationForSearch(round: ToolSearchRound): JsonObject? {
+        if (stopSearching(round)) return null
+        val exhaustive = round.roundIndex == policy.searchRounds - 1
+        val items = buildList {
+            // this round's reasoning items, ONLY when non-empty (a dangling reasoning item with no
+            // following item is a 400 — the same idiom ResponsesFoldController.continuation uses).
+            addAll(round.outcome.reasoningEnvelopes.mapNotNull(decodeReasoningEnvelope))
+            // The round's own prose, already on the client's wire — replay it as context so the
+            // model does not re-say it (ResponsesReanchorController.assistantText's sibling rule).
+            // Gated on emittedText (not just bodyText.isNotEmpty()): on FoldRunner's buffered path
+            // the CALLER strips both to "" / false before this outcome ever reaches here, so a
+            // buffered-and-discarded round can never leak never-forwarded prose (review 2026-07-24).
+            if (round.outcome.emittedText && round.outcome.bodyText.isNotEmpty()) {
+                add(assistantText(round.outcome.bodyText))
+            }
+            answeredOnce(round.outcome.toolSearches).forEach { call ->
+                add(call.raw) // verbatim — the backend's own shape, never a re-authored guess
+                add(toolSearchOutputItem(call.callId.v, answerFor(call, exhaustive), emitStrict, forceStrictFalse))
+            }
+        }
+        return continuationRequest(round.requestBody, items)
+    }
+
+    /** The round's prose the client already saw, replayed as context — mirrors
+     *  ResponsesReanchorController.assistantText (duplicated, not shared: a 2-line JSON builder,
+     *  and every wire literal in this file is already private-per-file). */
+    private fun assistantText(text: String): JsonObject = buildJsonObject {
+        put(FIELD_ROLE, ROLE_ASSISTANT)
+        put(FIELD_CONTENT, text)
+    }
+
+    // Stop conditions, each a plain early return via a flat when — never a compound boolean.
+    private fun stopSearching(round: ToolSearchRound): Boolean = when {
+        round.outcome.hasToolUse -> true // a real tool_use already committed to the client's wire
+        round.outcome.toolSearches.isEmpty() -> true // nothing to answer
+        else -> round.roundIndex >= policy.searchRounds // hard stop (unreachable in practice)
+    }
+
+    /** Dedup by call_id, first wins — a round can (in principle) carry the same id twice. */
+    private fun answeredOnce(calls: List<ToolSearchCall>): List<ToolSearchCall> {
+        val seen = HashSet<String>(calls.size)
+        return calls.filter { seen.add(it.callId.v) }
+    }
+
+    // The final permitted round hands over the ENTIRE deferred set (the loop-can't-wedge law);
+    // an unrankable blank query is answered the same way rather than starving the model with [].
+    private fun answerFor(call: ToolSearchCall, exhaustive: Boolean): List<ToolDefinition> = when {
+        exhaustive -> index.all()
+        call.query.isBlank() -> index.all()
+        else -> index.search(call.query, clampedLimit(call.limit))
+    }
+
+    private fun clampedLimit(requested: Int?): Int = (requested ?: policy.searchLimit).coerceIn(1, policy.searchLimit)
+}
+
+/** The tool_search_output shape (type, call_id, status, execution, tools[]) — the ONE builder for
+ *  both callers: the within-turn answer above ([ResponsesToolSearchController.continuationForSearch])
+ *  and the declaration-replay injection (ResponsesRequestBuilder.kt CHANGE 2, cache-prefix
+ *  stability 2026-07-25) that re-declares a deferred tool's schema in history before its
+ *  function_call. Never re-authored as a second shape — see this file's header and ToolSurface.kt's. */
+internal fun toolSearchOutputItem(
+    callId: String,
+    tools: List<ToolDefinition>,
+    emitStrict: Boolean,
+    forceStrictFalse: Boolean,
+): JsonObject = buildJsonObject {
+    put(FIELD_TYPE, TYPE_TOOL_SEARCH_OUTPUT)
+    put(FIELD_CALL_ID, callId)
+    put(FIELD_STATUS, STATUS_COMPLETED)
+    put(FIELD_EXECUTION, EXECUTION_CLIENT)
+    put(FIELD_TOOLS, buildJsonArray { tools.forEach { add(deferredToolObject(it, emitStrict, forceStrictFalse)) } })
+}
+
+private const val FIELD_TYPE = "type"
+private const val FIELD_CALL_ID = "call_id"
+private const val FIELD_STATUS = "status"
+private const val FIELD_EXECUTION = "execution"
+private const val FIELD_TOOLS = "tools"
+private const val FIELD_PROPERTIES = "properties"
+private const val FIELD_DESCRIPTION = "description"
+private const val FIELD_ROLE = "role"
+private const val FIELD_CONTENT = "content"
+private const val ROLE_ASSISTANT = "assistant"
+private const val TYPE_TOOL_SEARCH_OUTPUT = "tool_search_output"
+private const val STATUS_COMPLETED = "completed"
+private const val EXECUTION_CLIENT = "client"

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ToolSurface.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ToolSurface.kt
@@ -45,6 +45,13 @@ import splice.core.wire.ToolDefinition
 import splice.core.wire.ToolUseBlock
 import java.util.concurrent.atomic.AtomicBoolean
 
+/** Per-provider deferred-tool-surface policy — governs whether/how a request's `tools` gets
+ *  PARTITIONed into an eager set (declared normally in `additional_tools`) and a deferred set
+ *  (answered on demand via `tool_search`; see this file's header). Overlaid from the operator-
+ *  facing TOML `[providers.*.quirks.tool_surface]` table via [withToolSurfaceToml] into
+ *  [ResponsesQuirks.toolSurface]. An ABSENT policy (`toolSurface == null`) means the feature is
+ *  OFF — every request is byte-identical to pre-feature status quo (all tools eager, no
+ *  tool_search object); there is no "configured but inert" state between off and active. */
 public data class ToolDeferralPolicy(
     val deferPrefixes: List<String> = listOf(MCP_PREFIX),
     /** Names FORCED deferred regardless of prefix — the Agent/Task availability brake. */
@@ -53,7 +60,17 @@ public data class ToolDeferralPolicy(
     val eager: Set<String> = emptySet(),
     /** Below this many deferrable tools the split buys nothing and costs a round. */
     val minDeferred: Int = DEFAULT_MIN_DEFERRED,
+    /** Max tools returned by one `tool_search` answer (clamped 1..this —
+     *  [ResponsesToolSearchController.clampedLimit]). Trades answer size against round count: a
+     *  HIGHER limit answers a broad query in fewer rounds at the cost of a bigger
+     *  tool_search_output payload every round; a LOWER limit keeps each round's answer small but
+     *  pushes more queries toward [searchRounds]'s exhaustive fallback. */
     val searchLimit: Int = DEFAULT_SEARCH_LIMIT,
+    /** Permitted `tool_search` rounds before the FINAL round answers with the ENTIRE deferred set
+     *  regardless of query — the loop-can't-wedge law (ResponsesToolSearch.kt header): capability
+     *  at the cap is exactly today's full surface. Trades round budget against when narrowing
+     *  gives up: MORE rounds lets ranked, limit-sized answers keep narrowing longer before the
+     *  exhaustive fallback; FEWER rounds reaches the larger, unranked exhaustive answer sooner. */
     val searchRounds: Int = DEFAULT_SEARCH_ROUNDS,
 )
 
@@ -66,13 +83,29 @@ internal data class ToolPartition(val eager: List<ToolDefinition>, val deferred:
 /** The capability latch — the ENTIRE persistent state of this design: one bit per provider
  *  instance, moving in exactly ONE direction (toward status quo). Closed by a backend rejection
  *  of the tool-surface shape; a daemon restart re-opens it, so a transient backend change costs
- *  one re-probe per lifetime, never a permanent silent downgrade. */
+ *  one re-probe per lifetime, never a permanent silent downgrade.
+ *
+ *  Honesty gap, accepted (review 2026-07-25, options 1+2 over 3): the turn that TRIGGERS the
+ *  close is itself served on a degraded surface, not full status quo. [ResponsesProvider.
+ *  amendBodyOnFailure]'s signature is `(status, responseText, bodyJson)` — the already-serialized
+ *  wire body, never the [ToolPartition] or [ToolDeferralPolicy] that produced it — so the amend
+ *  path can strip the invented tool_search shape but cannot reconstruct and re-attach the
+ *  deferred tools' full schemas (they never rode the request by design; this file's header). That
+ *  ONE recovery turn therefore completes eager-only: one turn below full status quo. Every LATER
+ *  turn on this provider instance reads [open] == false and builds the full eager set from the
+ *  start via [partitionTools]'s `!opts.toolSurfaceOpen -> allEager` branch — true status quo.
+ *  Cost: one degraded-but-successful turn per provider instance per daemon lifetime. Restoring
+ *  the full surface on the amend path itself (option 3) was rejected: it would touch the same
+ *  shared amend seam RC-4's stale-reasoning recovery uses. [close] returns whether THIS call
+ *  performed the actual transition so the caller can fire its one observable signal exactly once
+ *  per instance, never once per amend attempt. */
 internal class ToolSurfaceLatch {
     private val openFlag = AtomicBoolean(true)
     val open: Boolean get() = openFlag.get()
-    fun close() {
-        openFlag.set(false)
-    }
+
+    /** CAS, not a plain set: only the open->closed transition returns true, so a caller racing
+     *  two amend attempts (or any future re-entry) fires its visibility signal exactly once. */
+    fun close(): Boolean = openFlag.compareAndSet(true, false)
 }
 
 /** Overlay the head's TOML `[providers.*.quirks.tool_surface]` table — a DIRECT set, not the
@@ -153,7 +186,11 @@ internal fun functionToolObject(t: ToolDefinition, emitStrict: Boolean, forceStr
         put(FIELD_DESCRIPTION, t.description ?: "")
         put(FIELD_PARAMETERS, t.inputSchema ?: emptyObjectSchema())
         when {
-            forceStrictFalse -> put(FIELD_STRICT, t.strict == true)
+            // forceStrictFalse is a HARD SET (codex-rs parity, responses_api.rs:29-32): every
+            // function tool gets strict:false regardless of the tool's OWN value — passing
+            // t.strict through here (review 2026-07-25) would send strict:true for a tool that
+            // arrives with strict==true, breaking the exact parity this quirk exists for.
+            forceStrictFalse -> put(FIELD_STRICT, false)
             emitStrict && t.strict == true -> put(FIELD_STRICT, true)
             else -> Unit
         }
@@ -172,7 +209,10 @@ internal fun deferredToolObject(t: ToolDefinition, emitStrict: Boolean, forceStr
         put(FIELD_DEFER_LOADING, true)
         put(FIELD_PARAMETERS, t.inputSchema ?: emptyObjectSchema())
         when {
-            forceStrictFalse -> put(FIELD_STRICT, t.strict == true)
+            // Same hard-set law as functionToolObject's identical branch just above (review
+            // 2026-07-25) — a deferred tool answered through tool_search gets forced strict:false
+            // too, never a pass-through of its own strict==true.
+            forceStrictFalse -> put(FIELD_STRICT, false)
             emitStrict && t.strict == true -> put(FIELD_STRICT, true)
             else -> Unit
         }

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ToolSurface.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ToolSurface.kt
@@ -1,0 +1,264 @@
+// NEW: the deferred tool surface for responses-lite (gpt-5.6 family). splice forwards Claude Code's
+// FULL tool list — measured 64-87 function tools per request, median upstream body 399KB, p90 1.1MB —
+// while OpenAI's own client serves these models a collapsed surface (models.json gives gpt-5.6-sol
+// supports_search_tool:true, and core/src/client.rs:838-921 wraps ToolSpec::ToolSearch into the same
+// additional_tools developer item splice already emits). This file owns the PARTITION and the wire
+// tool objects; the answering side lives in ResponsesToolSearch.kt, and the shape-400 recovery lives
+// in ToolSurfaceRecovery.kt (split 2026-07-24: this file hit the SAME TooManyFunctions ceiling
+// ResponsesLite.kt was originally split from ResponsesRequestBuilder to avoid).
+// Invariants:
+//   - PURE and ORDER-STABLE: the partition is a function of (body.tools, policy) ONLY — no
+//     transcript signal participates, so an identical client request produces identical bytes and
+//     the additional_tools payload (position 0 of the lite input array, ResponsesLite.kt liteInput)
+//     never moves mid-conversation. This used to be false: a prior cut promoted any tool NAMED BY a
+//     ToolUseBlock to always-eager ("the R2 wall", via warmToolNames) as the stateless replacement
+//     for codex's session-held loaded-tool set. Removed 2026-07-25: the client's tool list is
+//     otherwise stable across a conversation, so that promotion flipped the tools[] set — and
+//     therefore additional_tools' bytes — the FIRST time the model actually used a previously
+//     deferred tool, busting the ENTIRE cached prefix (measured: ~94K re-billed tokens against a
+//     few-K-to-15K/request deferral saving; one bust erases dozens of requests of savings and
+//     recurs per distinct newly-used deferred tool). codex-rs never does this: it does not promote
+//     a searched tool into the tools array, ever — see the permanent regression test at codex-rs
+//     core/tests/suite/search_tool.rs:782-814 ("follow-up request should rely on
+//     tool_search_output history, not tool injection" / "...not namespace injection"). The model
+//     is meant to learn a deferred tool's schema FROM HISTORY (tool_search_output), never from a
+//     moving tools array. [warmToolNames] is KEPT — it now feeds ResponsesRequestBuilder.kt's
+//     declaration-replay instead: a deferred tool a ToolUseBlock already named gets its full
+//     schema re-declared IN HISTORY, immediately before that function_call, which closes the same
+//     "replayed history references an undeclared tool" failure mode without ever touching
+//     additional_tools;
+//   - OFF (quirks.toolSurface == null), non-lite, compact, latch-closed, or below the minDeferred
+//     floor => (all eager, none deferred), byte-identical to today (ResponsesContractTest pins it);
+//   - deferred tools are ABSENT from the request entirely — defer_loading never rides the request
+//     side, only the tool_search_output (codex core/tests/suite/search_tool.rs:723-741).
+package splice.dialect.responses
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import splice.core.wire.AnthropicRequest
+import splice.core.wire.ToolDefinition
+import splice.core.wire.ToolUseBlock
+import java.util.concurrent.atomic.AtomicBoolean
+
+public data class ToolDeferralPolicy(
+    val deferPrefixes: List<String> = listOf(MCP_PREFIX),
+    /** Names FORCED deferred regardless of prefix — the Agent/Task availability brake. */
+    val defer: Set<String> = emptySet(),
+    /** Names FORCED eager; wins over every defer rule. */
+    val eager: Set<String> = emptySet(),
+    /** Below this many deferrable tools the split buys nothing and costs a round. */
+    val minDeferred: Int = DEFAULT_MIN_DEFERRED,
+    val searchLimit: Int = DEFAULT_SEARCH_LIMIT,
+    val searchRounds: Int = DEFAULT_SEARCH_ROUNDS,
+)
+
+/** The per-request split. [eager] PRESERVES body.tools order — a reordering breaks the
+ *  prompt-cache prefix when Claude Code retries the identical request. */
+internal data class ToolPartition(val eager: List<ToolDefinition>, val deferred: List<ToolDefinition>) {
+    val deferring: Boolean get() = deferred.isNotEmpty()
+}
+
+/** The capability latch — the ENTIRE persistent state of this design: one bit per provider
+ *  instance, moving in exactly ONE direction (toward status quo). Closed by a backend rejection
+ *  of the tool-surface shape; a daemon restart re-opens it, so a transient backend change costs
+ *  one re-probe per lifetime, never a permanent silent downgrade. */
+internal class ToolSurfaceLatch {
+    private val openFlag = AtomicBoolean(true)
+    val open: Boolean get() = openFlag.get()
+    fun close() {
+        openFlag.set(false)
+    }
+}
+
+/** Overlay the head's TOML `[providers.*.quirks.tool_surface]` table — a DIRECT set, not the
+ *  null-preserves-base merge [withReasoningCacheToml] uses: toolSurface's null means literally
+ *  OFF (the field's own KDoc), and no provider's defaultQuirks() ever presets a non-null base to
+ *  inherit from, so a direct set is both simpler and exactly as correct. Chained (not folded into
+ *  [withToml]) because that function already sits at detekt's complexity ceiling. */
+public fun ResponsesQuirks.withToolSurfaceToml(policy: ToolDeferralPolicy?): ResponsesQuirks =
+    copy(toolSurface = policy)
+
+/** The partition gate: SEQUENTIAL early returns via a `when` ladder, never a compound boolean —
+ *  the decision has five clauses and ComplexCondition fails at 3 operands. */
+internal fun ResponsesQuirks.partitionTools(body: AnthropicRequest, opts: BuildOptions): ToolPartition {
+    val allEager = ToolPartition(body.tools, emptyList())
+    val policy = toolSurface
+    return when {
+        policy == null -> allEager
+        !opts.toolSurfaceOpen -> allEager // latch closed
+        !isLite(opts) -> allEager // compact is subsumed: isLite is already !compact && …
+        else -> partitionWithPolicy(body, policy, allEager)
+    }
+}
+
+private fun partitionWithPolicy(
+    body: AnthropicRequest,
+    policy: ToolDeferralPolicy,
+    allEager: ToolPartition,
+): ToolPartition {
+    val chosenName = body.toolChoice?.name
+    val deferred = body.tools.filter { eligibleForDefer(it, policy, chosenName) }
+    val deferredNames = deferred.mapTo(HashSet(deferred.size)) { it.name }
+    val eager = body.tools.filter { it.name !in deferredNames }
+    return when {
+        deferred.size < policy.minDeferred -> allEager
+        eager.isEmpty() -> allEager // degenerate-config guard
+        else -> ToolPartition(eager, deferred)
+    }
+}
+
+private fun eligibleForDefer(
+    t: ToolDefinition,
+    policy: ToolDeferralPolicy,
+    chosenName: String?,
+): Boolean = when {
+    !deferrable(t, policy) -> false
+    t.name in policy.eager -> false
+    else -> t.name != chosenName
+}
+
+private fun deferrable(t: ToolDefinition, policy: ToolDeferralPolicy): Boolean =
+    t.name in policy.defer || policy.deferPrefixes.any { t.name.startsWith(it) }
+
+/** Any tool named by a ToolUseBlock anywhere in this transcript — a pure scan of the request
+ *  Claude Code already resends every turn, so it is restart-proof and needs no cache, no TTL, no
+ *  keys. Used to no longer promote these tools to eager (removed 2026-07-25, see this file's
+ *  header): the intersection of this set with [ToolPartition.deferred] is now the input to
+ *  ResponsesRequestBuilder.kt's declaration-replay — every deferred tool a ToolUseBlock already
+ *  named gets its full schema re-declared in history, immediately before that tool's
+ *  function_call, instead of forcing the tool eager (which moved additional_tools and busted the
+ *  cached prefix). */
+internal fun warmToolNames(body: AnthropicRequest): Set<String> =
+    body.messages.asSequence()
+        .flatMap { it.content.asSequence() }
+        .filterIsInstance<ToolUseBlock>()
+        .mapTo(HashSet()) { it.name }
+
+/** [forceStrictFalse] (codex-rs parity: hard-sets `strict:false` on every function tool,
+ *  responses_api.rs:29-32) and [emitStrict] (pass through a tool's own strict==true) are
+ *  DISTINCT quirks, not one flag with two meanings (review 2026-07-24 round 2/3): GrokProvider's
+ *  pre-existing `emitStrict = true` predates this feature and was never consequential (Claude
+ *  Code's ToolDefinition.strict is always null), so folding the codex-only forced-false behavior
+ *  into `emitStrict` silently changed grok's live wire bytes too — a head this feature must not
+ *  touch. forceStrictFalse defaults false and only CodexProvider sets it. */
+internal fun functionToolObject(t: ToolDefinition, emitStrict: Boolean, forceStrictFalse: Boolean): JsonObject =
+    buildJsonObject {
+        put(FIELD_TYPE, TYPE_FUNCTION)
+        put(FIELD_NAME, t.name)
+        put(FIELD_DESCRIPTION, t.description ?: "")
+        put(FIELD_PARAMETERS, t.inputSchema ?: emptyObjectSchema())
+        when {
+            forceStrictFalse -> put(FIELD_STRICT, t.strict == true)
+            emitStrict && t.strict == true -> put(FIELD_STRICT, true)
+            else -> Unit
+        }
+    }
+
+/** A deferred tool as it rides inside a tool_search_output.tools[] answer — carries the same
+ *  fields as [functionToolObject] plus `defer_loading:true` (tool_search.rs:36-40). Authored
+ *  standalone rather than composed from [functionToolObject]: JSON key order is semantically
+ *  irrelevant to the API, but composing would put defer_loading last instead of adjacent to the
+ *  other declared-shape fields, and this way the two builders stay independently readable. */
+internal fun deferredToolObject(t: ToolDefinition, emitStrict: Boolean, forceStrictFalse: Boolean): JsonObject =
+    buildJsonObject {
+        put(FIELD_TYPE, TYPE_FUNCTION)
+        put(FIELD_NAME, t.name)
+        put(FIELD_DESCRIPTION, t.description ?: "")
+        put(FIELD_DEFER_LOADING, true)
+        put(FIELD_PARAMETERS, t.inputSchema ?: emptyObjectSchema())
+        when {
+            forceStrictFalse -> put(FIELD_STRICT, t.strict == true)
+            emitStrict && t.strict == true -> put(FIELD_STRICT, true)
+            else -> Unit
+        }
+    }
+
+private fun emptyObjectSchema(): JsonObject = buildJsonObject {
+    put("type", "object")
+    put(FIELD_PROPERTIES, buildJsonObject { })
+}
+
+/** Shape verbatim from codex core/src/tools/handlers/tool_search_spec.rs:63-76 (the
+ *  ToolSearchSourceListing::Omit branch — splice has no MCP-server description metadata to
+ *  list), MINUS the "with BM25" clause codex's copy carries: splice's ranking is a deterministic
+ *  field-weighted substring score, not BM25 (spec §2.3; ToolSearchIndex's own header). Dropping
+ *  that clause is deliberate, not a missed port. execution:"client" is what tells the backend WE
+ *  answer the search, never Claude Code. [limit] is the operator's configured policy.searchLimit
+ *  (threaded from the caller) so the advertised default matches what [ResponsesToolSearchController]
+ *  actually clamps to (review 2026-07-24: this used to hardcode DEFAULT_SEARCH_LIMIT). */
+internal fun toolSearchToolObject(limit: Int): JsonObject = buildJsonObject {
+    put(FIELD_TYPE, TYPE_TOOL_SEARCH)
+    put(FIELD_EXECUTION, EXECUTION_CLIENT)
+    put(FIELD_DESCRIPTION, TOOL_SEARCH_DESCRIPTION)
+    put(
+        FIELD_PARAMETERS,
+        buildJsonObject {
+            put("type", "object")
+            put(
+                FIELD_PROPERTIES,
+                buildJsonObject {
+                    put(
+                        "query",
+                        buildJsonObject {
+                            put("type", "string")
+                            put(FIELD_DESCRIPTION, "Search query for deferred tools.")
+                        },
+                    )
+                    put(
+                        "limit",
+                        buildJsonObject {
+                            put("type", "number")
+                            put(FIELD_DESCRIPTION, "Maximum number of tools to return. Defaults to $limit.")
+                        },
+                    )
+                },
+            )
+            put("required", buildJsonArray { add(JsonPrimitive("query")) })
+            put("additionalProperties", false)
+        },
+    )
+}
+
+/** The additional_tools array for this request: every eager tool, then (only when deferring) the
+ *  tool_search tool. The deferred tools themselves never ride here (search_tool.rs:723-741). */
+internal fun toolsSection(
+    partition: ToolPartition,
+    emitStrict: Boolean,
+    forceStrictFalse: Boolean,
+    searchLimit: Int,
+): JsonArray = buildJsonArray {
+    partition.eager.forEach { add(functionToolObject(it, emitStrict, forceStrictFalse)) }
+    if (partition.deferring) add(toolSearchToolObject(searchLimit))
+}
+
+// Wire field/type literals shared by the request-side (this file) and the answer-side
+// (ResponsesToolSearch.kt) — each private-per-file since StringLiteralDuplication scopes per file.
+private const val MCP_PREFIX = "mcp__"
+internal const val DEFAULT_MIN_DEFERRED = 8
+internal const val DEFAULT_SEARCH_LIMIT = 8
+internal const val DEFAULT_SEARCH_ROUNDS = 3
+
+private const val FIELD_TYPE = "type"
+private const val FIELD_NAME = "name"
+private const val FIELD_DESCRIPTION = "description"
+private const val FIELD_PARAMETERS = "parameters"
+private const val FIELD_PROPERTIES = "properties"
+private const val FIELD_STRICT = "strict"
+private const val FIELD_DEFER_LOADING = "defer_loading"
+private const val FIELD_EXECUTION = "execution"
+private const val TYPE_FUNCTION = "function"
+private const val TYPE_TOOL_SEARCH = "tool_search"
+private const val EXECUTION_CLIENT = "client"
+
+private const val TOOL_SEARCH_DESC_HEAD = "# Tool discovery\n\n" +
+    "Searches over deferred tool metadata and exposes matching tools for the next model call.\n\n"
+private const val TOOL_SEARCH_DESC_TAIL = "Some of the tools may not have been provided to you upfront, " +
+    "and you should use this tool (`tool_search`) to search for the required tools. " +
+    "For MCP tool discovery, always use `tool_search` instead of `list_mcp_resources` " +
+    "or `list_mcp_resource_templates`."
+private const val TOOL_SEARCH_DESCRIPTION = TOOL_SEARCH_DESC_HEAD + TOOL_SEARCH_DESC_TAIL

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ToolSurfaceRecovery.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ToolSurfaceRecovery.kt
@@ -1,0 +1,112 @@
+// NEW: shape-400 recovery for the deferred tool surface — split from ToolSurface.kt (2026-07-24
+// hardening: that file was at detekt's TooManyFunctions ceiling). Owns the RC-4-style amend path:
+// detect a backend rejection of the tool_search SHAPE, strip every invented item, and hand back a
+// request that is a genuinely clean status-quo-shaped body for the ONE-SHOT UpstreamClient retry
+// (amendedOnce, UpstreamClient.kt) to land on.
+// Invariant (review 2026-07-24, HIGH): the first cut of this recovery stripped only the tool_search
+// TOOL entry from the additional_tools item, leaving orphaned tool_search_call / tool_search_output
+// items in `input` — a rejection of THOSE invented items (the shape splice itself authors, not
+// codex's) could not be recovered, since the one-shot retry re-POSTed a body still carrying them.
+// [dropToolSearchTool] now strips BOTH: the tool, and every search-call/output item plus their
+// now-dangling preceding reasoning items (a reasoning item with nothing after it is itself a 400 —
+// the same rule ResponsesFoldController.continuation guards).
+package splice.dialect.responses
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
+import splice.core.util.strOrEmpty
+
+/** Deliberately broad (status-shape, not exact wording) — a narrower literal match is exactly
+ *  what the 2026-07-24 review flagged as letting a backend wording drift skip the recovery. */
+internal fun isToolSurfaceRejection(status: Int, responseText: String): Boolean {
+    if (status < REJECTION_STATUS_MIN || status > REJECTION_STATUS_MAX) return false
+    val lower = responseText.lowercase()
+    return lower.contains(TYPE_TOOL_SEARCH) || lower.contains(FIELD_DEFER_LOADING)
+}
+
+/** RC-4-style shape recovery: decode the closed DTO, strip every invented tool-surface item, then
+ *  re-encode. Null = nothing to strip (the rejection was not ours to fix; the caller's plain retry
+ *  plan applies instead). */
+internal fun dropToolSearchTool(bodyJson: String): String? {
+    val parsed = Json.parseToJsonElement(bodyJson).jsonObject
+    val base = responsesRequestJson.decodeFromJsonElement(ResponsesRequest.serializer(), parsed)
+    if (!hasToolSearchTool(base.input) && !hasToolSearchItems(base.input)) return null
+    val toolStripped = buildJsonArray { base.input.forEach { add(stripToolSearchFromItem(it)) } }
+    val next = base.copy(input = stripToolSearchItems(toolStripped))
+    return responsesRequestJson.encodeToJsonElement(ResponsesRequest.serializer(), next).toString()
+}
+
+private fun hasToolSearchTool(input: JsonArray): Boolean = input.any { item ->
+    ((item as? JsonObject)?.get(FIELD_TOOLS) as? JsonArray)?.any(::isToolSearchTool) == true
+}
+
+private fun hasToolSearchItems(input: JsonArray): Boolean = input.any { isSearchCallOrOutput(itemType(it)) }
+
+/** [item] unchanged, except an item carrying a `tools` array has its tool_search entry filtered. */
+private fun stripToolSearchFromItem(item: JsonElement): JsonElement {
+    val obj = item as? JsonObject ?: return item
+    val tools = obj[FIELD_TOOLS] as? JsonArray ?: return item
+    return buildJsonObject {
+        obj.forEach { (k, v) -> if (k != FIELD_TOOLS) put(k, v) }
+        put(FIELD_TOOLS, buildJsonArray { tools.forEach { if (!isToolSearchTool(it)) add(it) } })
+    }
+}
+
+private fun isToolSearchTool(t: JsonElement): Boolean = itemType(t) == TYPE_TOOL_SEARCH
+
+/** Drops every tool_search_call/tool_search_output item, plus the contiguous run of "reasoning"
+ *  items immediately preceding a dropped call — see the file header for why those would otherwise
+ *  dangle. Two passes (mark, then extend the mark backward over reasoning) kept as separate
+ *  functions so neither trips CyclomaticComplexMethod on its own. */
+private fun stripToolSearchItems(input: JsonArray): JsonArray {
+    val drop = markSearchCallOutputs(input)
+    markDanglingReasoning(input, drop)
+    return buildJsonArray { input.forEachIndexed { i, item -> if (!drop[i]) add(item) } }
+}
+
+private fun markSearchCallOutputs(input: JsonArray): BooleanArray {
+    val drop = BooleanArray(input.size)
+    for (i in input.indices) {
+        if (isSearchCallOrOutput(itemType(input[i]))) drop[i] = true
+    }
+    return drop
+}
+
+private fun markDanglingReasoning(input: JsonArray, drop: BooleanArray) {
+    for (i in input.indices) {
+        if (!drop[i] || itemType(input[i]) != TYPE_TOOL_SEARCH_CALL) continue
+        var j = i - 1
+        while (isPrecedingReasoning(input, drop, j)) {
+            drop[j] = true
+            j--
+        }
+    }
+}
+
+// Split into a guard + a plain check (not one 3-operand &&) — ComplexCondition fails at 3 operands.
+private fun isPrecedingReasoning(input: JsonArray, drop: BooleanArray, j: Int): Boolean {
+    if (j < 0 || drop[j]) return false
+    return itemType(input[j]) == TYPE_REASONING
+}
+
+private fun isSearchCallOrOutput(type: String): Boolean =
+    type == TYPE_TOOL_SEARCH_CALL || type == TYPE_TOOL_SEARCH_OUTPUT
+
+private fun itemType(t: JsonElement): String = strOrEmpty((t as? JsonObject)?.get(FIELD_TYPE))
+
+private const val REJECTION_STATUS_MIN = 400
+private const val REJECTION_STATUS_MAX = 422
+
+private const val FIELD_TYPE = "type"
+private const val FIELD_TOOLS = "tools"
+private const val FIELD_DEFER_LOADING = "defer_loading"
+private const val TYPE_TOOL_SEARCH = "tool_search"
+private const val TYPE_TOOL_SEARCH_CALL = "tool_search_call"
+private const val TYPE_TOOL_SEARCH_OUTPUT = "tool_search_output"
+private const val TYPE_REASONING = "reasoning"

--- a/gateway/dialect-openai-responses/src/test/kotlin/ResponsesContractTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ResponsesContractTest.kt
@@ -17,32 +17,76 @@ import splice.dialect.responses.InjectPriorReasoning
 import splice.dialect.responses.RequestEncryptedReasoning
 import splice.dialect.responses.ResponsesQuirks
 import splice.dialect.responses.ResponsesRequestBuilder
+import splice.dialect.responses.ToolDeferralPolicy
 import java.io.File
 
+// The codex quirk profile, mirrored from CodexProvider.defaultQuirks() (provider-codex DEPENDS ON
+// this module, never the reverse — the dialect can never import a concrete provider).
+private fun codexProfileQuirks(toolSurface: ToolDeferralPolicy? = null) = ResponsesQuirks(
+    providerTag = "claudex",
+    summaryDelivery = "sequential_cutoff",
+    forceStrictFalse = true,
+    toolSurface = toolSurface,
+)
+
 class ResponsesContractTest {
+    private val canonicalAnthropic =
+        """{"model":"claude-codex--gpt-5.6-sol","stream":true,"max_tokens":1024,""" +
+            """"system":"You are Splice, a contract fixture.",""" +
+            """"messages":[{"role":"user","content":"Ping."}]}"""
+
+    private fun canonicalOpts() = BuildOptions(
+        compact = false,
+        originalModel = "claude-codex--gpt-5.6-sol",
+        upstreamModel = "gpt-5.6-sol",
+        configEffort = "high",
+        configSummary = "detailed",
+        showReasoning = ReasoningDisplay.TEXT,
+        replayReasoning = InjectPriorReasoning(false),
+        includeEncryptedReasoning = RequestEncryptedReasoning(true),
+        sessionId = "contract-fixture",
+        decodeReasoningEnvelope = { null },
+    )
+
     @Test
     fun `responses canonical request matches the golden bytes`() {
-        val anthropic =
-            """{"model":"claude-codex--gpt-5.6-sol","stream":true,"max_tokens":1024,""" +
-                """"system":"You are Splice, a contract fixture.",""" +
-                """"messages":[{"role":"user","content":"Ping."}]}"""
-        val parsed = parseAnthropicBody(anthropic)
-        val opts = BuildOptions(
-            compact = false,
-            originalModel = "claude-codex--gpt-5.6-sol",
-            upstreamModel = "gpt-5.6-sol",
-            configEffort = "high",
-            configSummary = "detailed",
-            showReasoning = ReasoningDisplay.TEXT,
-            replayReasoning = InjectPriorReasoning(false),
-            includeEncryptedReasoning = RequestEncryptedReasoning(true),
-            sessionId = "contract-fixture",
-            decodeReasoningEnvelope = { null },
-        )
+        // This golden's green IS the default-off proof: neither emitStrict nor toolSurface moves
+        // it — the fixture builds with the bare ResponsesQuirks(providerTag = "claudex").
+        val parsed = parseAnthropicBody(canonicalAnthropic)
         val req = ResponsesRequestBuilder(ResponsesQuirks(providerTag = "claudex"))
-            .build(parsed.typed, parsed.raw, opts)
+            .build(parsed.typed, parsed.raw, canonicalOpts())
             .req
         assertGoldenContract("responses-canonical", req) { ResponsesContractTest::class.java }
+    }
+
+    @Test
+    fun `responses codex profile pins strict false on every function tool`() {
+        val toolBody = """{"model":"claude-codex--gpt-5.6-sol","stream":true,"max_tokens":1024,""" +
+            """"system":"You are Splice, a contract fixture.",""" +
+            """"tools":[{"name":"Read","input_schema":{"type":"object"}}],""" +
+            """"messages":[{"role":"user","content":"Ping."}]}"""
+        val parsed = parseAnthropicBody(toolBody)
+        val req = ResponsesRequestBuilder(codexProfileQuirks())
+            .build(parsed.typed, parsed.raw, canonicalOpts())
+            .req
+        assertGoldenContract("responses-codex-profile", req) { ResponsesContractTest::class.java }
+    }
+
+    @Test
+    fun `responses tool search pins the eager array, absent deferred tools, and the tool_search object`() {
+        val mcpTools = (1..12).joinToString(",") {
+            """{"name":"mcp__exa__tool_$it","input_schema":{"type":"object"}}"""
+        }
+        val toolBody = """{"model":"claude-codex--gpt-5.6-sol","stream":true,"max_tokens":1024,""" +
+            """"system":"You are Splice, a contract fixture.",""" +
+            """"tools":[{"name":"Read","input_schema":{"type":"object"}},$mcpTools],""" +
+            """"messages":[{"role":"user","content":"Ping."}]}"""
+        val parsed = parseAnthropicBody(toolBody)
+        val quirks = codexProfileQuirks(toolSurface = ToolDeferralPolicy(minDeferred = 4))
+        val req = ResponsesRequestBuilder(quirks)
+            .build(parsed.typed, parsed.raw, canonicalOpts())
+            .req
+        assertGoldenContract("responses-tool-search", req) { ResponsesContractTest::class.java }
     }
 }
 

--- a/gateway/dialect-openai-responses/src/test/kotlin/ResponsesContractTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ResponsesContractTest.kt
@@ -61,9 +61,14 @@ class ResponsesContractTest {
 
     @Test
     fun `responses codex profile pins strict false on every function tool`() {
+        // The second tool arrives with its OWN "strict":true (review 2026-07-25, comment 1): the
+        // golden must still pin "strict":false for it, or a forceStrictFalse regression that lets
+        // a tool's own strict value pass through (ToolSurface.kt functionToolObject) would stay
+        // green — the prior fixture only ever exercised a tool with no strict field at all.
         val toolBody = """{"model":"claude-codex--gpt-5.6-sol","stream":true,"max_tokens":1024,""" +
             """"system":"You are Splice, a contract fixture.",""" +
-            """"tools":[{"name":"Read","input_schema":{"type":"object"}}],""" +
+            """"tools":[{"name":"Read","input_schema":{"type":"object"}},""" +
+            """{"name":"Bash","input_schema":{"type":"object"},"strict":true}],""" +
             """"messages":[{"role":"user","content":"Ping."}]}"""
         val parsed = parseAnthropicBody(toolBody)
         val req = ResponsesRequestBuilder(codexProfileQuirks())

--- a/gateway/dialect-openai-responses/src/test/kotlin/ResponsesRequestBuilderTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ResponsesRequestBuilderTest.kt
@@ -22,6 +22,7 @@ import splice.dialect.responses.InjectPriorReasoning
 import splice.dialect.responses.RequestEncryptedReasoning
 import splice.dialect.responses.ResponsesQuirks
 import splice.dialect.responses.ResponsesRequestBuilder
+import splice.dialect.responses.ToolDeferralPolicy
 import splice.dialect.responses.stablePromptCacheKey
 import splice.dialect.responses.withReasoningCacheToml
 
@@ -527,5 +528,158 @@ class ReasoningInjectionTest {
         val req = build(body, options = cacheOpts(replay = true, lookup = { listOf("env1") }))
         val reasonings = items(req).filter { it["type"]?.jsonPrimitive?.content == "reasoning" }
         assertEquals(1, reasonings.size, "rs_env1 must appear exactly once across both paths")
+    }
+}
+
+// Tool-surface deferral walls (ToolSurface.kt / ResponsesRequestBuilder's toolSearchControllerFor).
+// The three EXISTING lite-shape tests above (`gpt-5-6 lite shape...`, `...without tools...`,
+// `non-lite models keep the normal shape...`) stay green UNMODIFIED — that green is the second
+// default-off proof (deferral off never perturbs the lite/non-lite shape they pin).
+private val MCP_TOOLS_JSON = (1..12).joinToString(",") {
+    """{"name":"mcp__exa__tool_$it","input_schema":{"type":"object"}}"""
+}
+
+private fun toolSurfaceBody() = """{"model":"m",
+    "tools":[{"name":"Read","input_schema":{"type":"object"}},$MCP_TOOLS_JSON],
+    "messages":[{"role":"user","content":"x"}]}"""
+
+// N+1 of toolSurfaceBody(): the same tools, plus a prior turn's tool_use/tool_result of [toolName].
+private fun toolSurfaceBodyWithHistory(toolName: String) = """{"model":"m",
+    "tools":[{"name":"Read","input_schema":{"type":"object"}},$MCP_TOOLS_JSON],
+    "messages":[
+        {"role":"user","content":"x"},
+        {"role":"assistant","content":[{"type":"tool_use","id":"call_x","name":"$toolName","input":{}}]},
+        {"role":"user","content":[
+            {"type":"tool_result","tool_use_id":"call_x","content":[{"type":"text","text":"ok"}]}]}
+    ]}"""
+
+class ToolSurfaceRequestTest {
+
+    private val quirksOn = CODEX.copy(toolSurface = ToolDeferralPolicy(minDeferred = 4))
+
+    @Test
+    fun `deferral on - deferred names absent, tool_search last, other fields unchanged`() {
+        val req = build(toolSurfaceBody(), quirks = quirksOn, options = opts(model = "gpt-5.6-sol"))
+        val toolsArr = req["input"]!!.jsonArray[0].jsonObject["tools"]!!.jsonArray
+        val kinds = toolsArr.map { t ->
+            t.jsonObject["name"]?.jsonPrimitive?.content ?: t.jsonObject["type"]?.jsonPrimitive?.content
+        }
+        assertFalse(kinds.any { it?.startsWith("mcp__") == true }, "deferred tools never ride the request")
+        assertEquals("tool_search", kinds.last())
+        assertEquals("auto", req["tool_choice"]?.jsonPrimitive?.content)
+        assertEquals("false", req["parallel_tool_calls"]?.jsonPrimitive?.content)
+        assertEquals("all_turns", req["reasoning"]?.jsonObject?.get("context")?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `BuiltRequest toolSearch is non-null exactly when the partition deferred something`() {
+        val parsedOn = parseAnthropicBody(toolSurfaceBody())
+        val builtOn = ResponsesRequestBuilder(quirksOn).build(parsedOn.typed, parsedOn.raw, opts(model = "gpt-5.6-sol"))
+        assertTrue(builtOn.toolSearch != null)
+
+        val parsedOff = parseAnthropicBody(toolSurfaceBody())
+        val builtOff = ResponsesRequestBuilder(CODEX).build(parsedOff.typed, parsedOff.raw, opts(model = "gpt-5.6-sol"))
+        assertNull(builtOff.toolSearch)
+    }
+
+    @Test
+    fun `TurnMeta stamps tools eager and deferred, null when deferral is off`() {
+        val parsedOn = parseAnthropicBody(toolSurfaceBody())
+        val builtOn = ResponsesRequestBuilder(quirksOn).build(parsedOn.typed, parsedOn.raw, opts(model = "gpt-5.6-sol"))
+        assertEquals(1, builtOn.meta.toolsEager)
+        assertEquals(12, builtOn.meta.toolsDeferred)
+
+        val parsedOff = parseAnthropicBody(toolSurfaceBody())
+        val builtOff = ResponsesRequestBuilder(CODEX).build(parsedOff.typed, parsedOff.raw, opts(model = "gpt-5.6-sol"))
+        assertNull(builtOff.meta.toolsEager)
+        assertNull(builtOff.meta.toolsDeferred)
+    }
+
+    // Declaration-replay walls (cache-prefix stability, 2026-07-25): ToolSurface.kt's transcript-
+    // warm promotion busted the cached prefix (the R2 wall moved additional_tools' bytes the FIRST
+    // time a deferred tool was actually used); these pin its replacement — the tool's schema is
+    // re-declared IN HISTORY, immediately before its function_call, and additional_tools never moves.
+
+    @Test
+    fun `additional_tools bytes are identical whether or not history already used a deferred tool`() {
+        val cold = build(toolSurfaceBody(), quirks = quirksOn, options = opts(model = "gpt-5.6-sol"))
+        val warm = build(
+            toolSurfaceBodyWithHistory("mcp__exa__tool_5"),
+            quirks = quirksOn,
+            options = opts(model = "gpt-5.6-sol"),
+        )
+        assertEquals(cold["input"]!!.jsonArray[0].toString(), warm["input"]!!.jsonArray[0].toString())
+    }
+
+    @Test
+    fun `turn N+1 (adds a tool_use plus tool_result of a deferred tool) keeps input(0) byte-identical to turn N`() {
+        val turnN = build(toolSurfaceBody(), quirks = quirksOn, options = opts(model = "gpt-5.6-sol"))
+        val turnNPlus1 = build(
+            toolSurfaceBodyWithHistory("mcp__exa__tool_5"),
+            quirks = quirksOn,
+            options = opts(model = "gpt-5.6-sol"),
+        )
+        assertEquals(turnN["input"]!!.jsonArray[0].toString(), turnNPlus1["input"]!!.jsonArray[0].toString())
+    }
+
+    @Test
+    fun `declaration replay - full schema, positioned immediately before the function_call`() {
+        val req = build(
+            toolSurfaceBodyWithHistory("mcp__exa__tool_5"),
+            quirks = quirksOn,
+            options = opts(model = "gpt-5.6-sol"),
+        )
+        val input = req["input"]!!.jsonArray.map { it.jsonObject }
+        val fcIdx = input.indexOfFirst { it["type"]?.jsonPrimitive?.content == "function_call" }
+        assertTrue(fcIdx >= 2, "reasoning-free turn: call then output must precede the function_call")
+        val call = input[fcIdx - 2]
+        val output = input[fcIdx - 1]
+        assertEquals("tool_search_call", call["type"]?.jsonPrimitive?.content)
+        assertEquals("tool_search_output", output["type"]?.jsonPrimitive?.content)
+        assertEquals(call["call_id"]?.jsonPrimitive?.content, output["call_id"]?.jsonPrimitive?.content)
+        val tools = output["tools"]!!.jsonArray
+        assertEquals(1, tools.size)
+        assertEquals("mcp__exa__tool_5", tools[0].jsonObject["name"]?.jsonPrimitive?.content)
+        assertEquals("true", tools[0].jsonObject["defer_loading"]?.jsonPrimitive?.content)
+        // nothing else in the input carries a second declaration of this tool
+        assertEquals(1, input.count { it["type"]?.jsonPrimitive?.content == "tool_search_call" })
+    }
+
+    @Test
+    fun `declaration replay is deterministic - identical JSON across repeated builds`() {
+        val body = toolSurfaceBodyWithHistory("mcp__exa__tool_5")
+        val a = build(body, quirks = quirksOn, options = opts(model = "gpt-5.6-sol"))
+        val b = build(body, quirks = quirksOn, options = opts(model = "gpt-5.6-sol"))
+        assertEquals(a.toString(), b.toString())
+    }
+
+    @Test
+    fun `a transcript tool_use naming a tool absent from body-tools does not crash or emit a declaration`() {
+        val req = build(
+            toolSurfaceBodyWithHistory("mcp__exa__ghost"),
+            quirks = quirksOn,
+            options = opts(model = "gpt-5.6-sol"),
+        ) // must not throw
+        val input = req["input"]!!.jsonArray.map { it.jsonObject }
+        assertTrue(input.none { it["type"]?.jsonPrimitive?.content == "tool_search_call" })
+        assertTrue(input.none { it["type"]?.jsonPrimitive?.content == "tool_search_output" })
+        val call = input.first { it["type"]?.jsonPrimitive?.content == "function_call" }
+        assertEquals(
+            "mcp__exa__ghost",
+            call["name"]?.jsonPrimitive?.content,
+            "the call rides bare, like an eager tool's",
+        )
+    }
+
+    @Test
+    fun `deferral off - a warm deferred-shaped tool_use still emits no declaration`() {
+        val req = build(
+            toolSurfaceBodyWithHistory("mcp__exa__tool_5"),
+            quirks = CODEX,
+            options = opts(model = "gpt-5.6-sol"),
+        )
+        val input = req["input"]!!.jsonArray.map { it.jsonObject }
+        assertTrue(input.none { it["type"]?.jsonPrimitive?.content == "tool_search_call" })
+        assertTrue(input.none { it["type"]?.jsonPrimitive?.content == "tool_search_output" })
     }
 }

--- a/gateway/dialect-openai-responses/src/test/kotlin/ResponsesStreamTranslatorTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ResponsesStreamTranslatorTest.kt
@@ -685,3 +685,154 @@ class TurnReasoningCaptureTest {
         assertFalse(fired)
     }
 }
+
+// Tool-search capture walls (ToolSurface deferral, the search round). A tool_search_call opens NO
+// wire block and must never touch hasToolUse/turnToolIds — a synthetic/foreign id there would
+// mis-key the reasoning cache (a known prior bug class this pins against).
+class ToolSearchCaptureTest {
+
+    @Test
+    fun `a tool_search_call opens no block, leaves hasToolUse false, lands in toolSearches`() = runTest {
+        val sink = RecordingSink()
+        val outcome = ResponsesStreamTranslator(ctx()).driveTurn(
+            listOf(
+                ev(
+                    """{"type":"response.output_item.done","output_index":0,"item":{"type":"tool_search_call",""" +
+                        """"call_id":"ts_1","execution":"client","arguments":{"query":"web search exa"}}}""",
+                ),
+                completed,
+            ).asFlow(),
+            sink,
+        )
+        val success = outcome as TurnOutcome.Success
+        assertFalse(success.hasToolUse)
+        val opened = setOf("openTool", "openText", "openThinking")
+        assertTrue(sink.calls.none { call -> opened.any { call.startsWith(it) } }, "no wire block opens")
+        assertEquals(1, success.toolSearches.size)
+        assertEquals("ts_1", success.toolSearches.single().callId.v)
+        assertEquals("web search exa", success.toolSearches.single().query)
+    }
+
+    @Test
+    fun `execution server is not captured`() = runTest {
+        val outcome = ResponsesStreamTranslator(ctx()).driveTurn(
+            listOf(
+                ev(
+                    """{"type":"response.output_item.done","output_index":0,"item":{"type":"tool_search_call",""" +
+                        """"call_id":"ts_1","execution":"server","arguments":{"query":"x"}}}""",
+                ),
+                completed,
+            ).asFlow(),
+            RecordingSink(),
+        )
+        val success = outcome as TurnOutcome.Success
+        assertTrue(success.toolSearches.isEmpty())
+    }
+
+    @Test
+    fun `arguments as a JSON string parses`() = runTest {
+        val outcome = ResponsesStreamTranslator(ctx()).driveTurn(
+            listOf(
+                ev(
+                    """{"type":"response.output_item.done","output_index":0,"item":{"type":"tool_search_call",""" +
+                        """"call_id":"ts_1","execution":"client",""" +
+                        """"arguments":"{\"query\":\"exa search\",\"limit\":3}"}}""",
+                ),
+                completed,
+            ).asFlow(),
+            RecordingSink(),
+        )
+        val success = outcome as TurnOutcome.Success
+        assertEquals("exa search", success.toolSearches.single().query)
+        assertEquals(3, success.toolSearches.single().limit)
+    }
+
+    @Test
+    fun `malformed arguments yields empty query and does not throw`() = runTest {
+        val outcome = ResponsesStreamTranslator(ctx()).driveTurn(
+            listOf(
+                ev(
+                    """{"type":"response.output_item.done","output_index":0,"item":{"type":"tool_search_call",""" +
+                        """"call_id":"ts_1","execution":"client","arguments":"not valid json {"}}""",
+                ),
+                completed,
+            ).asFlow(),
+            RecordingSink(),
+        )
+        val success = outcome as TurnOutcome.Success
+        assertEquals(1, success.toolSearches.size)
+        assertEquals("", success.toolSearches.single().query)
+    }
+
+    @Test
+    fun `empty call_id is dropped`() = runTest {
+        val outcome = ResponsesStreamTranslator(ctx()).driveTurn(
+            listOf(
+                ev(
+                    """{"type":"response.output_item.done","output_index":0,"item":{"type":"tool_search_call",""" +
+                        """"call_id":"","execution":"client","arguments":{"query":"x"}}}""",
+                ),
+                completed,
+            ).asFlow(),
+            RecordingSink(),
+        )
+        val success = outcome as TurnOutcome.Success
+        assertTrue(success.toolSearches.isEmpty())
+    }
+
+    @Test
+    fun `terminal-only delivery is recovered by the harvest fallback`() = runTest {
+        // No output_item.done for the search call — only the terminal response object carries it.
+        val terminal = ev(
+            """{"type":"response.completed","response":{"id":"r1","usage":{"input_tokens":10,"output_tokens":1},
+                "output":[{"type":"tool_search_call","call_id":"ts_9","execution":"client",
+                    "arguments":{"query":"harvested"}}]}}""",
+        )
+        val outcome = ResponsesStreamTranslator(ctx()).driveTurn(listOf(terminal).asFlow(), RecordingSink())
+        val success = outcome as TurnOutcome.Success
+        assertEquals(1, success.toolSearches.size)
+        assertEquals("ts_9", success.toolSearches.single().callId.v)
+    }
+
+    @Test
+    fun `streamed capture present - the harvest fallback does not duplicate`() = runTest {
+        val terminal = ev(
+            """{"type":"response.completed","response":{"id":"r1","usage":{"input_tokens":10,"output_tokens":1},
+                "output":[{"type":"tool_search_call","call_id":"ts_1","execution":"client",
+                    "arguments":{"query":"streamed"}}]}}""",
+        )
+        val outcome = ResponsesStreamTranslator(ctx()).driveTurn(
+            listOf(
+                ev(
+                    """{"type":"response.output_item.done","output_index":0,"item":{"type":"tool_search_call",""" +
+                        """"call_id":"ts_1","execution":"client","arguments":{"query":"streamed"}}}""",
+                ),
+                terminal,
+            ).asFlow(),
+            RecordingSink(),
+        )
+        val success = outcome as TurnOutcome.Success
+        assertEquals(1, success.toolSearches.size, "the streamed capture wins; the harvest never re-adds it")
+    }
+
+    // The dispatch-after-search wall: a function_call for a tool absent from THIS turn's
+    // declared set (i.e. a tool the model only learned about via a prior search) still opens an
+    // ordinary tool_use block — splice never validates names against the declared set.
+    @Test
+    fun `a function_call for an undeclared tool still opens a tool_use block`() = runTest {
+        val sink = RecordingSink()
+        val outcome = ResponsesStreamTranslator(ctx()).driveTurn(
+            listOf(
+                ev(
+                    """{"type":"response.output_item.added","output_index":0,""" +
+                        """"item":{"type":"function_call","call_id":"call_1","name":"mcp__exa__web_search_exa"}}""",
+                ),
+                completed,
+            ).asFlow(),
+            sink,
+        )
+        val success = outcome as TurnOutcome.Success
+        assertTrue(success.hasToolUse)
+        assertTrue(sink.calls.any { it.startsWith("openTool") && it.contains("mcp__exa__web_search_exa") })
+    }
+}

--- a/gateway/dialect-openai-responses/src/test/kotlin/ResponsesToolSearchTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ResponsesToolSearchTest.kt
@@ -1,0 +1,231 @@
+// Walls for the gateway-side tool_search answer (ResponsesToolSearch.kt): the continuation is an
+// APPEND-ONLY extension of the prior request (closed-DTO continuationRequest, every non-input field
+// untouched), the stop conditions (hasToolUse, empty toolSearches, round cap), the exhaustive-vs-
+// ranked answer split, limit clamping, call_id dedup, and the no-dangling-reasoning-item rule.
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import splice.core.reasoning.encodeReasoningEnvelope
+import splice.core.turn.ToolSearchCall
+import splice.core.turn.ToolSearchCallId
+import splice.core.turn.TurnOutcome
+import splice.core.turn.Usage
+import splice.core.wire.ToolDefinition
+import splice.dialect.responses.ResponsesRequest
+import splice.dialect.responses.ResponsesToolSearchController
+import splice.dialect.responses.ToolDeferralPolicy
+import splice.dialect.responses.ToolSearchIndex
+import splice.dialect.responses.responsesRequestJson
+import splice.spi.ToolSearchRound
+import splice.core.reasoning.decodeReasoningEnvelope as coreDecode
+
+private val DEFERRED = List(12) { ToolDefinition(name = "mcp__exa__tool_$it", description = "tool number $it") }
+private val POLICY = ToolDeferralPolicy(searchLimit = 4, searchRounds = 3)
+private val CONTROLLER = ResponsesToolSearchController(
+    index = ToolSearchIndex(DEFERRED),
+    policy = POLICY,
+    emitStrict = false,
+    forceStrictFalse = false,
+    decodeReasoningEnvelope = { coreDecode(it) },
+)
+
+private val priorRequest: JsonObject = Json.parseToJsonElement(
+    """{"model":"gpt-5.6-sol","input":[{"role":"developer","content":"hi"}],
+        "store":false,"stream":true,"prompt_cache_key":"splice-abc",
+        "tool_choice":"auto","parallel_tool_calls":false}""",
+).jsonObject
+
+private fun rawCall(callId: String, query: String, limit: Int? = null): JsonObject = buildJsonObject {
+    put("type", "tool_search_call")
+    put("call_id", callId)
+    put("execution", "client")
+    put(
+        "arguments",
+        buildJsonObject {
+            put("query", query)
+            limit?.let { put("limit", it) }
+        }.toString(),
+    )
+}
+
+private fun call(callId: String, query: String, limit: Int? = null) = ToolSearchCall(
+    callId = ToolSearchCallId(callId),
+    query = query,
+    limit = limit,
+    raw = rawCall(callId, query, limit),
+)
+
+private fun success(
+    toolSearches: List<ToolSearchCall>,
+    hasToolUse: Boolean = false,
+    reasoningEnvelopes: List<String> = emptyList(),
+    bodyText: String = "",
+    emittedText: Boolean = false,
+) = TurnOutcome.Success(
+    hasToolUse = hasToolUse,
+    incomplete = false,
+    usage = Usage(),
+    bodyText = bodyText,
+    emittedText = emittedText,
+    toolSearches = toolSearches,
+    reasoningEnvelopes = reasoningEnvelopes,
+)
+
+/** The items a continuation APPENDED past the prior request's own input — the assertion surface
+ *  for "append-only" tests, without repeating the two-sided subList expression at every call site. */
+private fun appendedTail(next: JsonObject): List<JsonElement> {
+    val prevSize = priorRequest["input"]!!.jsonArray.size
+    val nextInput = next["input"]!!.jsonArray
+    return nextInput.subList(prevSize, nextInput.size)
+}
+
+private fun envelopeFor(id: String): String = encodeReasoningEnvelope(
+    buildJsonObject {
+        put("type", "reasoning")
+        put("id", id)
+        put("encrypted_content", "ENC-$id")
+    },
+)!!
+
+class ResponsesToolSearchTest {
+
+    @Test
+    fun `continuation appends reasoning, verbatim call, and the output item - no other field changes`() {
+        val c = call("ts_1", "web search")
+        val outcome = success(listOf(c), reasoningEnvelopes = listOf(envelopeFor("rs_1")))
+        val round = ToolSearchRound(priorRequest, outcome, 0)
+        val next = CONTROLLER.continuationForSearch(round)
+        assertTrue(next != null)
+
+        val prevInput = priorRequest["input"]!!.jsonArray
+        val nextInput = next!!["input"]!!.jsonArray
+        // append-only: the prior input is an untouched PREFIX
+        assertEquals(prevInput.map { it.toString() }, nextInput.subList(0, prevInput.size).map { it.toString() })
+        // reasoning, then the verbatim call, then the output item
+        val tail = nextInput.subList(prevInput.size, nextInput.size).map { it.jsonObject }
+        assertEquals("reasoning", tail[0]["type"]?.jsonPrimitive?.content)
+        assertEquals("ENC-rs_1", tail[0]["encrypted_content"]?.jsonPrimitive?.content)
+        assertEquals(c.raw.toString(), tail[1].toString())
+        assertEquals("tool_search_output", tail[2]["type"]?.jsonPrimitive?.content)
+
+        // every OTHER request field, decoded through the closed DTO, is byte-identical
+        val prevDto = responsesRequestJson.decodeFromJsonElement(ResponsesRequest.serializer(), priorRequest)
+        val nextDto = responsesRequestJson.decodeFromJsonElement(ResponsesRequest.serializer(), next)
+        assertEquals(prevDto.copy(input = nextDto.input), nextDto)
+    }
+
+    @Test
+    fun `the output item shape is exact - type, call_id, status, execution, deferred tools`() {
+        val c = call("ts_1", "tool_0")
+        val next = CONTROLLER.continuationForSearch(ToolSearchRound(priorRequest, success(listOf(c)), 0))!!
+        val output = next["input"]!!.jsonArray.last().jsonObject
+        assertEquals("tool_search_output", output["type"]?.jsonPrimitive?.content)
+        assertEquals("ts_1", output["call_id"]?.jsonPrimitive?.content)
+        assertEquals("completed", output["status"]?.jsonPrimitive?.content)
+        assertEquals("client", output["execution"]?.jsonPrimitive?.content)
+        val tools = output["tools"]!!.jsonArray
+        assertTrue(tools.isNotEmpty())
+        assertTrue(tools.all { it.jsonObject["defer_loading"]?.jsonPrimitive?.content == "true" })
+    }
+
+    @Test
+    fun `hasToolUse true - no continuation`() {
+        val c = call("ts_1", "x")
+        val round = ToolSearchRound(priorRequest, success(listOf(c), hasToolUse = true), 0)
+        assertNull(CONTROLLER.continuationForSearch(round))
+    }
+
+    @Test
+    fun `empty toolSearches - no continuation`() {
+        assertNull(CONTROLLER.continuationForSearch(ToolSearchRound(priorRequest, success(emptyList()), 0)))
+    }
+
+    @Test
+    fun `final permitted round answers exhaustively - the entire deferred set`() {
+        val c = call("ts_1", "tool_0") // a narrow query that would otherwise rank-limit
+        val round = ToolSearchRound(priorRequest, success(listOf(c)), POLICY.searchRounds - 1)
+        val next = CONTROLLER.continuationForSearch(round)!!
+        val tools = next["input"]!!.jsonArray.last().jsonObject["tools"]!!.jsonArray
+        assertEquals(DEFERRED.size, tools.size)
+    }
+
+    @Test
+    fun `round index at or past the cap - no continuation`() {
+        val c = call("ts_1", "x")
+        val round = ToolSearchRound(priorRequest, success(listOf(c)), POLICY.searchRounds)
+        assertNull(CONTROLLER.continuationForSearch(round))
+    }
+
+    @Test
+    fun `blank query answers exhaustively rather than starving the model with an empty list`() {
+        val c = call("ts_1", "   ")
+        val next = CONTROLLER.continuationForSearch(ToolSearchRound(priorRequest, success(listOf(c)), 0))!!
+        val tools = next["input"]!!.jsonArray.last().jsonObject["tools"]!!.jsonArray
+        assertEquals(DEFERRED.size, tools.size)
+    }
+
+    @Test
+    fun `the model's limit is clamped into 1 point policy searchLimit`() {
+        val c = call("ts_1", "tool", limit = 999)
+        val next = CONTROLLER.continuationForSearch(ToolSearchRound(priorRequest, success(listOf(c)), 0))!!
+        val tools = next["input"]!!.jsonArray.last().jsonObject["tools"]!!.jsonArray
+        assertEquals(POLICY.searchLimit, tools.size)
+    }
+
+    @Test
+    fun `a duplicate call_id in one round is answered exactly once`() {
+        val calls = listOf(call("ts_1", "tool_0"), call("ts_1", "tool_1"))
+        val next = CONTROLLER.continuationForSearch(ToolSearchRound(priorRequest, success(calls), 0))!!
+        val tail = appendedTail(next)
+        val outputs = tail.map { it.jsonObject }.filter { it["type"]?.jsonPrimitive?.content == "tool_search_output" }
+        assertEquals(1, outputs.size)
+    }
+
+    @Test
+    fun `no reasoning envelopes - no dangling reasoning item injected`() {
+        val c = call("ts_1", "tool_0")
+        val next = CONTROLLER.continuationForSearch(ToolSearchRound(priorRequest, success(listOf(c)), 0))!!
+        val tail = appendedTail(next)
+        assertTrue(tail.none { it.jsonObject["type"]?.jsonPrimitive?.content == "reasoning" })
+        // exactly the verbatim call + its output, nothing else
+        assertEquals(2, tail.size)
+    }
+
+    // review 2026-07-24 (HIGH/MEDIUM across reviews): the round's own prose is already on the
+    // client's wire before the search call streamed — it must be replayed as context (the same
+    // rule ResponsesReanchorController.assistantText applies), or the model re-says it and the
+    // client sees it twice.
+    @Test
+    fun `the round's emitted prose is replayed as an assistant item before the call`() {
+        val c = call("ts_1", "tool_0")
+        val outcome = success(listOf(c), bodyText = "Let me find the right tool.", emittedText = true)
+        val next = CONTROLLER.continuationForSearch(ToolSearchRound(priorRequest, outcome, 0))!!
+        val tail = appendedTail(next)
+        assertEquals("assistant", tail[0].jsonObject["role"]?.jsonPrimitive?.content)
+        assertEquals("Let me find the right tool.", tail[0].jsonObject["content"]?.jsonPrimitive?.content)
+        assertEquals("tool_search_call", tail[1].jsonObject["type"]?.jsonPrimitive?.content)
+        assertEquals(3, tail.size, "assistant text + the verbatim call + its output, nothing else")
+    }
+
+    @Test
+    fun `never-forwarded prose (emittedText false) is never replayed`() {
+        val c = call("ts_1", "tool_0")
+        // The FoldRunner-buffered shape: bodyText can be non-empty while emittedText is false (the
+        // caller strips both before the outcome ever reaches the controller in production —
+        // TurnDriver.bufferedForSearch) — pin the controller's OWN honesty regardless of the caller.
+        val outcome = success(listOf(c), bodyText = "never sent", emittedText = false)
+        val next = CONTROLLER.continuationForSearch(ToolSearchRound(priorRequest, outcome, 0))!!
+        val tail = appendedTail(next)
+        assertTrue(tail.none { it.jsonObject["role"]?.jsonPrimitive?.content == "assistant" })
+        assertEquals(2, tail.size, "exactly the verbatim call + its output, nothing else")
+    }
+}

--- a/gateway/dialect-openai-responses/src/test/kotlin/ResponsesToolSearchTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ResponsesToolSearchTest.kt
@@ -181,6 +181,18 @@ class ResponsesToolSearchTest {
         assertEquals(POLICY.searchLimit, tools.size)
     }
 
+    // review 2026-07-25 (comment 3): the sibling of the test just above, which only ever exercised
+    // the UPPER bound. If clampedLimit lost its floor (a refactor to coerceAtMost, say), limit = 0
+    // would answer with an empty tools[] — the exact starvation the blank-query branch exists to
+    // avoid — and the suite would stay green without this.
+    @Test
+    fun `a limit of zero is clamped up to one tool`() {
+        val c = call("ts_1", "tool", limit = 0)
+        val next = CONTROLLER.continuationForSearch(ToolSearchRound(priorRequest, success(listOf(c)), 0))!!
+        val tools = next["input"]!!.jsonArray.last().jsonObject["tools"]!!.jsonArray
+        assertEquals(1, tools.size)
+    }
+
     @Test
     fun `a duplicate call_id in one round is answered exactly once`() {
         val calls = listOf(call("ts_1", "tool_0"), call("ts_1", "tool_1"))
@@ -188,6 +200,13 @@ class ResponsesToolSearchTest {
         val tail = appendedTail(next)
         val outputs = tail.map { it.jsonObject }.filter { it["type"]?.jsonPrimitive?.content == "tool_search_output" }
         assertEquals(1, outputs.size)
+        // review 2026-07-25 (comment 4): pin WHICH duplicate is answered, not just the count.
+        // answeredOnce (ResponsesToolSearch.kt:136-140) is documented first-wins; "tool_0" (the
+        // first call's query) matches only mcp__exa__tool_0 (no "tool_10"/"tool_11" substring
+        // collision the way "tool_1" would) — a first->last regression would answer with
+        // mcp__exa__tool_1 (and its "tool_1x" siblings) instead, and only this assertion catches it.
+        val names = outputs.single()["tools"]!!.jsonArray.map { it.jsonObject["name"]?.jsonPrimitive?.content }
+        assertEquals(listOf("mcp__exa__tool_0"), names)
     }
 
     @Test

--- a/gateway/dialect-openai-responses/src/test/kotlin/ToolSearchIndexTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ToolSearchIndexTest.kt
@@ -1,0 +1,93 @@
+// Walls for ToolSearchIndex's deterministic field-weighted ranking (ResponsesToolSearch.kt): the
+// corpus is name / name-with-spaces / description / property names+descriptions, weighted so a
+// name hit always outranks a description/property hit; ties break by name for reproducibility.
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import splice.core.wire.ToolDefinition
+import splice.dialect.responses.ToolSearchIndex
+
+private fun tool(name: String, description: String? = null, properties: Map<String, String> = emptyMap()) =
+    ToolDefinition(
+        name = name,
+        description = description,
+        inputSchema = if (properties.isEmpty()) {
+            null
+        } else {
+            buildJsonObject {
+                put("type", "object")
+                putJsonObject("properties") {
+                    properties.forEach { (propName, propDesc) ->
+                        putJsonObject(propName) {
+                            put("type", "string")
+                            put("description", propDesc)
+                        }
+                    }
+                }
+            }
+        },
+    )
+
+class ToolSearchIndexTest {
+
+    @Test
+    fun `exact-name query ranks the named tool first`() {
+        val target = tool("mcp__exa__web_search_exa", description = "Search the web")
+        val decoys = listOf(tool("mcp__exa__web_fetch_exa", description = "Fetch a URL"), tool("mcp__ast_grep__find"))
+        val index = ToolSearchIndex(listOf(target) + decoys)
+        val results = index.search("mcp__exa__web_search_exa", limit = 5)
+        assertEquals(target.name, results.first().name)
+    }
+
+    @Test
+    fun `underscore-split matching finds the tool via a spaced query`() {
+        val target = tool("mcp__exa__web_search_exa", description = "Full text web search")
+        val other = tool("mcp__ast_grep__find_code", description = "Structural code search")
+        val index = ToolSearchIndex(listOf(target, other))
+        val results = index.search("web search exa", limit = 5)
+        assertEquals(target.name, results.first().name)
+    }
+
+    @Test
+    fun `property-name and property-description hits score below name hits`() {
+        // "billing" hits toolA's NAME (weight 3) and toolB's property description ONLY (weight 1).
+        val toolA = tool("mcp__billing__nothing_relevant", description = "unrelated")
+        val toolB = tool(
+            "mcp__other__configure",
+            description = "configure things",
+            properties = mapOf("mode" to "the billing mode to apply"),
+        )
+        val index = ToolSearchIndex(listOf(toolB, toolA))
+        val results = index.search("billing", limit = 5)
+        assertEquals(toolA.name, results.first().name, "a name hit outranks a property-description hit")
+        assertTrue(results.contains(toolB))
+    }
+
+    @Test
+    fun `zero-match query yields an empty list, never a throw`() {
+        val index = ToolSearchIndex(listOf(tool("mcp__exa__web_search_exa"), tool("mcp__ast_grep__find")))
+        assertTrue(index.search("no such tool anywhere", limit = 5).isEmpty())
+    }
+
+    @Test
+    fun `determinism - equal scores tie-break by name, repeated runs are identical`() {
+        val toolA = tool("mcp__alpha__widget", description = "manage widget")
+        val toolB = tool("mcp__beta__widget", description = "manage widget")
+        val index = ToolSearchIndex(listOf(toolB, toolA))
+        val first = index.search("widget", limit = 5)
+        val second = index.search("widget", limit = 5)
+        assertEquals(first, second)
+        assertEquals(listOf(toolA.name, toolB.name), first.map { it.name }, "equal score ties break by name")
+    }
+
+    @Test
+    fun `limit is respected and all() returns the full set in input order`() {
+        val tools = List(20) { tool("mcp__exa__tool_$it", description = "search widget") }
+        val index = ToolSearchIndex(tools)
+        assertEquals(3, index.search("widget", limit = 3).size)
+        assertEquals(tools, index.all())
+    }
+}

--- a/gateway/dialect-openai-responses/src/test/kotlin/ToolSurfaceStrictAndRecoveryTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ToolSurfaceStrictAndRecoveryTest.kt
@@ -1,0 +1,106 @@
+// Split from ToolSurfaceTest.kt (review 2026-07-25, PR top-level comments 6 + 8): that file already
+// sat at detekt's TooManyFunctions ceiling (15 tests, thresholdInClasses: 15), so these two
+// unrelated-but-related-to-the-same-round test groups — deferredToolObject's strict handling
+// (comment 6) and dropToolSearchTool's multi-item stripping (comment 8) — get their own file
+// rather than pushing ToolSurfaceTest.kt over the wall.
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import splice.core.wire.ToolDefinition
+import splice.dialect.responses.deferredToolObject
+import splice.dialect.responses.dropToolSearchTool
+
+class ToolSurfaceStrictAndRecoveryTest {
+
+    // review 2026-07-25 (comment 1 + PR top-level comment 6): deferredToolObject shares
+    // functionToolObject's exact strict-handling `when` (ToolSurface.kt), but rides the
+    // tool_search ANSWER path, not the eager request path — untested by the fixture-pinned
+    // ResponsesContractTest (its fixtures only exercise functionToolObject), so the
+    // forceStrictFalse pass-through bug this round fixes could regress here unnoticed.
+    @Test
+    fun `deferredToolObject forces strict false under forceStrictFalse regardless of the tool's own value`() {
+        val bash = ToolDefinition(name = "Bash", strict = true)
+        val read = ToolDefinition(name = "Read") // strict = null
+        val strictTrue = deferredToolObject(bash, emitStrict = false, forceStrictFalse = true)
+        val strictNull = deferredToolObject(read, emitStrict = false, forceStrictFalse = true)
+        assertEquals("false", strictTrue["strict"]?.jsonPrimitive?.content)
+        assertEquals("false", strictNull["strict"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `deferredToolObject passes through emitStrict true - unaffected by removing forceStrictFalse`() {
+        val tool = ToolDefinition(name = "Bash", strict = true)
+        val passthrough = deferredToolObject(tool, emitStrict = true, forceStrictFalse = false)
+        assertEquals("true", passthrough["strict"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `deferredToolObject omits strict entirely when neither quirk is set`() {
+        val tool = ToolDefinition(name = "Bash", strict = true)
+        val omitted = deferredToolObject(tool, emitStrict = false, forceStrictFalse = false)
+        assertNull(omitted["strict"])
+    }
+
+    // review 2026-07-25 (PR top-level comment 8): markDanglingReasoning's backward walk
+    // (ToolSurfaceRecovery.kt) is a `while`, not a single `if` — it keeps marking as long as the
+    // PREVIOUS item is also reasoning, so a run of MULTIPLE contiguous reasoning items immediately
+    // before a dropped tool_search_call should all be stripped, not just the one adjacent to the
+    // call. Pinning what the code actually does (not what a single-hop fix would do).
+    @Test
+    fun `dropToolSearchTool strips the ENTIRE contiguous run of reasoning items, not just the nearest one`() {
+        val body = """{"model":"gpt-5.6-sol","input":[
+            {"type":"additional_tools","role":"developer","tools":[
+                {"type":"function","name":"Bash","description":"d","parameters":{"type":"object","properties":{}}},
+                {"type":"tool_search","execution":"client","description":"x",
+                 "parameters":{"type":"object","properties":{}}}
+            ]},
+            {"role":"developer","content":"hi"},
+            {"type":"reasoning","id":"rs_1","encrypted_content":"enc1"},
+            {"type":"reasoning","id":"rs_2","encrypted_content":"enc2"},
+            {"type":"tool_search_call","call_id":"ts_1","execution":"client","arguments":"{}"},
+            {"type":"tool_search_output","call_id":"ts_1","status":"completed","execution":"client","tools":[]}
+        ],"store":false,"stream":true}"""
+        val stripped = dropToolSearchTool(body)
+        assertTrue(stripped != null)
+        val input = Json.parseToJsonElement(stripped!!).jsonObject["input"]!!.jsonArray
+        assertEquals(2, input.size, "both reasoning items, the call, and the output are all gone")
+        assertEquals("hi", input[1].jsonObject["content"]?.jsonPrimitive?.content, "unrelated item survives")
+    }
+
+    // review 2026-07-25 (PR top-level comment 8): markSearchCallOutputs/markDanglingReasoning both
+    // scan the WHOLE input array unconditionally, so a SECOND round's reasoning+call+output should
+    // strip exactly like the first, and a plain message BETWEEN the two rounds — never itself a
+    // search item — must survive untouched and in its original relative position.
+    @Test
+    fun `dropToolSearchTool strips MULTIPLE search rounds - survivors keep their original order`() {
+        val body = """{"model":"gpt-5.6-sol","input":[
+            {"type":"additional_tools","role":"developer","tools":[
+                {"type":"function","name":"Bash","description":"d","parameters":{"type":"object","properties":{}}},
+                {"type":"tool_search","execution":"client","description":"x",
+                 "parameters":{"type":"object","properties":{}}}
+            ]},
+            {"role":"developer","content":"hi"},
+            {"type":"reasoning","id":"rs_1","encrypted_content":"enc1"},
+            {"type":"tool_search_call","call_id":"ts_1","execution":"client","arguments":"{}"},
+            {"type":"tool_search_output","call_id":"ts_1","status":"completed","execution":"client","tools":[]},
+            {"role":"assistant","content":"between rounds"},
+            {"type":"reasoning","id":"rs_2","encrypted_content":"enc2"},
+            {"type":"tool_search_call","call_id":"ts_2","execution":"client","arguments":"{}"},
+            {"type":"tool_search_output","call_id":"ts_2","status":"completed","execution":"client","tools":[]}
+        ],"store":false,"stream":true}"""
+        val stripped = dropToolSearchTool(body)
+        assertTrue(stripped != null)
+        val input = Json.parseToJsonElement(stripped!!).jsonObject["input"]!!.jsonArray
+        // survivors: the additional_tools scaffold, "hi", and "between rounds" — IN THAT ORDER —
+        // both full rounds (reasoning + call + output each) are gone.
+        assertEquals(3, input.size, "both search rounds are fully stripped; only the 3 ordinary items remain")
+        assertEquals(1, input[0].jsonObject["tools"]!!.jsonArray.size, "the tool_search TOOL entry is stripped")
+        assertEquals("hi", input[1].jsonObject["content"]?.jsonPrimitive?.content)
+        assertEquals("between rounds", input[2].jsonObject["content"]?.jsonPrimitive?.content)
+    }
+}

--- a/gateway/dialect-openai-responses/src/test/kotlin/ToolSurfaceTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ToolSurfaceTest.kt
@@ -1,0 +1,255 @@
+// Walls for the deferred tool surface partition (ToolSurface.kt). Pins the NEVER-BELOW-STATUS-QUO
+// gate order (off/latch/non-lite/compact/floor/degenerate all fall back to all-eager), transcript
+// INDEPENDENCE (the partition is a pure function of (body.tools, policy) ONLY — cache-prefix
+// stability, 2026-07-25; replaces the removed R2 always-eager-promotion, whose declaration-replay
+// successor is pinned in ResponsesRequestBuilderTest.kt), the eager/defer overrides, and the
+// shape-400 recovery helpers.
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import splice.core.turn.ReasoningDisplay
+import splice.core.wire.AnthropicMessage
+import splice.core.wire.AnthropicRequest
+import splice.core.wire.ToolChoice
+import splice.core.wire.ToolDefinition
+import splice.core.wire.ToolUseBlock
+import splice.dialect.responses.BuildOptions
+import splice.dialect.responses.InjectPriorReasoning
+import splice.dialect.responses.RequestEncryptedReasoning
+import splice.dialect.responses.ResponsesQuirks
+import splice.dialect.responses.ToolDeferralPolicy
+import splice.dialect.responses.dropToolSearchTool
+import splice.dialect.responses.isToolSurfaceRejection
+import splice.dialect.responses.partitionTools
+import splice.dialect.responses.warmToolNames
+
+private fun opts(
+    compact: Boolean = false,
+    model: String = "gpt-5.6-sol",
+    toolSurfaceOpen: Boolean = true,
+): BuildOptions = BuildOptions(
+    compact = compact,
+    originalModel = "claude-codex--$model",
+    upstreamModel = model,
+    configEffort = null,
+    configSummary = null,
+    showReasoning = ReasoningDisplay.from("text"),
+    replayReasoning = InjectPriorReasoning(false),
+    includeEncryptedReasoning = RequestEncryptedReasoning(true),
+    sessionId = null,
+    decodeReasoningEnvelope = { null },
+    toolSurfaceOpen = toolSurfaceOpen,
+)
+
+private fun mcpTools(n: Int, prefix: String = "mcp__exa__tool_") = List(n) { ToolDefinition(name = "$prefix$it") }
+private fun builtins(n: Int) = List(n) { ToolDefinition(name = "Builtin$it") }
+
+private fun requestOf(
+    tools: List<ToolDefinition>,
+    messages: List<AnthropicMessage> = emptyList(),
+    toolChoice: ToolChoice? = null,
+): AnthropicRequest = AnthropicRequest(model = "m", messages = messages, tools = tools, toolChoice = toolChoice)
+
+private val POLICY = ToolDeferralPolicy()
+private val QUIRKS_OFF = ResponsesQuirks(providerTag = "t")
+private val QUIRKS_ON = ResponsesQuirks(providerTag = "t", toolSurface = POLICY)
+
+class ToolSurfaceTest {
+
+    @Test
+    fun `feature off - every tool eager, deferred empty`() {
+        val body = requestOf(mcpTools(20) + builtins(16))
+        val partition = QUIRKS_OFF.partitionTools(body, opts())
+        assertEquals(body.tools, partition.eager)
+        assertTrue(partition.deferred.isEmpty())
+    }
+
+    @Test
+    fun `non-lite model with the policy set - every tool eager`() {
+        val body = requestOf(mcpTools(20) + builtins(16))
+        val partition = QUIRKS_ON.partitionTools(body, opts(model = "gpt-5.5"))
+        assertEquals(body.tools, partition.eager)
+        assertTrue(partition.deferred.isEmpty())
+    }
+
+    @Test
+    fun `compact turn - every tool eager`() {
+        val body = requestOf(mcpTools(20) + builtins(16))
+        val partition = QUIRKS_ON.partitionTools(body, opts(compact = true))
+        assertEquals(body.tools, partition.eager)
+        assertTrue(partition.deferred.isEmpty())
+    }
+
+    @Test
+    fun `latch closed - every tool eager`() {
+        val body = requestOf(mcpTools(20) + builtins(16))
+        val partition = QUIRKS_ON.partitionTools(body, opts(toolSurfaceOpen = false))
+        assertEquals(body.tools, partition.eager)
+        assertTrue(partition.deferred.isEmpty())
+    }
+
+    @Test
+    fun `mcp prefix rule - 50 MCP deferred, 16 built-ins eager`() {
+        val body = requestOf(builtins(16) + mcpTools(50))
+        val partition = QUIRKS_ON.partitionTools(body, opts())
+        assertEquals(50, partition.deferred.size)
+        assertEquals(16, partition.eager.size)
+        assertTrue(partition.deferred.all { it.name.startsWith("mcp__") })
+    }
+
+    // Cache-prefix stability (2026-07-25): the partition must NOT react to transcript content —
+    // a tool named by a ToolUseBlock in history is deferred or eager exactly as if that history
+    // never happened. This test must never be deleted; it is the wall against the cache-bust bug
+    // the removed R2 always-eager promotion caused (a deferred tool's first real use used to flip
+    // additional_tools' bytes mid-conversation). The declaration-replay successor that keeps
+    // replayed history self-describing without touching the partition is pinned in
+    // ResponsesRequestBuilderTest.kt (ToolSurfaceRequestTest).
+    @Test
+    fun `a conversation whose history contains a tool_use for an mcp tool does not change the partition`() {
+        val mcp = mcpTools(10)
+        val warmed = mcp[3]
+        val messages = listOf(
+            AnthropicMessage(role = "assistant", content = listOf(ToolUseBlock(id = "t1", name = warmed.name))),
+        )
+        val cold = requestOf(builtins(16) + mcp)
+        val warm = requestOf(builtins(16) + mcp, messages = messages)
+        val coldPartition = QUIRKS_ON.partitionTools(cold, opts())
+        val warmPartition = QUIRKS_ON.partitionTools(warm, opts())
+        assertEquals(coldPartition.eager.map { it.name }, warmPartition.eager.map { it.name })
+        assertEquals(coldPartition.deferred.map { it.name }, warmPartition.deferred.map { it.name })
+        // the warmed tool still defers, exactly as it would with no history at all
+        assertTrue(warmPartition.deferred.any { it.name == warmed.name })
+        assertEquals(setOf(warmed.name), warmToolNames(warm))
+    }
+
+    @Test
+    fun `defer list forces a tool deferred even without a matching prefix`() {
+        val builtinTask = ToolDefinition(name = "Task")
+        val body = requestOf(mcpTools(10) + builtins(15) + builtinTask)
+        val policy = ToolDeferralPolicy(defer = setOf("Task"))
+        val partition = ResponsesQuirks(providerTag = "t", toolSurface = policy).partitionTools(body, opts())
+        assertTrue(partition.deferred.any { it.name == "Task" })
+    }
+
+    @Test
+    fun `eager list wins over the prefix rule`() {
+        val forcedEager = ToolDefinition(name = "mcp__exa__web_search_exa")
+        val body = requestOf(mcpTools(10) + builtins(16) + forcedEager)
+        val policy = ToolDeferralPolicy(eager = setOf("mcp__exa__web_search_exa"))
+        val partition = ResponsesQuirks(providerTag = "t", toolSurface = policy).partitionTools(body, opts())
+        assertTrue(partition.eager.any { it.name == "mcp__exa__web_search_exa" })
+        assertFalse(partition.deferred.any { it.name == "mcp__exa__web_search_exa" })
+    }
+
+    @Test
+    fun `the tool_choice-named tool is never deferred`() {
+        val mcp = mcpTools(10)
+        val chosen = mcp[5]
+        val body = requestOf(builtins(16) + mcp, toolChoice = ToolChoice(type = "tool", name = chosen.name))
+        val partition = QUIRKS_ON.partitionTools(body, opts())
+        assertTrue(partition.eager.any { it.name == chosen.name })
+        assertFalse(partition.deferred.any { it.name == chosen.name })
+    }
+
+    @Test
+    fun `min_deferred floor - 7 MCP tools all eager, 8 splits`() {
+        val below = requestOf(builtins(16) + mcpTools(7))
+        val belowPartition = QUIRKS_ON.partitionTools(below, opts())
+        assertTrue(belowPartition.deferred.isEmpty())
+
+        val atFloor = requestOf(builtins(16) + mcpTools(8))
+        val atFloorPartition = QUIRKS_ON.partitionTools(atFloor, opts())
+        assertEquals(8, atFloorPartition.deferred.size)
+    }
+
+    @Test
+    fun `degenerate config never empties the eager set`() {
+        val body = requestOf(mcpTools(20))
+        val policy = ToolDeferralPolicy(deferPrefixes = listOf(""))
+        val partition = ResponsesQuirks(providerTag = "t", toolSurface = policy).partitionTools(body, opts())
+        assertTrue(partition.eager.isNotEmpty())
+        assertTrue(partition.deferred.isEmpty())
+    }
+
+    @Test
+    fun `order stability and idempotence`() {
+        val body = requestOf(builtins(16) + mcpTools(20))
+        val first = QUIRKS_ON.partitionTools(body, opts())
+        val second = QUIRKS_ON.partitionTools(body, opts())
+        assertEquals(first, second)
+        assertEquals(body.tools.filter { it in first.eager }, first.eager, "eager preserves body.tools order")
+    }
+
+    @Test
+    fun `isToolSurfaceRejection fires on a shape-400, not an unrelated one`() {
+        assertTrue(isToolSurfaceRejection(400, """{"error":{"message":"Unknown parameter: 'tool_search'"}}"""))
+        assertTrue(isToolSurfaceRejection(422, "unsupported field defer_loading"))
+        assertFalse(isToolSurfaceRejection(400, "rate limit exceeded"))
+        assertFalse(isToolSurfaceRejection(500, "tool_search unsupported"), "status outside 400..422")
+    }
+
+    @Test
+    fun `dropToolSearchTool removes exactly the tool_search entry, null when absent`() {
+        val withSearch = """{"model":"gpt-5.6-sol","input":[
+            {"type":"additional_tools","role":"developer","tools":[
+                {"type":"function","name":"Bash","description":"d","parameters":{"type":"object","properties":{}}},
+                {"type":"tool_search","execution":"client","description":"x",
+                 "parameters":{"type":"object","properties":{}}}
+            ]},
+            {"role":"developer","content":"hi"}
+        ],"store":false,"stream":true}"""
+        val stripped = dropToolSearchTool(withSearch)
+        assertTrue(stripped != null)
+        val parsed = Json.parseToJsonElement(stripped!!).jsonObject
+        val toolsArr = parsed["input"]!!.jsonArray[0].jsonObject["tools"]!!.jsonArray
+        assertEquals(1, toolsArr.size)
+        assertEquals("Bash", toolsArr[0].jsonObject["name"]?.jsonPrimitive?.content)
+        assertEquals("gpt-5.6-sol", parsed["model"]?.jsonPrimitive?.content)
+
+        val withoutSearch = """{"model":"m","input":[
+            {"type":"additional_tools","role":"developer","tools":[
+                {"type":"function","name":"Bash","description":"d","parameters":{"type":"object","properties":{}}}
+            ]}
+        ],"store":false,"stream":true}"""
+        assertNull(dropToolSearchTool(withoutSearch))
+    }
+
+    // review 2026-07-24 (known HIGH): the first cut of this recovery stripped only the tool_search
+    // TOOL, leaving the invented tool_search_call/tool_search_output items (and their preceding
+    // reasoning item) in `input` — a rejection of THOSE items could never be recovered by the
+    // one-shot amend budget. The retry must be a clean status-quo-shaped request.
+    @Test
+    fun `dropToolSearchTool also strips tool_search_call, tool_search_output, and the dangling reasoning before it`() {
+        val withSearchRound = """{"model":"gpt-5.6-sol","input":[
+            {"type":"additional_tools","role":"developer","tools":[
+                {"type":"function","name":"Bash","description":"d","parameters":{"type":"object","properties":{}}},
+                {"type":"tool_search","execution":"client","description":"x",
+                 "parameters":{"type":"object","properties":{}}}
+            ]},
+            {"role":"developer","content":"hi"},
+            {"type":"reasoning","id":"rs_1","encrypted_content":"enc"},
+            {"type":"tool_search_call","call_id":"ts_1","execution":"client","arguments":"{}"},
+            {"type":"tool_search_output","call_id":"ts_1","status":"completed","execution":"client","tools":[]}
+        ],"store":false,"stream":true}"""
+        val stripped = dropToolSearchTool(withSearchRound)
+        assertTrue(stripped != null)
+        val input = Json.parseToJsonElement(stripped!!).jsonObject["input"]!!.jsonArray
+
+        val toolsArr = input[0].jsonObject["tools"]!!.jsonArray
+        assertEquals(1, toolsArr.size, "the tool_search TOOL entry is stripped")
+        assertEquals("Bash", toolsArr[0].jsonObject["name"]?.jsonPrimitive?.content)
+        assertEquals("hi", input[1].jsonObject["content"]?.jsonPrimitive?.content, "unrelated items survive")
+        assertEquals(
+            2,
+            input.size,
+            "the reasoning item, the invented call, and the invented output are ALL gone — " +
+                "a clean status-quo-shaped retry, no dangling reasoning, no orphan output",
+        )
+    }
+}

--- a/gateway/dialect-openai-responses/src/test/resources/contract/responses-codex-profile.json
+++ b/gateway/dialect-openai-responses/src/test/resources/contract/responses-codex-profile.json
@@ -13,6 +13,15 @@
                         "type": "object"
                     },
                     "strict": false
+                },
+                {
+                    "type": "function",
+                    "name": "Bash",
+                    "description": "",
+                    "parameters": {
+                        "type": "object"
+                    },
+                    "strict": false
                 }
             ]
         },

--- a/gateway/dialect-openai-responses/src/test/resources/contract/responses-codex-profile.json
+++ b/gateway/dialect-openai-responses/src/test/resources/contract/responses-codex-profile.json
@@ -1,0 +1,44 @@
+{
+    "model": "gpt-5.6-sol",
+    "input": [
+        {
+            "type": "additional_tools",
+            "role": "developer",
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "Read",
+                    "description": "",
+                    "parameters": {
+                        "type": "object"
+                    },
+                    "strict": false
+                }
+            ]
+        },
+        {
+            "role": "developer",
+            "content": "You are Splice, a contract fixture."
+        },
+        {
+            "role": "user",
+            "content": "Ping."
+        }
+    ],
+    "store": false,
+    "stream": true,
+    "include": [
+        "reasoning.encrypted_content"
+    ],
+    "prompt_cache_key": "splice-7d6e0aa0474b35db01b1f13cba38ea78",
+    "tool_choice": "auto",
+    "parallel_tool_calls": false,
+    "reasoning": {
+        "effort": "high",
+        "summary": "detailed",
+        "context": "all_turns"
+    },
+    "stream_options": {
+        "reasoning_summary_delivery": "sequential_cutoff"
+    }
+}

--- a/gateway/dialect-openai-responses/src/test/resources/contract/responses-tool-search.json
+++ b/gateway/dialect-openai-responses/src/test/resources/contract/responses-tool-search.json
@@ -1,0 +1,66 @@
+{
+    "model": "gpt-5.6-sol",
+    "input": [
+        {
+            "type": "additional_tools",
+            "role": "developer",
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "Read",
+                    "description": "",
+                    "parameters": {
+                        "type": "object"
+                    },
+                    "strict": false
+                },
+                {
+                    "type": "tool_search",
+                    "execution": "client",
+                    "description": "# Tool discovery\n\nSearches over deferred tool metadata and exposes matching tools for the next model call.\n\nSome of the tools may not have been provided to you upfront, and you should use this tool (`tool_search`) to search for the required tools. For MCP tool discovery, always use `tool_search` instead of `list_mcp_resources` or `list_mcp_resource_templates`.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "query": {
+                                "type": "string",
+                                "description": "Search query for deferred tools."
+                            },
+                            "limit": {
+                                "type": "number",
+                                "description": "Maximum number of tools to return. Defaults to 8."
+                            }
+                        },
+                        "required": [
+                            "query"
+                        ],
+                        "additionalProperties": false
+                    }
+                }
+            ]
+        },
+        {
+            "role": "developer",
+            "content": "You are Splice, a contract fixture."
+        },
+        {
+            "role": "user",
+            "content": "Ping."
+        }
+    ],
+    "store": false,
+    "stream": true,
+    "include": [
+        "reasoning.encrypted_content"
+    ],
+    "prompt_cache_key": "splice-7d6e0aa0474b35db01b1f13cba38ea78",
+    "tool_choice": "auto",
+    "parallel_tool_calls": false,
+    "reasoning": {
+        "effort": "high",
+        "summary": "detailed",
+        "context": "all_turns"
+    },
+    "stream_options": {
+        "reasoning_summary_delivery": "sequential_cutoff"
+    }
+}

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnDriver.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnDriver.kt
@@ -56,6 +56,8 @@ import splice.spi.ReanchorController
 import splice.spi.ReanchorRound
 import splice.spi.SseFrameTooLargeException
 import splice.spi.StreamTornBeforeClient
+import splice.spi.ToolSearchController
+import splice.spi.ToolSearchRound
 import splice.spi.TurnSignals
 import splice.spi.TurnWatchdog
 import splice.spi.UpstreamAuthMissing
@@ -89,6 +91,9 @@ internal data class TurnDrive(
     val signals: RunnerSignals,
     /** The client-facing SSE channel: coalesced writer + write mutex + clientGone flag. */
     val channel: ClientChannel,
+    /** The provider's answering policy for THIS turn's deferred tool surface. Null = no deferral
+     *  this turn, or the feature is off — the round loop is byte-for-byte unchanged. */
+    val toolSearch: ToolSearchController?,
 )
 
 /** Per-turn client write surface: the coalesced writer, a mutex serializing the emitter vs the
@@ -259,6 +264,10 @@ internal class TurnDriver(
         val meta = built.meta
         val bodyJson = built.requestBody.toString()
         perf.setCount(PerfKeys.UPSTREAM_REQ_BYTES, bodyJson.length.toLong())
+        // Tool-surface partition sizes — the expected-delta instrument (#959): setCount (not add)
+        // so a request that stamped tools_deferred=0 is VISIBLE, never silently absent.
+        meta.toolsEager?.let { perf.setCount(PerfKeys.TOOLS_EAGER, it.toLong()) }
+        meta.toolsDeferred?.let { perf.setCount(PerfKeys.TOOLS_DEFERRED, it.toLong()) }
         val watchdog = TurnWatchdog(provider.watchdog, clock)
         // Absorbed round failures still count for the G20 health split (code-review 2026-07-24).
         val signals = RunnerSignals(
@@ -271,6 +280,7 @@ internal class TurnDriver(
                 )
                 if (f.providerReported) health.provider() else health.local()
             },
+            onSearchRound = { perf.setCount(PerfKeys.SEARCH_ROUNDS, it.toLong()) },
         )
         return TurnDrive(
             bodyJson = bodyJson,
@@ -291,6 +301,7 @@ internal class TurnDriver(
             turnHeaders = built.extraHeaders,
             channel = channel,
             signals = signals,
+            toolSearch = built.toolSearch,
         )
     }
 
@@ -378,8 +389,9 @@ internal class TurnDriver(
                             finish = { outcome -> finishTurn(drive, outcome) },
                             reanchor = reanchor,
                             signals = drive.signals,
+                            toolSearch = drive.toolSearch,
                         ).run(drive.requestBody, fold)
-                    } else if (reanchor == null) {
+                    } else if (reanchor == null && drive.toolSearch == null) {
                         finishTurn(drive, postRound(drive, drive.bodyJson, drive.emitter, self, turnJob))
                     } else {
                         ReanchorRunner(
@@ -388,6 +400,7 @@ internal class TurnDriver(
                             postRound = { bodyJson -> postRound(drive, bodyJson, drive.emitter, self, turnJob) },
                             finish = { outcome -> finishTurn(drive, outcome) },
                             signals = drive.signals,
+                            toolSearch = drive.toolSearch,
                         ).run(drive.requestBody, reanchor)
                     }
                 } finally {
@@ -730,6 +743,31 @@ private fun TurnDrive.perfCounter(key: String): Long = perf.snapshot().counters[
 
 private const val ROUND_FAILURE_SNIPPET = 160
 
+/** The search-continuation gate, shared by both runners (never two copies — the v29 law). A
+ *  search NEVER continues past a watchdog fire or a dead client (the same rule re-anchor
+ *  applies), and never past a round that already committed a real tool_use to the client's wire
+ *  — that check lives inside ResponsesToolSearchController itself (TurnOutcome.Success.hasToolUse),
+ *  so it need not be repeated here. */
+internal fun searchContinuation(
+    search: ToolSearchController?,
+    outcome: TurnOutcome,
+    body: JsonObject,
+    roundIndex: Int,
+    signals: RunnerSignals,
+): JsonObject? {
+    if (search == null || outcome !is TurnOutcome.Success) return null
+    if (signals.watchdogFired() || signals.clientGone()) return null
+    return search.continuationForSearch(ToolSearchRound(body, outcome, roundIndex))
+}
+
+/** FoldRunner's rounds run through a BufferingWireSink: [TurnOutcome.Success.emittedText]/
+ *  [TurnOutcome.Success.bodyText] reflect what the round PRODUCED, not what reached the client.
+ *  Strips both before a search continuation can replay them — the same rule FoldRunner's own
+ *  re-anchor branch (trigger B) applies to its salvage. A no-op for ReanchorRunner's LIVE rounds
+ *  (non-Success outcomes pass through; searchContinuation's own type guard ignores them anyway). */
+internal fun bufferedForSearch(outcome: TurnOutcome): TurnOutcome =
+    if (outcome is TurnOutcome.Success) outcome.copy(bodyText = "", emittedText = false) else outcome
+
 internal class FoldRunner(
     // Only the buffer's `real` sink — never a terminal here (L3: FoldRunner finishes via [finish]).
     private val emitter: WireSink,
@@ -739,12 +777,14 @@ internal class FoldRunner(
     private val finish: suspend (TurnOutcome) -> Unit,
     private val reanchor: ReanchorController? = null,
     private val signals: RunnerSignals = RunnerSignals(),
+    private val toolSearch: ToolSearchController? = null,
 ) {
     suspend fun run(initialBody: JsonObject, fold: FoldController) {
         var body = initialBody
         var acc = RoundUsage()
         var roundIndex = 0
         var reanchorAttempt = 0
+        var searchIndex = 0
         val salvaged = mutableListOf<TurnOutcome.PartialRound>()
         val absorbedFailures = mutableListOf<TurnOutcome.Failure>()
         while (true) {
@@ -752,15 +792,19 @@ internal class FoldRunner(
             val outcome = postRound(body.toString(), buffer)
             val success = outcome as? TurnOutcome.Success
             if (success != null) acc = acc.plusRound(success.usage)
-            val next = success?.let { fold.continuation(FoldRound(body, it, roundIndex)) }
-            if (next != null) {
-                buffer.discard()
-                val reasoningTokens = success.usage.reasoningTokens
-                log("[$key] fold round ${roundIndex + 1}: reasoning truncated at $reasoningTokens tokens, continuing\n")
-                body = next
-                roundIndex++
+
+            // Fold-continuation and search are two of this loop's three continuation triggers,
+            // tried in that fixed precedence (a truncated round re-runs and re-emits its own
+            // search call next round, so this ordering is unchanged from before the extraction —
+            // detekt 2026-07-24: inlined here the loop carried 2 `continue`s + CC 11 + 50 lines).
+            val nextRound = nextRoundBody(fold, outcome, buffer, salvaged, RoundCursor(body, roundIndex, searchIndex))
+            if (nextRound != null) {
+                body = nextRound.body
+                roundIndex = nextRound.roundIndex
+                searchIndex = nextRound.searchIndex
                 continue
             }
+
             // Trigger B (code-review 2026-07-24: fold-eligible models — the truncation-prone
             // ones — previously had NO re-anchor cover). The round's final output was BUFFERED,
             // never forwarded, so bodyText is stripped from the salvage: replaying
@@ -791,6 +835,49 @@ internal class FoldRunner(
             reanchorAttempt++
         }
     }
+
+    /** The fold-continuation and search-continuation checks, extracted out of [run] (detekt
+     *  2026-07-24: LongMethod/CyclomaticComplexMethod/LoopWithTooManyJumpStatements). Null = neither
+     *  fired; the caller falls through to the re-anchor check exactly as before the extraction. */
+    private fun nextRoundBody(
+        fold: FoldController,
+        outcome: TurnOutcome,
+        buffer: BufferingWireSink,
+        salvaged: MutableList<TurnOutcome.PartialRound>,
+        cursor: RoundCursor,
+    ): RoundCursor? {
+        val (body, roundIndex, searchIndex) = cursor
+        val success = outcome as? TurnOutcome.Success
+        val foldNext = success?.let { fold.continuation(FoldRound(body, it, roundIndex)) }
+        if (foldNext != null) {
+            buffer.discard()
+            log(
+                "[$key] fold round ${roundIndex + 1}: reasoning truncated at " +
+                    "${success.usage.reasoningTokens} tokens, continuing\n",
+            )
+            return RoundCursor(foldNext, roundIndex + 1, searchIndex)
+        }
+        // FoldRunner's rounds run through a BufferingWireSink — reducer.emittedText/bodyText
+        // reflect what the round PRODUCED, not what reached the client. Strip both before the
+        // controller ever sees them, so a buffered-and-discarded round can never "vouch" for
+        // prose the client never saw in the search continuation's own replay (review 2026-07-24;
+        // the same rule this loop's own re-anchor branch below already applies).
+        val searchNext = searchContinuation(toolSearch, bufferedForSearch(outcome), body, searchIndex, signals)
+        if (searchNext != null) {
+            buffer.discard() // the buffered final output never reached the client
+            salvaged.add(searchPartial(outcome as TurnOutcome.Success, buffered = true))
+            val nextSearchIndex = searchIndex + 1
+            signals.onSearchRound(nextSearchIndex)
+            log("[$key] tool search round $nextSearchIndex: answering locally, continuing\n")
+            return RoundCursor(searchNext, roundIndex, nextSearchIndex)
+        }
+        return null
+    }
+
+    /** One position in the round loop: the body to POST plus the two round counters. Serves
+     *  BOTH directions — passed INTO [nextRoundBody] as the current cursor and returned as the
+     *  next one (detekt 2026-07-24: the 8-arg form tripped LongParameterList). */
+    private data class RoundCursor(val body: JsonObject, val roundIndex: Int, val searchIndex: Int)
 
     private fun continuationForFailedRound(outcome: TurnOutcome, body: JsonObject, attempt: Int): JsonObject? =
         when {
@@ -825,6 +912,9 @@ internal data class RunnerSignals(
     val watchdogFired: () -> Boolean = { false },
     val clientGone: () -> Boolean = { false },
     val onRoundFailure: (TurnOutcome.Failure) -> Unit = {},
+    /** Search-continuation counter sink — the expected-delta instrument. Stamped as an absolute
+     *  count, so a turn that never searched records nothing and a turn that did records exactly N. */
+    val onSearchRound: (Int) -> Unit = {},
 )
 
 /** The round-usage law, ONE implementation for both runners (2026-07-20, unified in the
@@ -852,6 +942,24 @@ internal data class RoundUsage(
         reasoningTokens = reasoningSum,
     )
 }
+
+/** The search-round salvage entry, shared by both runners so they cannot drift (the v29 law).
+ *  [buffered]=true (FoldRunner) means the round's output never reached the client — text signals
+ *  are stripped so a discarded round cannot vouch for content in the merge (the same rule the
+ *  fold re-anchor branch applies just above). [buffered]=false (ReanchorRunner) carries the
+ *  round's REAL emitted text truthfully — it already reached the wire. usage is zeroed on both;
+ *  the caller already folded it into acc. hasToolUse is always false: [searchContinuation] never
+ *  fires on a round that carried one. */
+internal fun searchPartial(success: TurnOutcome.Success, buffered: Boolean): TurnOutcome.PartialRound =
+    if (buffered) {
+        TurnOutcome.PartialRound(thinkingText = success.thinkingText, bodyText = "", emittedText = false)
+    } else {
+        TurnOutcome.PartialRound(
+            thinkingText = success.thinkingText,
+            bodyText = success.bodyText,
+            emittedText = success.emittedText,
+        )
+    }
 
 /** A turn that absorbed re-anchor rounds and STILL failed burned real billed tokens on those
  *  rounds; carry them on the Failure so finishTurn can account them (review-pr 2026-07-24 —
@@ -895,10 +1003,15 @@ internal class ReanchorRunner(
     private val postRound: suspend (bodyJson: String) -> TurnOutcome,
     private val finish: suspend (TurnOutcome) -> Unit,
     private val signals: RunnerSignals,
+    private val toolSearch: ToolSearchController? = null,
 ) {
-    suspend fun run(initialBody: JsonObject, reanchor: ReanchorController) {
+    // [reanchor] is nullable — a turn may reach this runner with search-only continuation (no
+    // ReanchorController at all): driveOneTurn routes here whenever EITHER exists, so the seam is
+    // total rather than resting on an undocumented cross-object invariant.
+    suspend fun run(initialBody: JsonObject, reanchor: ReanchorController?) {
         var body = initialBody
         var attempt = 0
+        var searchIndex = 0
         var acc = RoundUsage()
         val salvaged = mutableListOf<TurnOutcome.PartialRound>()
         val absorbedFailures = mutableListOf<TurnOutcome.Failure>()
@@ -907,8 +1020,22 @@ internal class ReanchorRunner(
             val failure = outcome as? TurnOutcome.Failure
             val next = failure
                 ?.takeIf { !signals.watchdogFired() && !signals.clientGone() }
-                ?.let { reanchor.continuationForFailure(ReanchorRound(body, it, attempt)) }
+                ?.let { reanchor?.continuationForFailure(ReanchorRound(body, it, attempt)) }
             if (next == null) {
+                // A search round is inserted HERE — after the failure-continuation is computed and
+                // found null, so it never competes with re-anchor for a retryable failure, and
+                // only ever fires on a Success (searchContinuation's own type guard).
+                val searchNext = searchContinuation(toolSearch, outcome, body, searchIndex, signals)
+                if (searchNext != null) {
+                    val searched = outcome as TurnOutcome.Success
+                    salvaged.add(searchPartial(searched, buffered = false))
+                    acc = acc.plusRound(searched.usage)
+                    body = searchNext
+                    searchIndex++
+                    signals.onSearchRound(searchIndex)
+                    log("[$key] tool search round $searchIndex: answering locally, continuing\n")
+                    continue
+                }
                 // Absorbed failures hit the health split ONLY when the turn ultimately succeeds
                 // (a rescued turn must not report a degraded provider as healthy); a turn that
                 // ultimately FAILS is attributed exactly once by finishTurn — firing per absorbed

--- a/gateway/gateway/src/test/kotlin/ReanchorRunnerTest.kt
+++ b/gateway/gateway/src/test/kotlin/ReanchorRunnerTest.kt
@@ -11,15 +11,38 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import splice.core.turn.ErrorType
+import splice.core.turn.ToolSearchCall
+import splice.core.turn.ToolSearchCallId
 import splice.core.turn.TurnOutcome
 import splice.core.turn.Usage
 import splice.gateway.head.FoldRunner
 import splice.gateway.head.ReanchorRunner
 import splice.gateway.head.RunnerSignals
 import splice.gateway.wire.SseEmitter
+import splice.spi.FoldController
 import splice.spi.ReanchorController
+import splice.spi.ToolSearchController
+import splice.spi.WireSink
 
 private fun continuationBody() = buildJsonObject { }
+
+// A search-carrying Success — usage/text default to a no-op round so tests opt into only what
+// they need (the ReanchorRunnerTest / FoldRunnerReanchorTest precedent's retryableFailure()).
+private fun searchSuccess(
+    outputTokens: Long = 0,
+    bodyText: String = "",
+    thinkingText: String = "",
+    emittedText: Boolean = false,
+    hasToolUse: Boolean = false,
+) = TurnOutcome.Success(
+    hasToolUse = hasToolUse,
+    incomplete = false,
+    usage = Usage(outputTokens = outputTokens),
+    thinkingText = thinkingText,
+    bodyText = bodyText,
+    emittedText = emittedText,
+    toolSearches = listOf(ToolSearchCall(ToolSearchCallId("ts_1"), "q", null, buildJsonObject { })),
+)
 
 private class Harness {
     val frames = mutableListOf<String>()
@@ -31,11 +54,13 @@ private class Harness {
     )
     var finished: TurnOutcome? = null
     val absorbed = mutableListOf<TurnOutcome.Failure>()
+    val searchRounds = mutableListOf<Int>()
 
     fun signals(watchdog: Boolean = false, gone: Boolean = false) = RunnerSignals(
         watchdogFired = { watchdog },
         clientGone = { gone },
         onRoundFailure = { absorbed.add(it) },
+        onSearchRound = { searchRounds.add(it) },
     )
 
     suspend fun finish(outcome: TurnOutcome) {
@@ -330,5 +355,283 @@ class FoldRunnerReanchorTest {
         ).run(continuationBody()) { null }
         assertEquals(0, asks)
         assertNull(h.finished as? TurnOutcome.Success)
+    }
+}
+
+// Search-continuation walls on ReanchorRunner (the search-only path — no ReanchorController at
+// all, or a ReanchorController that stays silent because nothing failed).
+class ReanchorRunnerSearchTest {
+
+    @Test
+    fun `a search round continues once, appends, and the turn emits exactly one terminal`() = runTest {
+        val h = Harness()
+        val rounds = ArrayDeque<suspend () -> TurnOutcome>()
+        rounds.add { searchSuccess() }
+        rounds.add {
+            TurnOutcome.Success(
+                hasToolUse = false,
+                incomplete = false,
+                usage = Usage(outputTokens = 5),
+                bodyText = "answer",
+                emittedText = true,
+            )
+        }
+        var searchAsks = 0
+        val search = ToolSearchController { round ->
+            // The runner consults the controller on EVERY Success round (searchContinuation only
+            // type/liveness-guards); the "nothing to answer" decision lives inside the real
+            // controller (ResponsesToolSearch.kt). Count only genuine answers, matching this
+            // test's intent ("a search round continues ONCE") — review 2026-07-24 round 1.
+            if (round.outcome.toolSearches.isEmpty()) {
+                null
+            } else {
+                searchAsks++
+                continuationBody()
+            }
+        }
+        ReanchorRunner(
+            key = "t",
+            log = { },
+            postRound = { rounds.removeFirst().invoke() },
+            finish = { h.finish(it) },
+            signals = h.signals(),
+            toolSearch = search,
+        ).run(continuationBody(), reanchor = null)
+
+        assertEquals(1, searchAsks)
+        assertEquals(1, h.count("message_stop"), "exactly one clean terminal")
+        assertEquals(0, h.count("error"))
+        val success = h.finished as TurnOutcome.Success
+        assertEquals("answer", success.bodyText)
+    }
+
+    @Test
+    fun `search salvage carries the round's real emitted text truthfully`() = runTest {
+        val h = Harness()
+        val rounds = ArrayDeque<suspend () -> TurnOutcome>()
+        rounds.add {
+            searchSuccess(
+                bodyText = "partial answer",
+                thinkingText = "reasoning so far",
+                emittedText = true,
+                outputTokens = 3,
+            )
+        }
+        rounds.add { TurnOutcome.Success(hasToolUse = false, incomplete = false, usage = Usage(outputTokens = 2)) }
+        val search = ToolSearchController { round ->
+            if (round.outcome.toolSearches.isEmpty()) null else continuationBody()
+        }
+        ReanchorRunner(
+            key = "t",
+            log = { },
+            postRound = { rounds.removeFirst().invoke() },
+            finish = { h.finish(it) },
+            signals = h.signals(),
+            toolSearch = search,
+        ).run(continuationBody(), reanchor = null)
+
+        val success = h.finished as TurnOutcome.Success
+        assertTrue(success.emittedText, "round-1's real emitted text must count for the honesty gate")
+        assertEquals("reasoning so far", success.thinkingText)
+        assertEquals("partial answer", success.bodyText)
+        assertEquals(5, success.usage.outputTokens)
+    }
+
+    @Test
+    fun `hasToolUse in the outcome reaches the controller, which then blocks the continuation`() = runTest {
+        val h = Harness()
+        var sawHasToolUse = false
+        val search = ToolSearchController { round ->
+            sawHasToolUse = round.outcome.hasToolUse
+            if (round.outcome.hasToolUse) null else continuationBody()
+        }
+        ReanchorRunner(
+            key = "t",
+            log = { },
+            postRound = { searchSuccess(hasToolUse = true) },
+            finish = { h.finish(it) },
+            signals = h.signals(),
+            toolSearch = search,
+        ).run(continuationBody(), reanchor = null)
+        assertTrue(sawHasToolUse, "the runner must pass the round's real hasToolUse to the controller")
+        assertEquals(1, h.count("message_stop"))
+    }
+
+    @Test
+    fun `a watchdog fire never continues a search - its cancellation owns the turn`() = runTest {
+        val h = Harness()
+        var asks = 0
+        val search = ToolSearchController {
+            asks++
+            continuationBody()
+        }
+        ReanchorRunner(
+            key = "t",
+            log = { },
+            postRound = { searchSuccess() },
+            finish = { h.finish(it) },
+            signals = h.signals(watchdog = true),
+            toolSearch = search,
+        ).run(continuationBody(), reanchor = null)
+        assertEquals(0, asks, "the controller is never consulted after a watchdog fire")
+        assertEquals(1, h.count("message_stop"))
+    }
+
+    @Test
+    fun `a gone client never continues a search`() = runTest {
+        val h = Harness()
+        var asks = 0
+        val search = ToolSearchController {
+            asks++
+            continuationBody()
+        }
+        ReanchorRunner(
+            key = "t",
+            log = { },
+            postRound = { searchSuccess() },
+            finish = { h.finish(it) },
+            signals = h.signals(gone = true),
+            toolSearch = search,
+        ).run(continuationBody(), reanchor = null)
+        assertEquals(0, asks)
+        assertEquals(1, h.count("message_stop"))
+    }
+
+    @Test
+    fun `the search counter is independent of the re-anchor attempt counter`() = runTest {
+        val h = Harness()
+        val rounds = ArrayDeque<suspend () -> TurnOutcome>()
+        rounds.add { retryableFailure(outputTokens = 1) }
+        rounds.add { searchSuccess(outputTokens = 1) }
+        rounds.add { TurnOutcome.Success(hasToolUse = false, incomplete = false, usage = Usage(outputTokens = 1)) }
+        val search = ToolSearchController { round ->
+            if (round.outcome.toolSearches.isEmpty()) null else continuationBody()
+        }
+        var reanchorAsks = 0
+        ReanchorRunner(
+            key = "t",
+            log = { },
+            postRound = { rounds.removeFirst().invoke() },
+            finish = { h.finish(it) },
+            signals = h.signals(),
+            toolSearch = search,
+        ).run(
+            continuationBody(),
+            ReanchorController { round ->
+                reanchorAsks++
+                if (round.attempt < 1) continuationBody() else null
+            },
+        )
+        assertEquals(1, reanchorAsks, "the re-anchor budget was consulted for its own retryable round only")
+        assertEquals(listOf(1), h.searchRounds, "one search round, an independent counter from re-anchor's attempt")
+        assertEquals(1, h.count("message_stop"))
+    }
+
+    @Test
+    fun `reanchor null and a non-null search still runs the loop`() = runTest {
+        val h = Harness()
+        val rounds = ArrayDeque<suspend () -> TurnOutcome>()
+        rounds.add { searchSuccess() }
+        rounds.add { TurnOutcome.Success(hasToolUse = false, incomplete = false, usage = Usage(outputTokens = 1)) }
+        val search = ToolSearchController { round ->
+            if (round.outcome.toolSearches.isEmpty()) null else continuationBody()
+        }
+        ReanchorRunner(
+            key = "t",
+            log = { },
+            postRound = { rounds.removeFirst().invoke() },
+            finish = { h.finish(it) },
+            signals = h.signals(),
+            toolSearch = search,
+        ).run(continuationBody(), reanchor = null)
+        assertEquals(1, h.count("message_stop"))
+    }
+}
+
+// Search-continuation walls on FoldRunner: buffered rounds strip bodyText/emittedText but keep
+// live thinking (the same rule fold's own re-anchor trigger-B applies), and fold-continuation
+// (a truncated round) takes precedence over a search on the same round.
+class FoldRunnerSearchTest {
+
+    @Test
+    fun `a fold-round search continuation discards the buffer and strips only the text signals`() = runTest {
+        val h = Harness()
+        val rounds = ArrayDeque<suspend (WireSink) -> TurnOutcome>()
+        rounds.add { sink ->
+            val i = sink.openText()
+            sink.textDelta(i, "buffered never-sent prose")
+            sink.closeBlock(i)
+            searchSuccess(
+                bodyText = "buffered never-sent prose",
+                thinkingText = "live reasoning",
+                emittedText = true,
+                outputTokens = 2,
+            )
+        }
+        rounds.add { _ ->
+            TurnOutcome.Success(
+                hasToolUse = false,
+                incomplete = false,
+                usage = Usage(outputTokens = 1),
+                bodyText = "final",
+                emittedText = true,
+            )
+        }
+        val search = ToolSearchController { round ->
+            if (round.outcome.toolSearches.isEmpty()) null else continuationBody()
+        }
+        FoldRunner(
+            emitter = h.emitter,
+            key = "t",
+            log = { },
+            postRound = { _, sink -> rounds.removeFirst().invoke(sink) },
+            finish = { h.finish(it) },
+            signals = h.signals(),
+            toolSearch = search,
+        ).run(continuationBody()) { null }
+
+        val success = h.finished as TurnOutcome.Success
+        assertEquals("final", success.bodyText, "the buffered never-sent prose must not leak into the merge")
+        assertEquals("live reasoning", success.thinkingText, "live-streamed thinking belongs in the mirror merge")
+        assertEquals(1, h.count("message_stop"))
+    }
+
+    @Test
+    fun `fold-continuation takes precedence over search on a round that is both truncated and searching`() = runTest {
+        val h = Harness()
+        // A dumb controller that always declines — the point is proving it is never even ASKED
+        // about the round that carries a search (round 1); round 2 legitimately has none.
+        var consultedForSearchingRound = false
+        val search = ToolSearchController { round ->
+            if (round.outcome.toolSearches.isNotEmpty()) consultedForSearchingRound = true
+            null
+        }
+        val fold = FoldController { round -> if (round.roundIndex == 0) continuationBody() else null }
+        val rounds = ArrayDeque<suspend (WireSink) -> TurnOutcome>()
+        rounds.add { _ ->
+            TurnOutcome.Success(
+                hasToolUse = false,
+                incomplete = false,
+                usage = Usage(reasoningTokens = 516),
+                toolSearches = listOf(ToolSearchCall(ToolSearchCallId("ts_1"), "q", null, buildJsonObject { })),
+            )
+        }
+        rounds.add { _ -> TurnOutcome.Success(hasToolUse = false, incomplete = false, usage = Usage(outputTokens = 1)) }
+        FoldRunner(
+            emitter = h.emitter,
+            key = "t",
+            log = { },
+            postRound = { _, sink -> rounds.removeFirst().invoke(sink) },
+            finish = { h.finish(it) },
+            signals = h.signals(),
+            toolSearch = search,
+        ).run(continuationBody(), fold)
+
+        assertEquals(
+            false,
+            consultedForSearchingRound,
+            "fold continuation wins on round 1; the search gate never sees that round's outcome",
+        )
+        assertEquals(1, h.count("message_stop"))
     }
 }

--- a/gateway/gateway/src/test/kotlin/UsageTest.kt
+++ b/gateway/gateway/src/test/kotlin/UsageTest.kt
@@ -10,8 +10,10 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import splice.core.turn.Usage
 import splice.core.usage.RateLimitState
 import splice.core.usage.computeUsageWarn
+import splice.gateway.head.RoundUsage
 import splice.gateway.usage.TurnUsage
 import splice.gateway.usage.UsageStore
 import splice.gateway.usage.buildUsagePayload
@@ -54,6 +56,22 @@ class UsageTest {
         val none = computeUsageWarn(outputTokens5h = 999_999, warnTokens5h = 0)
         assertEquals("ok", none.level)
         assertEquals("none", none.source)
+    }
+
+    // A search round re-POSTs the WHOLE conversation (tool_search_call/output appended to input),
+    // so it obeys the exact same RoundUsage law fold/re-anchor rounds do: input/cached are this
+    // round's OWN reading (last-round-wins), never summed — an inflated prompt count would fire
+    // Claude Code's context bar / autocompact early, the regression this law prevents.
+    @Test
+    fun `a search round obeys the RoundUsage law - last-round input cached, summed output reasoning`() {
+        var acc = RoundUsage()
+        acc = acc.plusRound(Usage(inputTokens = 1000, outputTokens = 50, cachedTokens = 800, reasoningTokens = 20))
+        acc = acc.plusRound(Usage(inputTokens = 1500, outputTokens = 30, cachedTokens = 1200, reasoningTokens = 10))
+        val usage = acc.toUsage()
+        assertEquals(1500, usage.inputTokens, "last round's input wins - never summed across rounds")
+        assertEquals(1200, usage.cachedTokens, "last round's cached wins")
+        assertEquals(80, usage.outputTokens, "output accrues per round")
+        assertEquals(30, usage.reasoningTokens, "reasoning accrues per round")
     }
 
     @Test

--- a/gateway/provider-codex/src/main/kotlin/splice/provider/codex/CodexProvider.kt
+++ b/gateway/provider-codex/src/main/kotlin/splice/provider/codex/CodexProvider.kt
@@ -37,6 +37,12 @@ public class CodexProvider(
             providerTag = "claudex",
             // richer titled reasoning sections from the ChatGPT backend (probed 2026-07-19)
             summaryDelivery = "sequential_cutoff",
+            // codex-rs parity: hard-sets strict:false on every function tool (responses_api.rs:29-32);
+            // OpenCode does the same, marked "Codex parity". Omitting it lets the backend attempt
+            // strict auto-normalisation of ~87 MCP schemas and silently report whatever it settled on.
+            // forceStrictFalse, NOT emitStrict (review 2026-07-24): emitStrict is grok's pre-existing,
+            // never-consequential pass-through flag — reusing it here silently changed grok's bytes too.
+            forceStrictFalse = true,
         )
     }
 }

--- a/gateway/provider-codex/src/test/kotlin/CodexProviderTest.kt
+++ b/gateway/provider-codex/src/test/kotlin/CodexProviderTest.kt
@@ -3,6 +3,10 @@
 // flag=true + a Bearer with an account id => header present; flag=false => absent, even with an
 // account id available.
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -12,10 +16,14 @@ import splice.core.auth.Credentials
 import splice.core.auth.RefreshableAuthProvider
 import splice.core.model.ModelCatalog
 import splice.core.model.ModelEntry
+import splice.core.parse.parseAnthropicBody
 import splice.core.turn.ReasoningDisplay
 import splice.core.turn.WatchdogBudget
+import splice.dialect.responses.ToolDeferralPolicy
 import splice.provider.codex.CodexProvider
 import splice.spi.ProviderTuning
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
 import kotlin.time.Duration.Companion.seconds
 
 class CodexProviderTest {
@@ -26,7 +34,7 @@ class CodexProviderTest {
         override suspend fun describe() = AuthDescription(true, "chatgpt-oauth", emptyMap())
     }
 
-    private fun provider(accountIdHeader: Boolean) = CodexProvider(
+    private fun provider(accountIdHeader: Boolean, toolSurface: ToolDeferralPolicy? = null) = CodexProvider(
         tuning = ProviderTuning(
             key = "codex",
             label = "claudex",
@@ -44,6 +52,7 @@ class CodexProviderTest {
         replayReasoning = false,
         configEffort = "high",
         configSummary = "detailed",
+        quirks = CodexProvider.defaultQuirks().copy(toolSurface = toolSurface),
         accountIdHeader = accountIdHeader,
     )
 
@@ -62,4 +71,84 @@ class CodexProviderTest {
         assertFalse(headers.containsKey("ChatGPT-Account-ID")) // the flag actually suppresses it
         assertTrue(headers.containsKey("Accept"))
     }
+
+    // A turn body with 1 builtin (eager) + 10 mcp-prefixed tools (deferrable at minDeferred=4).
+    private fun deferrableTurnBody() = parseAnthropicBody(
+        """{"model":"claude-codex--gpt-5.6-sol","stream":true,"max_tokens":1024,"system":"s",""" +
+            """"tools":[{"name":"Read","input_schema":{"type":"object"}},$TEN_MCP_TOOLS],""" +
+            """"messages":[{"role":"user","content":"hi"}]}""",
+    )
+
+    /** Runs [block] with stderr captured, restoring the original stream in [finally] — same
+     *  idiom as DoctorCommandTest's System.setOut capture. */
+    private fun <T> captureStderr(block: () -> T): Pair<T, String> {
+        val err = ByteArrayOutputStream()
+        val original = System.err
+        return try {
+            System.setErr(PrintStream(err, true, Charsets.UTF_8))
+            block() to err.toString(Charsets.UTF_8)
+        } finally {
+            System.setErr(original)
+        }
+    }
+
+    // review 2026-07-25 (PR top-level comment 7): the latch-close path (amendBodyOnFailure ->
+    // dropToolSearchTool -> ToolSurfaceLatch.close) had no direct test — every existing test
+    // exercises dropToolSearchTool as a free function (ToolSurfaceTest.kt) or the partition in
+    // isolation, never through a real provider instance's amendBodyOnFailure, and never checking
+    // that a LATER buildTurn on that same instance actually restores full eager. Drives the real
+    // sequence end to end and pins the ResponsesProvider.logToolSurfaceLatchClosed signal
+    // (comment 2) firing exactly once, not once per amend attempt or per turn.
+    @Test
+    fun `a shape-400 through amendBodyOnFailure strips tool_search, closes the latch once, next turn is eager`() {
+        val deferring = provider(accountIdHeader = false, toolSurface = ToolDeferralPolicy(minDeferred = 4))
+        val body = deferrableTurnBody()
+        val before = deferring.buildTurn(body, compact = false, sessionId = "s1")
+        assertEquals(10, before.meta.toolsDeferred, "setup: this turn actually deferred the mcp tools")
+        assertEquals(1, before.meta.toolsEager)
+
+        val (turnResult, logged) = captureStderr {
+            val amended = deferring.amendBodyOnFailure(SHAPE_400, SHAPE_400_TEXT, REJECTED_TOOL_SEARCH_BODY)
+            // a second rejection on the now-closed latch must not fire a second log line
+            deferring.amendBodyOnFailure(SHAPE_400, SHAPE_400_TEXT, REJECTED_TOOL_SEARCH_BODY)
+            amended to deferring.buildTurn(body, compact = false, sessionId = "s1")
+        }
+        val (amended, after) = turnResult
+
+        assertTrue(amended != null)
+        val amendedInput = Json.parseToJsonElement(amended!!).jsonObject["input"]!!.jsonArray
+        assertEquals(1, amendedInput[0].jsonObject["tools"]!!.jsonArray.size, "tool_search TOOL entry stripped")
+        val strippedTypes = setOf("tool_search_call", "tool_search_output", "reasoning")
+        assertTrue(
+            amendedInput.none { it.jsonObject["type"]?.jsonPrimitive?.content in strippedTypes },
+            "the synthesized call/output items and their now-dangling reasoning are stripped too",
+        )
+
+        assertEquals(0, after.meta.toolsDeferred, "latch closed -> the next turn builds the full eager surface")
+        assertEquals(11, after.meta.toolsEager, "all 11 tools (1 builtin + 10 mcp) ride eager now")
+        assertEquals(1, logged.lines().count { "tool-surface latch closed" in it }, "fires exactly once, not per turn")
+    }
 }
+
+private const val SHAPE_400 = 400
+private const val SHAPE_400_TEXT = "Unknown parameter: 'tool_search'"
+
+private val TEN_MCP_TOOLS = (1..10).joinToString(",") {
+    """{"name":"mcp__exa__tool_$it","input_schema":{"type":"object"}}"""
+}
+
+// A realistic post-rejection body: the additional_tools tool_search TOOL entry, plus a
+// synthesized reasoning + tool_search_call + tool_search_output round already appended to
+// `input` — same fixture shape as ToolSurfaceTest.kt's dropToolSearchTool tests, driven here
+// through the real provider instance (CodexProviderTest) instead of the free function.
+private const val REJECTED_TOOL_SEARCH_BODY = """{"model":"gpt-5.6-sol","input":[
+    {"type":"additional_tools","role":"developer","tools":[
+        {"type":"function","name":"Bash","description":"d","parameters":{"type":"object","properties":{}}},
+        {"type":"tool_search","execution":"client","description":"x",
+         "parameters":{"type":"object","properties":{}}}
+    ]},
+    {"role":"developer","content":"hi"},
+    {"type":"reasoning","id":"rs_1","encrypted_content":"enc"},
+    {"type":"tool_search_call","call_id":"ts_1","execution":"client","arguments":"{}"},
+    {"type":"tool_search_output","call_id":"ts_1","status":"completed","execution":"client","tools":[]}
+],"store":false,"stream":true}"""

--- a/gateway/provider-spi/src/main/kotlin/splice/spi/Provider.kt
+++ b/gateway/provider-spi/src/main/kotlin/splice/spi/Provider.kt
@@ -27,6 +27,10 @@ public data class BuiltTurn(
     val requestBody: JsonObject,
     val meta: TurnMeta,
     val extraHeaders: Map<String, String> = emptyMap(),
+    /** The answering policy for THIS turn's deferred surface, built by the request builder (the
+     *  only place that knows what was deferred). Null = no deferral this turn, or the feature is
+     *  off — the gateway's round loop is byte-for-byte unchanged. */
+    val toolSearch: ToolSearchController? = null,
 )
 
 /** Per-turn liveness signals the gateway hands the translator: the watchdog's typed sentinel and

--- a/gateway/provider-spi/src/main/kotlin/splice/spi/ToolSearchController.kt
+++ b/gateway/provider-spi/src/main/kotlin/splice/spi/ToolSearchController.kt
@@ -1,0 +1,30 @@
+// NEW: the answer-the-search-and-continue SPI — the SUCCESS-side sibling of ReanchorController
+// (which continues FAILED rounds) and FoldController (which continues TRUNCATED rounds). The
+// Responses `tool_search` tool declares execution:"client", so the GATEWAY answers it, never
+// Claude Code: the model emits a tool_search_call item and blocks until a tool_search_output
+// item appears in input. Keeping the contract HERE (not in the dialect) is why :gateway can run
+// the extra round without importing a concrete dialect — the module law again. Invariants:
+//   - request-scoped, NOT meta-scoped: the answer is a function of THIS request's deferred
+//     inventory, which TurnMeta does not and must not carry; it rides BuiltTurn and is garbage
+//     collected with the turn, so the provider stays immutable across concurrent turns;
+//   - returns a request BODY, never a terminal — a search round is invisible to Claude Code and
+//     can never reach WireSink (L3 stays a property of SseEmitter);
+//   - null = STOP: the gateway finishes the turn with the round's own outcome.
+package splice.spi
+
+import kotlinx.serialization.json.JsonObject
+import splice.core.turn.TurnOutcome
+
+public fun interface ToolSearchController {
+    public fun continuationForSearch(round: ToolSearchRound): JsonObject?
+}
+
+/** One completed round that asked the gateway a question: the request that produced it, its
+ *  outcome (carrying the calls + this round's reasoning envelopes), and how many search
+ *  continuations this turn already spent (0-based, counted SEPARATELY from the re-anchor budget —
+ *  a search is not a failure and must never consume re-anchor attempts). */
+public data class ToolSearchRound(
+    val requestBody: JsonObject,
+    val outcome: TurnOutcome.Success,
+    val roundIndex: Int,
+)


### PR DESCRIPTION
Closes part of #47.

## Problem

On `openai-responses` heads (codex provider, `gpt-5.6-*`), splice forwards the client's **entire** tool list on every request — measured **64–87 discrete function schemas**, median upstream request **375 KB**. Two costs:

1. **Tokens**, on every turn of every conversation.
2. **Tool-selection thrash** — the model is asked to choose among dozens of tools per step. This shows up as excessive sub-agent spawning, repeated attempts at the same tool, and stalled turns. It does *not* surface as an API error, so it is invisible in failure metrics.

OpenAI's own client does not do this: for `gpt-5.6-*` it runs `tool_mode = "code_mode_only"`, collapsing nearly all tools into a single grammar-constrained `exec` tool (~3 tools instead of dozens).

## Why not `code_mode`

Evaluated and rejected for a translation gateway. The model returns a *program*, and the tools it calls belong to the downstream client (which owns permissions, approvals, and execution). Honoring that would require suspending and resuming the program across separate HTTP round-trips; a restart, eviction, or interruption mid-program would leave the conversation unrecoverable, with side-effecting tool calls potentially re-executed on replay. That failure mode is worse than the problem being solved, and it cannot satisfy the never-below-status-quo law.

This PR ports the other sanctioned mechanism instead: **defer the long tail and answer `tool_search` at the gateway**, inside the existing multi-round turn loop (the same machinery fold/re-anchor already use — no new concurrency model, no new terminal path).

## Cache stability is the load-bearing property

This is the part worth reviewing closely. The tool payload rides at **`input[0]`** under a single `prompt_cache_key` for the whole conversation, so **anything that varies it per turn re-bills the entire cached prefix** (~94k tokens in the measured profile) — which would cost more than deferral saves and make the feature a net regression.

Three invariants keep it stable, each pinned by a test:

- The eager/deferred split is a **pure function of `(body.tools, policy)`**. No transcript input can reach it, so `input[0]` is byte-identical on every turn.
- A deferred tool used earlier in the transcript is re-declared **in position** — a `tool_search_call`/`tool_search_output` pair carrying its full schema, immediately before its `function_call` — and is **never** promoted into `input[0]`.
- The synthetic `call_id` is `sha256(toolName)`, so the injected pair is byte-identical across turns. (A counter or timestamp here would silently reintroduce the bust.)

This mirrors the reference implementation, which never injects a searched tool into `tools[]`; its own regression test pins the rule:

> `"follow-up request should rely on tool_search_output history, not tool injection"`
> — `codex-rs/core/tests/suite/search_tool.rs:782-814`

The mechanism that makes it work: `ToolSearchOutput { tools: Vec<LoadableToolSpec> }` carries the tool's **full schema into history**, so the model learns tools from history rather than from the tools array.

## Safety

- **Off by default.** `quirks.toolSurface == null` unless a `[providers.*.tool_surface]` table opts in. With it off the request is byte-identical to today (pinned by test + the untouched contract fixtures).
- **Never below status quo.** Cache miss, shape rejection, bad operator config, or a tool whose schema is gone all degrade to today's behavior — never a failed turn. Numeric knobs are clamped at assembly (a `search_limit = 0` typo previously threw).
- **Shape-400 recovery** strips both the `tool_search` tool *and* the invented `tool_search_call`/`tool_search_output` items (plus any dangling `reasoning` item), so the one-shot amend budget retries a clean status-quo-shaped request.
- **Grok untouched.** `forceStrictFalse` (codex parity: `strict:false` on every function tool, matching both reference clients) is deliberately kept **distinct** from grok's pre-existing `emitStrict`; folding them would have silently changed grok's live wire bytes.

## Verification

- `./gradlew check` green; **31/31** ast-grep walls; `config-guard` pass.
- `ToolSurfaceRequestTest` **9/9**, `ToolSurfaceTest` **15/15**, 0 skipped.
- Explicit tests: `input[0]` byte-identical between turn N and turn N+1 (N+1 adds a `tool_use` + `tool_result` of a deferred tool); repeated builds byte-identical; declaration positioned immediately before its `function_call`; deferral-off byte-identical; a transcript `tool_use` naming an absent tool neither crashes nor emits an undeclared call.

## CI

Green. (An earlier revision of this description claimed a pre-existing `webui dist` failure; that was
wrong — it came from a local run with a drifted `node_modules` (react 19.2.7 against a 19.2.8 lockfile).
With a lockfile-synced install the committed bundle reproduces byte-identically, and CI reports
`gate: success`. Retracted in the thread below — notably, "fixing" it would have committed a react
downgrade.)

## Not in this PR

- Live measurement of the realized token saving. `TOOLS_EAGER` / `TOOLS_DEFERRED` are instrumented in the perf JSONL; correlating them against `cached_tokens` on a live head is the empirical confirmation and should happen before enabling this by default anywhere.
- Grok: **do not apply** — no analogue on the xAI chat-completions wire.
- Kimi: **needs its own investigation** — the Anthropic wire has a plausible `tool_search_tool` analogue, worth a cheap live probe.

