### PR TITLE
fix(gateway): recover 16 unmerged hardening fixes + two generation-time walls

### DIFF
--- a/.rules/kotlin-splice/kt-force-strict-false-is-literal.yml
+++ b/.rules/kotlin-splice/kt-force-strict-false-is-literal.yml
@@ -30,6 +30,12 @@ rule:
       kind: when_condition
       regex: '^forceStrictFalse$'
 constraints:
+  # FIELD is pinned (review #49): unconstrained, the rule fired on ANY put in the branch — a
+  # future compliant edit that groups another builder call into it (e.g. put(FIELD_DEFER_LOADING,
+  # true)) would be blocked mid-write. A wall that fires on compliant code teaches agents that
+  # wall output is noise, which is the failure #924 is about.
+  FIELD:
+    regex: '^FIELD_STRICT$'
   VAL:
     not:
       regex: '^false$'

--- a/.rules/kotlin-splice/kt-force-strict-false-is-literal.yml
+++ b/.rules/kotlin-splice/kt-force-strict-false-is-literal.yml
@@ -1,0 +1,35 @@
+# VENDOR-PARITY WALL (2026-07-25): a `forceStrictFalse` branch must emit the LITERAL false.
+# The quirk exists for ONE reason — codex-rs hard-sets `strict:false` on EVERY function tool
+# regardless of the tool's own value (responses_api.rs:29-32; OpenCode does the same, marked
+# "Codex parity"). It SHIPPED as `put(FIELD_STRICT, t.strict == true)` in BOTH tool builders:
+# the KDoc promised a hard-set, the code passed the tool's own value through. A ToolDefinition
+# with strict=true would have sent strict:true where codex-rs sends false — a parity break in
+# the very quirk that exists for parity.
+#
+# It survived the gate because the contract golden meant to pin it ("pins strict false on every
+# function tool") used a fixture tool with NO strict field, so the assertion could not observe
+# the difference. Human review caught it; nothing mechanical did. This is the generation-time
+# half (PreToolUse scans the PROPOSED write) of that invariant; the gate half is the contract
+# fixture, which now carries a strict:true tool.
+id: kt-force-strict-false-is-literal
+language: kotlin
+severity: error
+message: "A forceStrictFalse branch must emit the LITERAL false — passing the tool's own strict value through defeats the codex-parity hard-set the quirk exists for (shipped bug, 2026-07-25)."
+note: >
+  Write `put(FIELD_STRICT, false)`. If a provider genuinely needs the tool's own value passed
+  through, that is the SEPARATE `emitStrict` quirk — do not overload forceStrictFalse, which is
+  defined as an unconditional hard-set (ResponsesQuirks KDoc, ResponsesRequestBuilder.kt).
+files:
+  - gateway/*/src/main/**/*.kt
+rule:
+  pattern: put($FIELD, $VAL)
+  inside:
+    kind: when_entry
+    stopBy: end
+    has:
+      kind: when_condition
+      regex: '^forceStrictFalse$'
+constraints:
+  VAL:
+    not:
+      regex: '^false$'

--- a/.rules/kotlin-splice/kt-tool-partition-no-transcript.yml
+++ b/.rules/kotlin-splice/kt-tool-partition-no-transcript.yml
@@ -1,0 +1,38 @@
+# PROMPT-CACHE WALL (2026-07-25): the deferred-tool partition must never read the transcript.
+# The tool payload rides `additional_tools` at input[0], AHEAD of every conversation item, under a
+# single prompt_cache_key for the whole conversation — so the eager/deferred split is INSIDE the
+# cached prefix. If the split varies per turn, the prefix changes and the entire cache is re-billed:
+# measured ~94,000 previously-cached tokens re-charged per bust, against a saving of only a few
+# thousand to ~15K tokens/request from deferring the schemas. One bust outweighs dozens of requests
+# of savings, and busts recur per distinct newly-used deferred tool.
+#
+# The first implementation did exactly this — `partitionWithPolicy` called `warmToolNames(body)` to
+# force previously-used tools eager, which silently turned the feature into a NET TOKEN REGRESSION.
+# Three independent adversarial reviews missed it: all verified the bytes-when-stable case, none
+# tested turn-to-turn stability. The reference client never injects a searched tool into tools[]
+# either — its own regression test pins "follow-up request should rely on tool_search_output
+# history, not tool injection" (codex-rs core/tests/suite/search_tool.rs:782-814).
+#
+# A deferred tool used earlier in the transcript is declared IN POSITION instead (a
+# tool_search_call/output pair immediately before its function_call), which extends history rather
+# than rewriting the prefix. warmToolNames itself stays legal — it feeds that declaration replay.
+id: kt-tool-partition-no-transcript
+language: kotlin
+severity: error
+message: "The tool-surface partition must be a pure function of (tools, policy) — reading the transcript here varies input[0] per turn and re-bills the whole prompt-cache prefix (~94k tokens/bust)."
+note: >
+  Keep the split derived from the tool list and policy only. If a transcript-derived tool needs to
+  reach the model, DECLARE it in position (tool_search_call/output before its function_call) instead
+  of promoting it into the eager set — that extends history without rewriting the cached prefix.
+files:
+  - gateway/*/src/main/**/*.kt
+rule:
+  any:
+    - pattern: $X.messages
+    - pattern: warmToolNames($$$ARGS)
+  inside:
+    kind: function_declaration
+    stopBy: end
+    has:
+      kind: simple_identifier
+      regex: '^partition'

