### PR TITLE
fix(responses): tool_search_call.arguments must be a JSON object, not a string

### DIFF
--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesRequestBuilder.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesRequestBuilder.kt
@@ -594,7 +594,7 @@ private class ResponsesInputBuilder(private val quirks: ResponsesQuirks) {
                 put("type", "tool_search_call")
                 put("call_id", callId)
                 put("execution", "client")
-                put("arguments", buildJsonObject { put("query", tool.name) }.toString())
+                put("arguments", buildJsonObject { put("query", tool.name) })
             },
         )
         sink.add(toolSearchOutputItem(callId, listOf(tool), quirks.emitStrict, quirks.forceStrictFalse))

--- a/gateway/dialect-openai-responses/src/test/kotlin/ResponsesRequestBuilderTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ResponsesRequestBuilderTest.kt
@@ -635,6 +635,11 @@ class ToolSurfaceRequestTest {
         val call = input[fcIdx - 2]
         val output = input[fcIdx - 1]
         assertEquals("tool_search_call", call["type"]?.jsonPrimitive?.content)
+        // REGRESSION (PR #48 shipped this as a stringified JSON → upstream 400 "input[N].arguments:
+        // expected an object, but got a string"): the Responses API types tool_search_call.arguments
+        // as an OBJECT (codex-rs models.rs:888 `arguments: serde_json::Value`), unlike function_call.
+        assertTrue(call["arguments"] is JsonObject, "tool_search_call.arguments must be a JSON object, not a string")
+        assertEquals("mcp__exa__tool_5", call["arguments"]!!.jsonObject["query"]?.jsonPrimitive?.content)
         assertEquals("tool_search_output", output["type"]?.jsonPrimitive?.content)
         assertEquals(call["call_id"]?.jsonPrimitive?.content, output["call_id"]?.jsonPrimitive?.content)
         val tools = output["tools"]!!.jsonArray


### PR DESCRIPTION
## Problem

gpt-5.6 (codex head) turns were dying with a hard upstream 400:

```
400 Invalid type for 'input[N].arguments': expected an object, but got a string
```

PR #48 (`c0a9161`, deferred-tool surface) serialized the synthetic
`tool_search_call.arguments` in `appendToolDeclaration` with `.toString()`,
sending a **stringified JSON**. The OpenAI Responses API types
`tool_search_call.arguments` as an **object** (codex-rs `protocol/src/models.rs:888`
`arguments: serde_json::Value`; and splice's own `parseToolSearchArguments`
comment: *"a real JSON object on this item type, unlike function_call where it
is a string"*). Every turn that replayed a deferred-tool declaration — which
fires constantly given Claude Code's tool surface + deferred MCP tools — got
rejected, surfacing to the client as dropped/stuck turns.

## Fix

- `ResponsesRequestBuilder.kt:597` — drop the `.toString()` so `arguments` rides
  as the object. `function_call.arguments` stays a **string** (line 578), which
  is correct per the same reference.

## Regression wall

- The `declaration replay` test asserted the item's `type` but never its
  `arguments` shape — exactly how #48 shipped green. Now it asserts
  `arguments is JsonObject` with the `query` field. Red-green by construction:
  pre-fix, `arguments` was a `JsonPrimitive` (stringified JSON) and the check
  fails.

## Verification

- `:dialect-openai-responses:test` green.
- Confirmed the correct shape against the codex-rs and OpenCode reference
  implementations (both emit `tool_search_call.arguments` as an object).
- Deployed to the local daemon (fat jar rebuilt + restarted) — the 400 clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)