--- a/.rules/rule-tests/kt-force-strict-false-is-literal-test.yml
+++ b/.rules/rule-tests/kt-force-strict-false-is-literal-test.yml
@@ -4,6 +4,14 @@ valid:
   - 'when { emitStrict && t.strict == true -> put(FIELD_STRICT, true) }'
   - 'when { lite -> put(FIELD_TOOL_CHOICE, "auto") }'
   - 'put(FIELD_STRICT, t.strict == true)'
+  # grouped branch: only FIELD_STRICT is governed — a sibling put must not be blocked (review #49)
+  - |
+    when {
+        forceStrictFalse -> {
+            put(FIELD_STRICT, false)
+            put(FIELD_DEFER_LOADING, true)
+        }
+    }
 invalid:
   - 'when { forceStrictFalse -> put(FIELD_STRICT, t.strict == true) }'
   - 'when { forceStrictFalse -> put(FIELD_STRICT, t.strict) }'

--- a/.rules/rule-tests/kt-force-strict-false-is-literal-test.yml
+++ b/.rules/rule-tests/kt-force-strict-false-is-literal-test.yml
@@ -1,0 +1,11 @@
+id: kt-force-strict-false-is-literal
+valid:
+  - 'when { forceStrictFalse -> put(FIELD_STRICT, false) }'
+  - 'when { emitStrict && t.strict == true -> put(FIELD_STRICT, true) }'
+  - 'when { lite -> put(FIELD_TOOL_CHOICE, "auto") }'
+  - 'put(FIELD_STRICT, t.strict == true)'
+invalid:
+  - 'when { forceStrictFalse -> put(FIELD_STRICT, t.strict == true) }'
+  - 'when { forceStrictFalse -> put(FIELD_STRICT, t.strict) }'
+  - 'when { forceStrictFalse -> put(FIELD_STRICT, strict == true) }'
+  - 'when { forceStrictFalse -> put(FIELD_STRICT, true) }'

--- a/.rules/rule-tests/kt-tool-partition-no-transcript-test.yml
+++ b/.rules/rule-tests/kt-tool-partition-no-transcript-test.yml
@@ -1,0 +1,28 @@
+id: kt-tool-partition-no-transcript
+valid:
+  # the pure form: split derived from tools + policy only
+  - |
+    private fun partitionWithPolicy(tools: List<ToolDefinition>, policy: ToolDeferralPolicy): ToolPartition {
+        val deferred = tools.filter { eligibleForDefer(it, policy) }
+        return ToolPartition(tools, deferred)
+    }
+  # warmToolNames' OWN definition is legal — it feeds in-position declaration replay, not the split
+  - |
+    internal fun warmToolNames(body: AnthropicRequest): Set<String> =
+        body.messages.asSequence().filterIsInstance<ToolUseBlock>().mapTo(HashSet()) { it.name }
+  # transcript reads outside any partition function are unaffected
+  - |
+    private fun declarationCandidates(body: AnthropicRequest): Set<String> = warmToolNames(body)
+invalid:
+  # the shape that shipped and silently defeated the feature
+  - |
+    private fun partitionWithPolicy(body: AnthropicRequest, policy: ToolDeferralPolicy): ToolPartition {
+        val warm = warmToolNames(body)
+        return ToolPartition(body.tools, body.tools.filter { it.name !in warm })
+    }
+  # the same defect reached directly rather than via the helper
+  - |
+    private fun partitionTools(body: AnthropicRequest, policy: ToolDeferralPolicy): ToolPartition {
+        val used = body.messages.flatMap { it.content }
+        return ToolPartition(body.tools, emptyList())
+    }

--- a/gateway/app/src/main/kotlin/splice/app/OAuthLoginFlow.kt
+++ b/gateway/app/src/main/kotlin/splice/app/OAuthLoginFlow.kt
@@ -231,10 +231,9 @@ public object OAuthLoginFlow {
                 }
                 val bodyText = resp.bodyAsText()
                 if (!resp.status.isSuccess()) {
-                    println(
-                        "splice: token exchange failed (HTTP ${resp.status.value}): " +
-                            sanitize(bodyText.take(ERR_BODY_CAP)),
-                    )
+                    // Never print the provider's response body here — a provider that echoes a
+                    // secret into error_description must not surface it on the operator's terminal.
+                    println("splice: token exchange failed (HTTP ${resp.status.value})")
                     false
                 } else {
                     writeCredentialFile(spec.authPath, spec.toAuthJson(bodyText))

--- a/gateway/core/src/main/kotlin/splice/core/config/ConfigService.kt
+++ b/gateway/core/src/main/kotlin/splice/core/config/ConfigService.kt
@@ -146,7 +146,14 @@ public class ConfigService(
         val data = LinkedHashMap<String, Any?>()
         for (knob in Knob.entries) {
             val raw = knob.envNames.firstNotNullOfOrNull { name -> envReader(name)?.takeIf { it.isNotEmpty() } }
-            if (raw != null) coerce(knob, raw)?.let { data[knob.key] = it }
+            if (raw != null) {
+                val coerced = coerce(knob, raw)
+                if (coerced != null) {
+                    data[knob.key] = coerced
+                } else {
+                    System.err.println("[config] ignoring invalid env value for ${knob.key}: '$raw'")
+                }
+            }
         }
         return data
     }

--- a/gateway/core/src/main/kotlin/splice/core/config/ConfigService.kt
+++ b/gateway/core/src/main/kotlin/splice/core/config/ConfigService.kt
@@ -117,7 +117,12 @@ public class ConfigService(
         if (!Files.exists(path)) return emptyMap()
         val modified = Files.getLastModifiedTime(path)
         val size = Files.size(path)
-        fileCache?.let { cached ->
+        // A same-second edit that lands at an identical byte count is invisible to (mtime, size)
+        // alone (torn-read risk) — refuse the cache while the file's mtime is still within the
+        // resolution window, forcing a fresh read until it ages past it.
+        val cacheable = System.currentTimeMillis() - modified.toMillis() >= MTIME_RESOLUTION_WINDOW_MS
+        val cached = fileCache
+        if (cacheable && cached != null) {
             if (cached.path == path && cached.modified == modified) {
                 if (cached.size == size) return cached.data
             }
@@ -158,7 +163,7 @@ public class ConfigService(
                 SecureFile.writeAtomic0600(path, json.encodeToString(JsonObject.serializer(), next) + "\n")
                 fileCache = null
             }
-        }
+        }.onFailure { e -> System.err.println("[config] failed to persist config to disk: $e") }
     }
 
     private fun readOnDisk(path: Path): JsonObject =
@@ -227,6 +232,9 @@ public class ConfigService(
     }
 
     private companion object {
+        // Filesystem mtime granularity is 1s on many platforms; a same-second edit landing at an
+        // identical byte count is otherwise indistinguishable from an unchanged file (CONF-3).
+        const val MTIME_RESOLUTION_WINDOW_MS = 2_000L
         const val MIN_UPSTREAM_TIMEOUT_MS = 30_000L
         const val MIN_FIRST_BYTE_MS = 10_000L
         const val MIN_STREAM_IDLE_MS = 30_000L

--- a/gateway/core/src/main/kotlin/splice/core/util/AsyncFileIo.kt
+++ b/gateway/core/src/main/kotlin/splice/core/util/AsyncFileIo.kt
@@ -5,6 +5,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -15,6 +16,8 @@ import java.util.concurrent.atomic.AtomicInteger
  */
 public object AsyncFileIo {
     private val pending = AtomicInteger()
+    private val dropped = AtomicInteger()
+    private val warned = AtomicBoolean(false)
     private val executor = ScheduledThreadPoolExecutor(1) { task ->
         Thread(task, "splice-file-io").apply { isDaemon = true }
     }.apply {
@@ -25,6 +28,7 @@ public object AsyncFileIo {
     public fun submit(delayMs: Long = 0L, task: () -> Unit): Boolean {
         if (pending.incrementAndGet() > MAX_PENDING_TASKS) {
             pending.decrementAndGet()
+            recordDrop()
             return false
         }
         val guarded = Runnable {
@@ -43,7 +47,20 @@ public object AsyncFileIo {
             true
         } catch (_: RejectedExecutionException) {
             pending.decrementAndGet()
+            recordDrop()
             false
+        }
+    }
+
+    /** Total tasks dropped since process start (pending cap exceeded or executor rejection). */
+    public fun droppedCount(): Int = dropped.get()
+
+    // Observable drop (CONF-1): 3 of 4 callers ignore submit()'s boolean, so a drop was previously
+    // silent data loss. Warn once on the first drop rather than spamming stderr under load.
+    private fun recordDrop() {
+        dropped.incrementAndGet()
+        if (warned.compareAndSet(false, true)) {
+            System.err.println("[async-file-io] task dropped (pending cap or rejection) — further drops silent")
         }
     }
 

--- a/gateway/core/src/main/kotlin/splice/core/util/JsonlSink.kt
+++ b/gateway/core/src/main/kotlin/splice/core/util/JsonlSink.kt
@@ -49,7 +49,10 @@ public object JsonlSink {
             val text = StandardCharsets.UTF_8.decode(buf).toString()
             // Mid-file start: drop the leading partial line (no newline at all -> nothing complete).
             val complete = if (readFrom > 0L) text.substringAfter('\n', missingDelimiterValue = "") else text
-            complete.lineSequence().filter { it.isNotEmpty() }.toList()
+            // Trailing tear: a torn write (disk-full mid-append) leaves bytes with no closing newline;
+            // every well-formed record ends in '\n', so drop a non-newline-terminated trailing remnant.
+            val whole = if (complete.endsWith('\n')) complete else complete.substringBeforeLast('\n', "")
+            whole.lineSequence().filter { it.isNotEmpty() }.toList()
         }
 
     private const val DEFAULT_MAX_BYTES = 64L * 1024 * 1024

--- a/gateway/dialect-anthropic-passthrough/src/main/kotlin/splice/dialect/passthrough/PassthroughRequestBuilder.kt
+++ b/gateway/dialect-anthropic-passthrough/src/main/kotlin/splice/dialect/passthrough/PassthroughRequestBuilder.kt
@@ -194,16 +194,27 @@ public class PassthroughRequestBuilder(private val quirks: PassthroughQuirks) {
 
     // --- helpers ---------------------------------------------------------------------------------
 
-    /** Recursively remove every `cache_control` key; other structure passes verbatim. */
-    private fun stripCacheControl(element: JsonElement): JsonElement = when (element) {
-        is JsonObject -> buildJsonObject {
-            for ((key, value) in element) if (key != CACHE_CONTROL) put(key, stripCacheControl(value))
+    /** Recursively remove every `cache_control` key; other structure passes verbatim. Bounded by
+     *  [DEPTH_CAP] (mirrors MfjsSanitizer's guard): client-supplied JSON deeper than the cap is
+     *  passed through AS-IS beyond that point — cache_control stripping at extreme depth is
+     *  immaterial, and this must never StackOverflow on adversarially nested input. */
+    private fun stripCacheControl(element: JsonElement, depth: Int = 0): JsonElement {
+        if (depth >= DEPTH_CAP) return element
+        return when (element) {
+            is JsonObject -> buildJsonObject {
+                for ((key, value) in element) {
+                    if (key != CACHE_CONTROL) put(key, stripCacheControl(value, depth + 1))
+                }
+            }
+            is JsonArray -> buildJsonArray { element.forEach { add(stripCacheControl(it, depth + 1)) } }
+            else -> element
         }
-        is JsonArray -> buildJsonArray { element.forEach { add(stripCacheControl(it)) } }
-        else -> element
     }
 
     private companion object {
+        // stripCacheControl's recursion guard (WIRE-1) — far above any legitimate request's
+        // nesting, well below a stack-overflow depth.
+        const val DEPTH_CAP = 200
         const val MODEL = "model"
         const val STREAM = "stream"
         const val THINKING = "thinking"

--- a/gateway/dialect-openai-chat/src/main/kotlin/splice/dialect/chat/ChatStreamTranslator.kt
+++ b/gateway/dialect-openai-chat/src/main/kotlin/splice/dialect/chat/ChatStreamTranslator.kt
@@ -79,7 +79,8 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
     override suspend fun driveTurn(upstream: Flow<JsonObject>, sink: WireSink): TurnOutcome {
         try {
             upstream.collect { evt ->
-                if (bufferOverCapacity(textBuf.length, thinkingBuf.length, toolIndexById.size)) {
+                val toolCount = maxOf(toolIndexById.size, pendingTools.size)
+                if (bufferOverCapacity(textBuf.length, thinkingBuf.length, toolCount)) {
                     runawayGuard = RUNAWAY_GUARD_MESSAGE
                     return@collect
                 }

--- a/gateway/dialect-openai-chat/src/main/kotlin/splice/dialect/chat/ChatStreamTranslator.kt
+++ b/gateway/dialect-openai-chat/src/main/kotlin/splice/dialect/chat/ChatStreamTranslator.kt
@@ -80,7 +80,12 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
         try {
             upstream.collect { evt ->
                 val toolCount = maxOf(toolIndexById.size, pendingTools.size)
-                if (bufferOverCapacity(textBuf.length, thinkingBuf.length, toolCount)) {
+                // pendingTools' per-entry `args` accumulate BEFORE the tool opens (deferred-open:
+                // a backend may stream index+id and large argument deltas but never function.name),
+                // so an entry count alone leaves those chars unbounded — review #49. Normally a
+                // handful of entries; the count cap bounds the sum's worst case.
+                val pendingArgsChars = pendingTools.values.sumOf { it.args.length }
+                if (bufferOverCapacity(textBuf.length, thinkingBuf.length, toolCount, pendingArgsChars)) {
                     runawayGuard = RUNAWAY_GUARD_MESSAGE
                     return@collect
                 }
@@ -349,11 +354,17 @@ private const val MAX_BUFFERED_CHARS = 20_000_000
 private const val MAX_TOOL_INDEX_ENTRIES = 50_000
 private const val RUNAWAY_GUARD_MESSAGE = "chat backend: response exceeded max buffered size — aborting"
 
-/** True once any of textBuf/thinkingBuf/toolIndexById has grown past its cap. Top-level (off the
- *  class function budget) — reads only its arguments; the caller latches [ChatStreamTranslator]'s
- *  own runawayGuard state. */
-private fun bufferOverCapacity(textLen: Int, thinkingLen: Int, toolIndexCount: Int): Boolean =
-    textLen >= MAX_BUFFERED_CHARS || thinkingLen >= MAX_BUFFERED_CHARS || toolIndexCount >= MAX_TOOL_INDEX_ENTRIES
+/** True once textBuf/thinkingBuf, the tool-index map, or the not-yet-opened tools' buffered
+ *  arguments have grown past their cap. Top-level (off the class function budget) — reads only its
+ *  arguments; the caller latches [ChatStreamTranslator]'s own runawayGuard state. */
+private fun bufferOverCapacity(
+    textLen: Int,
+    thinkingLen: Int,
+    toolIndexCount: Int,
+    pendingArgsLen: Int,
+): Boolean =
+    textLen >= MAX_BUFFERED_CHARS || thinkingLen >= MAX_BUFFERED_CHARS ||
+        toolIndexCount >= MAX_TOOL_INDEX_ENTRIES || pendingArgsLen >= MAX_BUFFERED_CHARS
 
 /** First non-empty cleartext reasoning field on a chat delta/message. Top-level (off the class
  *  function budget) — reads only its argument. */

--- a/gateway/dialect-openai-chat/src/main/kotlin/splice/dialect/chat/ChatStreamTranslator.kt
+++ b/gateway/dialect-openai-chat/src/main/kotlin/splice/dialect/chat/ChatStreamTranslator.kt
@@ -49,6 +49,12 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
     private var cachedTokens = 0L
     private var failure: String? = null
 
+    // WIRE-2/3/6: textBuf/thinkingBuf/toolIndexById exist for legitimate dedup/replay and must
+    // stay unbounded on the normal path; this local safety valve (never provider-reported) only
+    // trips far above any real response, cleanly failing the turn instead of a runaway upstream
+    // growing them without limit.
+    private var runawayGuard: String? = null
+
     // Index-less parallel tool_calls (Mistral-shape backends emit complete calls with no
     // `index`): each NEW id gets its own synthesized slot — defaulting to 0 folded every
     // parallel call into one corrupted block (ids/names dropped, arguments concatenated).
@@ -72,7 +78,13 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
 
     override suspend fun driveTurn(upstream: Flow<JsonObject>, sink: WireSink): TurnOutcome {
         try {
-            upstream.collect { evt -> onEvent(evt, sink) }
+            upstream.collect { evt ->
+                if (bufferOverCapacity(textBuf.length, thinkingBuf.length, toolIndexById.size)) {
+                    runawayGuard = RUNAWAY_GUARD_MESSAGE
+                    return@collect
+                }
+                onEvent(evt, sink)
+            }
         } catch (e: CancellationException) {
             // Only a watchdog fire may swallow cancellation; a real cancel propagates.
             if (ctx.watchdogFired() == null) throw e
@@ -91,7 +103,9 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
     // Ordering enforced by the shared spi.terminalPrecedence (a FINISHED turn beats a late
     // watchdog fire — the poller can sit on the socket-EOF read AFTER finish_reason arrived).
     private fun terminalOutcome(): TurnOutcome {
+        val runaway = runawayGuard
         val providerFailure = when {
+            runaway != null -> TurnOutcome.Failure(ErrorType.API_ERROR, runaway, providerReported = false)
             failure != null ->
                 TurnOutcome.Failure(ErrorType.API_ERROR, "chat backend: $failure", providerReported = true)
             // finish_reason=content_filter is a CENSORED turn — a clean end_turn would let a
@@ -327,6 +341,18 @@ public class ChatStreamTranslator(private val ctx: ChatTurnContext) : StreamTran
 }
 
 private val REASONING_KEYS = listOf("reasoning_content", "reasoning", "thinking", "reasoning_text")
+
+// WIRE-2/3/6 runaway-upstream guard: far above any legitimate response (200K-token completions
+// run well under 1M chars; real turns use a handful of tool calls).
+private const val MAX_BUFFERED_CHARS = 20_000_000
+private const val MAX_TOOL_INDEX_ENTRIES = 50_000
+private const val RUNAWAY_GUARD_MESSAGE = "chat backend: response exceeded max buffered size — aborting"
+
+/** True once any of textBuf/thinkingBuf/toolIndexById has grown past its cap. Top-level (off the
+ *  class function budget) — reads only its arguments; the caller latches [ChatStreamTranslator]'s
+ *  own runawayGuard state. */
+private fun bufferOverCapacity(textLen: Int, thinkingLen: Int, toolIndexCount: Int): Boolean =
+    textLen >= MAX_BUFFERED_CHARS || thinkingLen >= MAX_BUFFERED_CHARS || toolIndexCount >= MAX_TOOL_INDEX_ENTRIES
 
 /** First non-empty cleartext reasoning field on a chat delta/message. Top-level (off the class
  *  function budget) — reads only its argument. */

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesStreamTranslator.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesStreamTranslator.kt
@@ -437,10 +437,12 @@ private class ResponsesEventReducer(private val ctx: StreamTurnContext) {
         // deltas hadn't arrived — suppressing them both late (sawDelta return) and live (recap
         // match): total summary starvation (found live 2026-07-19).
         // Late-path recap filter: drop the leading recap run + within-item repeats, keep the rest.
-        val text = if (ctx.dedupeRepeatedSummaryParts) {
+        val text = if (ctx.dedupeRepeatedSummaryParts && raw.length <= MAX_DEDUP_SPLIT_CHARS) {
             raw.split(PART_SEPARATOR).filter { part -> !summaryDedup.suppress(outputIndex, part) }
                 .joinToString(PART_SEPARATOR)
         } else {
+            // WIRE-4: splitting an unbounded upstream reasoning delta allocates one substring per
+            // separator without limit; beyond the cap dedup is immaterial, so pass it through unsplit.
             raw
         }
         if (text.isEmpty()) return
@@ -538,6 +540,9 @@ private class ResponsesEventReducer(private val ctx: StreamTurnContext) {
 
         // Leave the positive int space for message/tool output_index; reasoning lives above.
         const val REASONING_KEY_BASE = 1_000_000
+
+        // WIRE-4 guard: far above any legitimate single reasoning item's text.
+        const val MAX_DEDUP_SPLIT_CHARS = 5_000_000
 
         fun reasoningKey(outputIndex: Int): Int = REASONING_KEY_BASE + outputIndex
     }

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnDriver.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnDriver.kt
@@ -612,9 +612,10 @@ internal class TurnDriver(
     /** One conn-reset surface for raw tears and reissue-exhausted [StreamTornBeforeClient]. */
     private suspend fun emitConnReset(drive: TurnDrive, detail: String?) {
         log(telemetry.errTurn("conn-reset", drive, ": $detail"))
+        val boundedDetail = (detail ?: "no detail").take(ERR_SNIPPET)
         drive.emitter.emitError(
             ErrorType.OVERLOADED,
-            "${provider.key}: upstream connection failed ($detail) — retry",
+            "${provider.key}: upstream connection failed ($boundedDetail) — retry",
         )
         telemetry.recordPerf(drive, "error:conn-reset")
         health.local()

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnDriver.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnDriver.kt
@@ -311,10 +311,11 @@ internal class TurnDriver(
                 val failure = UpstreamFailureClassifier.classify(FailureSource.HTTP, e.body, e.status)
                 val detail = "type=${failure.type.wireName} status=${e.status} msg=${failure.message.take(ERR_SNIPPET)}"
                 log(telemetry.errTurn("upstream-failed", drive, detail))
+                val boundedMessage = failure.message.take(ERR_SNIPPET)
                 val message = if (failure.type == ErrorType.AUTHENTICATION && provider.loginCommand.isNotEmpty()) {
-                    "${failure.message} — run: ${provider.loginCommand}"
+                    "$boundedMessage — run: ${provider.loginCommand}"
                 } else {
-                    failure.message
+                    boundedMessage
                 }
                 drive.emitter.emitError(failure.type, message)
                 telemetry.recordPerf(drive, "error:upstream-failed")
@@ -334,7 +335,7 @@ internal class TurnDriver(
                 // e.g. a URL-parse error from a bad base_url, an IllegalState out of Ktor
                 // internals. Previously ESCAPED: truncated 200, no error frame, no perf row.
                 log(telemetry.errTurn("unexpected", drive, ": ${e.javaClass.simpleName} ${e.message}"))
-                drive.emitter.emitError(ErrorType.API_ERROR, "claudex: internal gateway error (${e.message}) — retry")
+                drive.emitter.emitError(ErrorType.API_ERROR, "claudex: internal gateway error — retry")
                 telemetry.recordPerf(drive, "error:unexpected")
                 health.local() // internal gateway bug (e.g. bad base_url parse)
             }

--- a/gateway/provider-codex/src/main/kotlin/splice/provider/codex/CodexAuthProvider.kt
+++ b/gateway/provider-codex/src/main/kotlin/splice/provider/codex/CodexAuthProvider.kt
@@ -73,7 +73,7 @@ public class CodexAuthProvider(
     @Volatile
     private var cache: Cache? = null
 
-    private data class Cache(val snapshot: Snapshot, val mtimeMs: Long, val loadedAt: Long)
+    private data class Cache(val snapshot: Snapshot, val mtimeMs: Long, val loadedAt: Long, val sizeBytes: Long)
 
     private data class Snapshot(val access: String, val accountId: String?, val expiresAtMs: Long?)
 
@@ -101,9 +101,11 @@ public class CodexAuthProvider(
     private fun readSnapshot(): Snapshot? = runCatchingCancellable {
         if (!Files.exists(authPath)) return@runCatchingCancellable null
         val mtime = Files.getLastModifiedTime(authPath).toMillis()
+        val size = Files.size(authPath)
         val now = clock()
         cache?.let { c ->
-            if (c.mtimeMs == mtime && (now - c.loadedAt) < authCacheMs) {
+            val sameFile = c.mtimeMs == mtime && c.sizeBytes == size
+            if (sameFile && (now - c.loadedAt) < authCacheMs) {
                 return@runCatchingCancellable c.snapshot
             }
         }
@@ -112,7 +114,7 @@ public class CodexAuthProvider(
             val accountId = tokens.str(FIELD_ACCOUNT_ID)
             val expiresAtMs = decodeJwtClaims(access).long(FIELD_EXP)?.let { it * MS_PER_S }
             val snapshot = Snapshot(access, accountId, expiresAtMs)
-            cache = Cache(snapshot, mtime, now)
+            cache = Cache(snapshot, mtime, now, size)
             snapshot
         }
     }.onFailure {
@@ -167,7 +169,7 @@ public class CodexAuthProvider(
         val accountId = tokens.str(FIELD_ACCOUNT_ID)
         val expiresAtMs = decodeJwtClaims(freshAccess).long(FIELD_EXP)?.let { it * MS_PER_S }
         val snapshot = Snapshot(freshAccess, accountId, expiresAtMs)
-        cache = Cache(snapshot, Files.getLastModifiedTime(authPath).toMillis(), clock())
+        cache = Cache(snapshot, Files.getLastModifiedTime(authPath).toMillis(), clock(), Files.size(authPath))
         return RefreshOutcome.Refreshed(Credentials.Bearer(freshAccess, accountId))
     }
 


### PR DESCRIPTION
Recovers 16 gate-verified hardening fixes that were **never merged**, and adds two generation-time walls so the same class of loss is caught mechanically next time.

## The incident

Three hardening commits (`be1baee` / `473b7ff` / `1acceec` — 16 fixes across auth, wire, gateway and config, each gate-verified when written) sat on a local branch. `main` advanced independently through the PR #48 squash (`c0a9161`), cut from the same base — so **every hardening line was absent from `main`**, and from any build made from it.

Found by an audit of the working session's own transcript, not by any check in this repo. That is the point of the walls below.

## Live on `main` until this merge

- `TurnDriver`: raw `e.message` interpolated into the **client** error frame; unbounded upstream `failure.message`; nullable `(null)` conn-reset detail
- `PassthroughRequestBuilder`: unguarded `stripCacheControl` recursion → StackOverflow on adversarially nested client JSON
- `ChatStreamTranslator` / `ResponsesStreamTranslator`: unbounded accumulation buffers
- `AsyncFileIo`: silently dropped writes · `ConfigService`: swallowed persist failure + `(mtime,size)` torn read · `CodexAuthProvider`: mtime-only auth cache
- `OAuthLoginFlow`: provider error body echoed to operator stdout

## Merge detail

One real conflict, in `ResponsesStreamTranslator`'s companion: `main` had moved `REASONING_KEY_BASE`/`reasoningKey` to file top-level (a detekt extraction in #48) while the hardening branch added `MAX_DEDUP_SPLIT_CHARS` beside them. Resolved by keeping `main`'s structure and carrying only the WIRE-4 guard across.

## The two walls (concept #924)

Both defects were produced by agents in a single session. Per #924's corollary the bar is *"what holds when agents keep writing it"*, not *"the code is clean now"* — so each is encoded as a rule that runs at **write time** (PreToolUse, against proposed content) and again at the gate, per `sgconfig.yml`'s same-checker-twice doctrine.

- **`kt-force-strict-false-is-literal`** — a `forceStrictFalse` branch must emit the literal `false`. It shipped as `put(FIELD_STRICT, t.strict == true)` in both tool builders: the KDoc promised a codex-parity hard-set, the code passed the tool's own value through. It survived the gate because the contract golden meant to pin it used a fixture tool with no `strict` field, so the assertion could not observe the difference.
- **`kt-tool-partition-no-transcript`** — the deferred-tool partition must be a pure function of `(tools, policy)`. The payload rides `input[0]` inside the prompt-cache prefix, so a transcript-derived split varies it per turn and re-bills ~94k cached tokens per bust — silently turning #48 into a net token *regression*. Three independent adversarial reviews missed it; all verified bytes-when-stable, none turn-to-turn.

Both were validated with `ast-grep test_match_code_rule` before wiring, then proven red-green. Generation-time behavior was proven by probe: a `Write` carrying the shipped defect was **blocked and never landed**.

## Verification

- `gradlew check` green on the merged tree
- ast-grep walls **33 passed / 0 failed** (was 31), scan clean, hook tests 13 OK, `config-guard` PASS
- Fixes confirmed present in the built artifact, not just the source: the jar contains `internal gateway error — retry` and not the interpolated form

## Note for the reviewer

The lesson worth carrying: **an edit protects one branch; a wall protects the generator.** Sixteen verified fixes went missing precisely because they were only edits. The pattern-shaped findings among them (raw detail on the client wire, unguarded recursion over client JSON, unbounded grow-only buffers) deserve walls of their own — `kt-no-raw-detail-on-client-wire` is drafted and hand-verified against all 8 `emitError` call sites (2 hits, both real defects, 6 compliant sites silent), pending an operator grant since `.rules/` is grant-gated.
