### PR TITLE
feat(auth): api-key store + token capture — claudeor login, splice key, paste-to-store

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,19 @@ splice setup                      # write the supported API-key starter and inst
 claudeor                          # Claude Code through OpenRouter on loopback (:3101)
 ```
 
+No export handy? There are two other ways to get the key in — both land in
+`~/.config/splice/keys.toml` (0600), which every later daemon start reads from any shell:
+
+- `claudeor login` — a masked terminal prompt (the key never hits shell history, `ps`, or a
+  session transcript).
+- Inside a `claudeor` session, while the key is missing, splice offers to capture it: paste the
+  key as a **bare message** (nothing else in the text) and it is stored and blocked before it
+  reaches the model — it never travels upstream. The session transcript still records the paste,
+  so the masked `claudeor login` stays the zero-trace path.
+
+An explicit `OPENROUTER_API_KEY` in the daemon's environment always wins over the store.
+`splice key set|list|unset` manages the store directly (`--stdin` for scripts).
+
 `install.sh` builds the fat jar from a checkout (or fetches a release), installs the shared launch shim, links the wrapper commands into `~/.local/bin`, and finishes by running `splice doctor`, so the install ends with a checked report.
 
 **splice was built for ChatGPT, Grok, and Kimi subscriptions.** Copy the matching provider and head from [`config/splice.example.toml`](config/splice.example.toml) into `~/.config/splice/splice.toml`, run `splice install --all`, then sign in with that head's `login` command (`claudex login`, `claude-grok login`, `claude-kimi login`). These routes are unofficial: they reuse each vendor's own CLI OAuth client identity, which no vendor documents for third parties. Use them at your own risk; the API-key starter above is the zero-config alternative.
@@ -151,7 +164,9 @@ the exact fix under every failing check.
 
 The daemon reads API-key env vars from **its own** environment. Export a key *after* the daemon
 has started and the shell sees it but the daemon does not: launches warn, requests fail upstream. `splice restart` restarts the daemon with your current
-shell's environment; `splice doctor` detects this state explicitly.
+shell's environment; `splice doctor` detects this state explicitly. Keys in
+`~/.config/splice/keys.toml` sidestep the whole class: the store is re-read per request, so a
+`claudeor login` or `splice key set` lands on the next request, no restart required.
 
 ## Credential locations
 
@@ -162,8 +177,9 @@ Each of these is a **password-equivalent secret**: anything that can read the fi
 | codex (ChatGPT) | `chatgpt-oauth` | `~/.codex/auth.json` | OAuth tokens — password-equivalent |
 | grok (xAI) | `grok-oauth` | `~/.grok/auth.json` | OAuth tokens — password-equivalent |
 | kimi (Moonshot) | `kimi-oauth` | `~/.kimi/credentials/kimi-code.json` | device-flow token — password-equivalent |
-| OpenRouter | `api-key` | `$OPENROUTER_API_KEY` (env) | API key — password-equivalent |
-| Moonshot (pay-per-token) | `api-key` | `$MOONSHOT_API_KEY` (env) | API key — password-equivalent |
+| OpenRouter | `api-key` | `$OPENROUTER_API_KEY` (env) or `~/.config/splice/keys.toml` | API key — password-equivalent |
+| Moonshot (pay-per-token) | `api-key` | `$MOONSHOT_API_KEY` (env) or `~/.config/splice/keys.toml` | API key — password-equivalent |
+| splice api-key store | — | `~/.config/splice/keys.toml` (0600) | env wins over the store — password-equivalent |
 | splice control plane | — | `~/.claude-codex/state/mgmt-key` | dashboard/API unlock key — password-equivalent |
 
 ## Provider support

--- a/config/splice.example.toml
+++ b/config/splice.example.toml
@@ -88,6 +88,9 @@ context_window = 256000
 
 # ── openrouter: the "new vendor = pure TOML, zero code" proof (Chat Completions) ─
 # Swap base_url + env for Ollama (http://localhost:11434/v1), LM Studio, DeepSeek, etc.
+# api-key resolution: $OPENROUTER_API_KEY from the daemon's env wins; else the shared
+# ~/.config/splice/keys.toml store (written by `claudeor login` / `splice key set` /
+# the in-session token-capture hook) — env always overrides the store.
 [providers.openrouter]
 dialect = "openai-chat"
 base_url = "https://openrouter.ai/api/v1"

--- a/gateway/app/src/main/kotlin/splice/app/Daemon.kt
+++ b/gateway/app/src/main/kotlin/splice/app/Daemon.kt
@@ -94,9 +94,9 @@ private fun foldConfigFrom(cfg: SpliceConfig): FoldConfig = FoldConfig(
     maxTierN = cfg.foldMaxTier,
 )
 
-private const val CHATGPT_OAUTH = "chatgpt-oauth"
-private const val GROK_OAUTH = "grok-oauth"
-private const val KIMI_OAUTH = "kimi-oauth"
+internal const val CHATGPT_OAUTH = "chatgpt-oauth"
+internal const val GROK_OAUTH = "grok-oauth"
+internal const val KIMI_OAUTH = "kimi-oauth"
 
 // The whole head-stop phase's deadline (see [stopHeads]). Kept below Main's STOP_DEADLINE_MS so the
 // graceful stop + control shutdown finish before Main's hard halt watchdog would ever need to fire.
@@ -288,7 +288,7 @@ public class Daemon(
             val resolvedHead = resolveHeadConfig(key, head, providerCfg, cfg)
             val resolvedProvider = resolveProviderConfig(key, providerCfg, cfg)
             val catalog = resolvedProvider.catalogFor(resolvedHead, cfg.contextWindowOverride)
-            val loginCommand = loginInterception(resolvedProvider, resolvedHead, key).first
+            val loginCommand = signInPlan(resolvedProvider, resolvedHead, key).command
             val ctx = ProviderBuild(
                 key,
                 resolvedHead,
@@ -643,19 +643,8 @@ public class Daemon(
     }
 
     // Common assembly shared by every provider: stores, the generic HeadServer, launch spec.
-    // /login interception only makes sense for browser-OAuth providers; api-key heads have no
-    // sign-in flow, so they get no custom /login (just the disabled Anthropic built-in). Returns
-    // (loginCommand, signInLabel) — both blank when there is no OAuth flow.
-    private fun loginInterception(providerCfg: ProviderConfig, head: HeadConfig, key: String): Pair<String, String> {
-        val label = when (providerCfg.auth.kind) {
-            CHATGPT_OAUTH -> "Codex (ChatGPT)"
-            GROK_OAUTH -> "Grok (xAI)"
-            KIMI_OAUTH -> "Kimi (Moonshot)"
-            else -> ""
-        }
-        val command = if (label.isEmpty()) "" else "${head.claude.command ?: key} login"
-        return command to label
-    }
+    // The sign-in plan (OAuth browser flow vs api-key masked prompt + token capture) lives in
+    // SignInPlan.kt — factored out of this class (detekt LargeClass).
 
     private fun assembleHead(ctx: ProviderBuild, controlPort: Int): ManagedHead {
         val key = ctx.key
@@ -690,6 +679,7 @@ public class Daemon(
                 requestMaterializationGate = requestMaterializationGate,
             ),
         )
+        val apiKeyPresent = (wired.auth as? ApiKeyAuthProvider)?.hasKeyNow() != false
         return ManagedHead(
             head = server,
             auth = wired.auth,
@@ -699,17 +689,17 @@ public class Daemon(
             warnPct = cfg.usageWarnPct,
             warnTokens5h = cfg.usageWarnTokens5h,
             authKind = ctx.providerCfg.auth.kind,
-            launchSpec = launchSpecFor(ctx, controlPort),
+            launchSpec = launchSpecFor(ctx, controlPort, keyPresent = apiKeyPresent),
             perf = PerfStatsSource(perfStats),
         )
     }
 
-    private fun launchSpecFor(ctx: ProviderBuild, controlPort: Int): LaunchSpec {
+    private fun launchSpecFor(ctx: ProviderBuild, controlPort: Int, keyPresent: Boolean): LaunchSpec {
         val key = ctx.key
         val head = ctx.head
         val providerCfg = ctx.providerCfg
         val configDir = Paths.get(TopologyLoader.expandHome(head.claude.configDir ?: "~/.claude-$key"))
-        val (loginCommand, signInLabel) = loginInterception(providerCfg, head, key)
+        val signIn = signInPlan(providerCfg, head, key)
         return LaunchSpec(
             configDir = configDir,
             pinnedModel = head.pinnedModel,
@@ -719,9 +709,14 @@ public class Daemon(
             modelOptionsCache = modelOptionsCache(providerCfg),
             statuslineCommand = "curl -sS --data-binary @- http://127.0.0.1:$controlPort/statusline/$key",
             // The installed wrapper (`<command> login`) runs this head's provider sign-in; the
-            // materialized /login command + UserPromptSubmit hook route the user here.
-            loginCommand = loginCommand,
-            signInLabel = signInLabel,
+            // materialized /login command + UserPromptSubmit hook route the user here. api-key
+            // heads additionally capture a bare pasted token, and advertise the flow at session
+            // start ONLY while the key is unconfigured (re-materialized each launch).
+            loginCommand = signIn.command,
+            signInLabel = signIn.label,
+            signInViaBrowser = signIn.viaBrowser,
+            tokenCapture = signIn.tokenCapture,
+            advertiseKeySetup = signIn.tokenCapture != null && !keyPresent,
             policy = ClaudePolicy(share = topology.claude.share.toSet(), isolate = head.claude.isolate.toSet()),
             port = head.port,
             inferenceToken = mgmtKey.get(),

--- a/gateway/app/src/main/kotlin/splice/app/SignInPlan.kt
+++ b/gateway/app/src/main/kotlin/splice/app/SignInPlan.kt
@@ -1,0 +1,52 @@
+// NEW: what sign-in surface a head gets — the /login command + UX wording, and for api-key
+// heads the bare-token capture spec (factored out of Daemon.kt, detekt LargeClass).
+// OAuth heads get the browser flow; api-key heads get the masked-prompt wording plus — only for
+// providers with a known, prose-safe token shape — the capture hook. The OAuth kind constants
+// live in Daemon.kt (same package); API_KEY is only needed here.
+package splice.app
+
+import splice.core.launch.TokenCaptureSpec
+import splice.core.topology.HeadConfig
+import splice.core.topology.ProviderConfig
+import splice.core.topology.effectiveApiKeyEnv
+
+internal const val API_KEY = "api-key"
+
+// Display labels for api-key providers (the /login UX + capture-hook reasons).
+private val API_KEY_LABELS = mapOf(
+    "openrouter" to "OpenRouter",
+    "moonshot" to "Moonshot",
+    "fireworks" to "Fireworks",
+    "openai" to "OpenAI",
+)
+
+// Bare-token capture patterns (bash ERE, matched as the WHOLE prompt). Only shapes that cannot
+// collide with ordinary prose get an entry — everything else falls back to masked login only.
+private val API_KEY_TOKEN_PATTERNS = mapOf(
+    "openrouter" to "sk-or-[A-Za-z0-9_-]{20,}",
+)
+
+internal data class SignInPlan(
+    val command: String,
+    val label: String,
+    val viaBrowser: Boolean,
+    val tokenCapture: TokenCaptureSpec?,
+)
+
+internal fun signInPlan(providerCfg: ProviderConfig, head: HeadConfig, key: String): SignInPlan {
+    val command = "${head.claude.command ?: key} login"
+    return when (providerCfg.auth.kind) {
+        CHATGPT_OAUTH -> SignInPlan(command, "Codex (ChatGPT)", viaBrowser = true, tokenCapture = null)
+        GROK_OAUTH -> SignInPlan(command, "Grok (xAI)", viaBrowser = true, tokenCapture = null)
+        KIMI_OAUTH -> SignInPlan(command, "Kimi (Moonshot)", viaBrowser = true, tokenCapture = null)
+        API_KEY -> {
+            val label = API_KEY_LABELS[head.provider] ?: head.provider
+            // Capture only where the token shape is KNOWN and unambiguous (v1: OpenRouter).
+            val capture = API_KEY_TOKEN_PATTERNS[head.provider]?.let { pattern ->
+                TokenCaptureSpec(effectiveApiKeyEnv(head.provider, providerCfg.auth), pattern, label)
+            }
+            SignInPlan(command, label, viaBrowser = false, tokenCapture = capture)
+        }
+        else -> SignInPlan("", "", viaBrowser = true, tokenCapture = null)
+    }
+}

--- a/gateway/app/src/main/kotlin/splice/app/TopologyLoader.kt
+++ b/gateway/app/src/main/kotlin/splice/app/TopologyLoader.kt
@@ -20,8 +20,11 @@ show_reasoning = "text"
 summary = "detailed"
 replay_reasoning = false
 
-# Supported starter route: create an OpenRouter API key, export OPENROUTER_API_KEY, then run
-# `claudeor`. Experimental vendor-OAuth examples remain opt-in in config/splice.example.toml.
+# Supported starter route: create an OpenRouter API key, then EITHER export OPENROUTER_API_KEY
+# or let `claudeor login` store it to ~/.config/splice/keys.toml (0600 — survives restarts from
+# any shell; inside a claudeor session you can also paste it as a bare message and the
+# token-capture hook stores it without it reaching the model).
+# Experimental vendor-OAuth examples remain opt-in in config/splice.example.toml.
 [providers.openrouter]
 dialect = "openai-chat"
 base_url = "https://openrouter.ai/api/v1"

--- a/gateway/app/src/main/kotlin/splice/app/cli/Cli.kt
+++ b/gateway/app/src/main/kotlin/splice/app/cli/Cli.kt
@@ -6,7 +6,8 @@ package splice.app.cli
 public fun runCli(args: Array<String>): Int {
     val command = Command.parse(args) ?: run {
         System.err.println(
-            "usage: splice [setup|status|restart|dashboard|login <head>|install|uninstall|init|doctor|daemon|version]",
+            "usage: splice [setup|status|restart|dashboard|login <head>|key <set|list|unset>|" +
+                "install|uninstall|init|doctor|daemon|version]",
         )
         return 2
     }

--- a/gateway/app/src/main/kotlin/splice/app/cli/Command.kt
+++ b/gateway/app/src/main/kotlin/splice/app/cli/Command.kt
@@ -34,6 +34,9 @@ public sealed class Command {
     public data object Status : Command() { override fun run(): Int = success { status() } }
     public data object Restart : Command() { override fun run(): Int = outcomeExitCode(restart()) }
     public data object Dashboard : Command() { override fun run(): Int = outcomeExitCode(dashboard()) }
+    public data class Key(val args: List<String>) : Command() {
+        override fun run(): Int = outcomeExitCode(key(args))
+    }
 
     public companion object {
         // parse table (verb -> factory): a map keeps parse() at trivial complexity (no 10-arm `when`,
@@ -46,6 +49,7 @@ public sealed class Command {
             "login" to { a -> Login(a.getOrNull(1)) },
             "setup" to { Setup }, "status" to { Status }, "restart" to { Restart },
             "dashboard" to { Dashboard },
+            "key" to { a -> Key(a.drop(1)) },
         )
 
         /** argv -> Command, or null for an unknown/empty verb (caller prints usage). */

--- a/gateway/app/src/main/kotlin/splice/app/cli/KeyCommand.kt
+++ b/gateway/app/src/main/kotlin/splice/app/cli/KeyCommand.kt
@@ -1,0 +1,87 @@
+// NEW: `splice key set|list|unset` — the operator-facing front door to KeyStore
+// (~/.config/splice/keys.toml). Interactive `set` reads MASKED from the console (never echoed,
+// never in shell history); agents and hooks use --stdin or --value (both are transcript-visible —
+// the masked path exists precisely for humans). After a set, the next request already picks the
+// key up (ApiKeyAuthProvider re-reads the store per call); `splice restart` refreshes status.
+package splice.app.cli
+
+import splice.core.config.KeyStore
+
+private const val MASK_PROMPT = "API key: "
+
+/** argv after `key`: set <ENV> [--value V | --stdin] | list | unset <ENV>. Store injectable
+ *  for hermetic tests (the default is the operator's real ~/.config/splice/keys.toml). */
+internal fun key(args: List<String>, store: KeyStore = KeyStore(KeyStore.defaultPath())): Boolean {
+    return when (args.firstOrNull()) {
+        "set" -> keySet(store, args.getOrNull(1), args.drop(2))
+        "list" -> keyList(store)
+        "unset" -> keyUnset(store, args.getOrNull(1))
+        else -> {
+            System.err.println("usage: splice key set <ENV_NAME> [--value V | --stdin] | list | unset <ENV_NAME>")
+            false
+        }
+    }
+}
+
+private fun keySet(store: KeyStore, envVar: String?, flags: List<String>): Boolean {
+    if (envVar == null) {
+        System.err.println("splice key set: missing <ENV_NAME> (e.g. OPENROUTER_API_KEY)")
+        return false
+    }
+    val value = readValue(flags) ?: return false
+    return runCatching { store.write(envVar, value) }
+        .onSuccess {
+            println("$envVar stored to ${store.path} (0600).")
+            println("Live daemons pick it up on the next request; `splice restart` refreshes status.")
+        }
+        .onFailure { System.err.println("splice key set: ${it.message}") }
+        .isSuccess
+}
+
+private fun readValue(flags: List<String>): String? = when {
+    "--stdin" in flags -> readKeyStdin()
+    "--value" in flags -> flags.getOrNull(flags.indexOf("--value") + 1)
+        ?: run {
+            System.err.println("splice key set: --value needs an argument (prefer --stdin; --value shows in ps)")
+            null
+        }
+    else -> readKeyMasked()
+}
+
+private fun readKeyStdin(): String? =
+    System.`in`.bufferedReader().readText().trim().ifEmpty {
+        System.err.println("splice key set: empty key on stdin")
+        null
+    }
+
+private fun readKeyMasked(): String? {
+    val console = System.console() ?: run {
+        System.err.println("splice key set: no interactive console — use --stdin, or --value (visible in ps/history)")
+        return null
+    }
+    val chars = console.readPassword(MASK_PROMPT) ?: return null
+    return String(chars).trim().ifEmpty {
+        System.err.println("splice key set: empty key")
+        null
+    }
+}
+
+private fun keyList(store: KeyStore): Boolean {
+    val names = store.names()
+    if (names.isEmpty()) {
+        println("no keys stored (${store.path})")
+    } else {
+        names.sorted().forEach { println("$it = stored") }
+    }
+    return true
+}
+
+private fun keyUnset(store: KeyStore, envVar: String?): Boolean {
+    if (envVar == null) {
+        System.err.println("splice key unset: missing <ENV_NAME>")
+        return false
+    }
+    val removed = store.unset(envVar)
+    println(if (removed) "$envVar removed from ${store.path}" else "$envVar was not stored")
+    return true
+}

--- a/gateway/app/src/main/kotlin/splice/app/cli/LoginCommand.kt
+++ b/gateway/app/src/main/kotlin/splice/app/cli/LoginCommand.kt
@@ -11,9 +11,11 @@ import splice.app.DeviceLoginSpec
 import splice.app.LoginSpec
 import splice.app.OAuthLoginFlow
 import splice.app.TopologyLoader
+import splice.core.config.KeyStore
 import splice.core.topology.ProviderConfig
 import splice.core.topology.Topology
 import splice.core.topology.ambiguousHeadMessage
+import splice.core.topology.effectiveApiKeyEnv
 import splice.core.util.str
 import splice.provider.codex.CodexOAuthEndpoints
 import splice.provider.codex.authJsonFromTokens
@@ -40,22 +42,51 @@ private val env: (String) -> String? = System::getenv
 internal suspend fun login(headArg: String?): Boolean {
     val topology = TopologyLoader.loadOrMaterialize(TopologyLoader.configPath())
     val headKey = resolveHeadKey(headArg, topology) ?: return false
-    val provider = topology.heads[headKey]?.let { topology.providers[it.provider] }
+    val providerKey = topology.heads[headKey]?.provider
+    val provider = providerKey?.let { topology.providers[it] }
     if (provider == null) {
         println("splice: unknown head '$headKey' (heads: ${topology.heads.keys})")
         return false
     }
-    val ok = runLoginFlow(headKey, provider, topology)
+    val ok = runLoginFlow(headKey, providerKey, provider, topology)
     if (!ok) println("splice: login for '$headKey' did not complete.")
     return ok
 }
 
-// kimi uses the RFC 8628 device flow (no loopback); codex/grok use the browser-loopback flow.
-private suspend fun runLoginFlow(headKey: String, provider: ProviderConfig, topology: Topology): Boolean =
+// kimi uses the RFC 8628 device flow (no loopback); codex/grok use the browser-loopback flow;
+// api-key heads get a masked terminal prompt into the KeyStore (no browser anywhere).
+private suspend fun runLoginFlow(
+    headKey: String,
+    providerKey: String,
+    provider: ProviderConfig,
+    topology: Topology,
+): Boolean =
     when (provider.auth.kind) {
         "kimi-oauth" -> DeviceLoginFlow.run(kimiDeviceSpec(headKey, provider))
+        "api-key" -> apiKeyLogin(providerKey, provider)
         else -> specFor(headKey, topology)?.let { OAuthLoginFlow.run(it) } ?: false
     }
+
+// Masked read into ~/.config/splice/keys.toml — the key never hits shell history, ps, or a
+// transcript. Live daemons pick it up on the next request; restart only refreshes status.
+private fun apiKeyLogin(providerKey: String, provider: ProviderConfig): Boolean {
+    val envVar = effectiveApiKeyEnv(providerKey, provider.auth)
+    val console = System.console()
+    val value = when {
+        console == null -> {
+            println("splice: no interactive console — pipe it instead:")
+            println("  printf '%s' \"\$KEY\" | splice key set $envVar --stdin")
+            null
+        }
+        else -> console.readPassword("$providerKey API key ($envVar): ")?.let { String(it).trim() }
+    }
+    if (value != null && value.isEmpty()) println("splice: empty key — nothing stored.")
+    return !value.isNullOrEmpty() && runCatching {
+        val store = KeyStore(KeyStore.defaultPath())
+        store.write(envVar, value)
+        println("$envVar stored to ${store.path} (0600) — live daemons pick it up on the next request.")
+    }.onFailure { System.err.println("splice: failed to store key: ${it.message}") }.isSuccess
+}
 
 private fun resolveHeadKey(headArg: String?, topology: Topology): String? {
     if (headArg != null) {
@@ -71,14 +102,14 @@ private fun resolveHeadKey(headArg: String?, topology: Topology): String? {
         )
         return null
     }
-    // No arg: pick the sole browser-login head, else make the user choose — never silently
+    // No arg: pick the sole sign-in-capable head, else make the user choose — never silently
     // sign into whichever head happens to be declared first.
-    val oauth = topology.oauthHeads()
-    return oauth.singleOrNull() ?: run {
-        if (oauth.isEmpty()) {
-            println("splice: no browser-login heads in the topology.")
+    val signIn = topology.signInHeads()
+    return signIn.singleOrNull() ?: run {
+        if (signIn.isEmpty()) {
+            println("splice: no sign-in-capable heads in the topology.")
         } else {
-            println("splice: which head? " + oauth.joinToString(", ") { "$it login" })
+            println("splice: which head? " + signIn.joinToString(", ") { "$it login" })
         }
         null
     }
@@ -191,8 +222,10 @@ private fun kimiDeviceSpec(head: String, provider: ProviderConfig): DeviceLoginS
 
 private const val TOKEN_BYTES = 24
 
-/** Which heads support browser login — keyed off auth.kind, matching login()'s own dispatch. */
-public fun Topology.oauthHeads(): List<String> =
+/** Which heads support ANY sign-in flow (browser OAuth or api-key prompt) — keyed off auth.kind,
+ *  matching login()'s own dispatch. */
+public fun Topology.signInHeads(): List<String> =
     heads.entries.filter { (_, h) ->
-        providers[h.provider]?.auth?.kind?.endsWith("oauth") == true
+        val kind = providers[h.provider]?.auth?.kind
+        kind?.endsWith("oauth") == true || kind == "api-key"
     }.map { it.key }

--- a/gateway/app/src/main/kotlin/splice/app/cli/StatusCommand.kt
+++ b/gateway/app/src/main/kotlin/splice/app/cli/StatusCommand.kt
@@ -5,6 +5,7 @@ package splice.app.cli
 
 import splice.app.TopologyLoader
 import splice.core.config.InstallPaths
+import splice.core.config.KeyStore
 import splice.core.topology.AuthKind
 import splice.core.topology.HeadConfig
 import splice.core.topology.ProviderConfig
@@ -82,7 +83,11 @@ internal fun authPresent(key: String, provider: ProviderConfig, envReader: (Stri
         effectiveApiKeyEnv(key, provider.auth)
     }
     val envPresent = envVar?.let { envReader(it)?.isNotBlank() } == true
-    return filePresent || envPresent
+    // The KeyStore is the third presence source for api-key heads — a key stored by
+    // `splice key set` / `<head> login` / token capture reads as configured here too.
+    val storePresent = !AuthKind.isOAuth(provider.auth.kind) && envVar != null &&
+        KeyStore(KeyStore.defaultPath(envReader)).read(envVar) != null
+    return filePresent || envPresent || storePresent
 }
 
 internal fun wrapperInstalled(command: String, envReader: (String) -> String?): Boolean =

--- a/gateway/app/src/test/kotlin/splice/app/cli/KeyCommandTest.kt
+++ b/gateway/app/src/test/kotlin/splice/app/cli/KeyCommandTest.kt
@@ -1,0 +1,52 @@
+// NEW: `splice key set|list|unset` over an injected hermetic KeyStore. The masked console path
+// is untestable here (System.console is null under surefire) — --value and --stdin are the
+// scripted routes, and the console-null branch must point at them.
+package splice.app.cli
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import splice.core.config.KeyStore
+import java.nio.file.Path
+
+class KeyCommandTest {
+
+    private fun store(tmp: Path) = KeyStore(tmp.resolve("keys.toml"))
+
+    @Test
+    fun `set --value stores and list shows the name`(@TempDir tmp: Path) {
+        val s = store(tmp)
+        assertTrue(key(listOf("set", "OPENROUTER_API_KEY", "--value", "sk-or-abc"), s))
+        assertEquals("sk-or-abc", s.read("OPENROUTER_API_KEY"))
+        assertTrue(key(listOf("list"), s))
+    }
+
+    @Test
+    fun `set without value and without console fails with guidance`(@TempDir tmp: Path) {
+        val s = store(tmp)
+        assertFalse(key(listOf("set", "OPENROUTER_API_KEY"), s))
+        assertEquals(null, s.read("OPENROUTER_API_KEY"))
+    }
+
+    @Test
+    fun `set rejects invalid env names`(@TempDir tmp: Path) {
+        val s = store(tmp)
+        assertFalse(key(listOf("set", "not-a-name", "--value", "x"), s))
+        assertTrue(s.names().isEmpty())
+    }
+
+    @Test
+    fun `unset removes and reports`(@TempDir tmp: Path) {
+        val s = store(tmp)
+        key(listOf("set", "OPENROUTER_API_KEY", "--value", "sk-or-abc"), s)
+        assertTrue(key(listOf("unset", "OPENROUTER_API_KEY"), s))
+        assertEquals(null, s.read("OPENROUTER_API_KEY"))
+    }
+
+    @Test
+    fun `unknown subcommand is a usage error`(@TempDir tmp: Path) {
+        assertFalse(key(listOf("frobnicate"), store(tmp)))
+    }
+}

--- a/gateway/control/src/main/kotlin/splice/control/LaunchService.kt
+++ b/gateway/control/src/main/kotlin/splice/control/LaunchService.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.json.JsonElement
 import splice.core.launch.ClaudeConfigMaterializer
 import splice.core.launch.ClaudePolicy
 import splice.core.launch.MaterializeSpec
+import splice.core.launch.TokenCaptureSpec
 import java.nio.file.Path
 import kotlin.math.max
 
@@ -25,6 +26,12 @@ public data class LaunchSpec(
     val statuslineCommand: String, // per-head statusline command (…/statusline/<head>)
     val loginCommand: String, // shell command that runs THIS head's provider sign-in (e.g. `claudex login`)
     val signInLabel: String, // provider label for the /login UX ("Codex (ChatGPT)", "Grok (xAI)")
+    /** False for api-key heads: the /login block reason points at a masked terminal prompt. */
+    val signInViaBrowser: Boolean = true,
+    /** api-key heads: capture a bare pasted token into the KeyStore (blocked from model context). */
+    val tokenCapture: TokenCaptureSpec? = null,
+    /** Install the SessionStart key-missing advertiser (daemon sets it only while unconfigured). */
+    val advertiseKeySetup: Boolean = false,
     val policy: ClaudePolicy,
     val port: Int,
     /** Per-install local gateway credential; shared with the head's inbound verifier. */
@@ -62,6 +69,9 @@ public class LaunchService(
                 statuslineCommand = spec.statuslineCommand,
                 loginCommand = spec.loginCommand,
                 signInLabel = spec.signInLabel,
+                signInViaBrowser = spec.signInViaBrowser,
+                tokenCapture = spec.tokenCapture,
+                advertiseKeySetup = spec.advertiseKeySetup,
             ),
         )
         val env = buildEnv(spec)

--- a/gateway/core/src/main/kotlin/splice/core/config/KeyStore.kt
+++ b/gateway/core/src/main/kotlin/splice/core/config/KeyStore.kt
@@ -1,0 +1,92 @@
+// NEW: the durable api-key store (~/.config/splice/keys.toml, 0600). Until now an api-key head
+// authenticated only when the DAEMON's own process environment carried the key — export it after
+// the daemon started and the shell saw it but the daemon did not (the #1 documented setup pain).
+// KeyStore is the file fallback ApiKeyAuthProvider reads after env and any explicit auth.file:
+// `splice key set`, `claudeor login`, or a head's token-capture hook writes here once and every
+// later `splice restart` picks the key up from any shell. Flat `NAME = "value"` subset of TOML —
+// we are the only writer, so a tolerant line parser is enough and core stays ktoml-free.
+// Lives in core/config: System.getenv is walled to this package (kt-no-system-getenv) and the
+// path/env readers stay injectable for hermetic tests (StatePaths idiom — JVM cannot setenv).
+// Writes route through SecureFile.writeAtomic0600 — the single credential-write primitive (#924).
+package splice.core.config
+
+import splice.core.util.SecureFile
+import splice.core.util.runCatchingCancellable
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+public class KeyStore(
+    public val path: Path,
+) {
+    /** The key for [envVar], or null when absent/blank/unreadable. Last assignment wins,
+     *  comments (#) and blanks are skipped, single or double quotes stripped. */
+    public fun read(envVar: String): String? = entries()[envVar]
+
+    /** Every configured env-var NAME (never the values — safe for `splice key list`). */
+    public fun names(): Set<String> = entries().keys
+
+    /** Insert or replace [envVar] = [value] (0600 atomic write). Preserves sibling entries;
+     *  comments are NOT (we are the only writer — hand edits survive only as entries). */
+    public fun write(envVar: String, value: String) {
+        require(envVar.matches(ENV_NAME)) { "invalid env name '$envVar' (want $ENV_NAME)" }
+        require(value.isNotBlank()) { "empty key for '$envVar'" }
+        val next = entries().toMutableMap()
+        next[envVar] = value.trim()
+        persist(next)
+    }
+
+    /** Remove [envVar]; returns true when it was present. */
+    public fun unset(envVar: String): Boolean {
+        val next = entries().toMutableMap()
+        val removed = next.remove(envVar) != null
+        if (removed) persist(next)
+        return removed
+    }
+
+    private fun entries(): Map<String, String> {
+        if (!Files.exists(path)) return emptyMap()
+        return runCatchingCancellable {
+            Files.readAllLines(path)
+                .mapNotNull { line ->
+                    val cut = line.substringBefore('#').trim()
+                    if (cut.isEmpty() || '=' !in cut) return@mapNotNull null
+                    val name = cut.substringBefore('=').trim()
+                    val value = cut.substringAfter('=').trim().trim('"', '\'')
+                    if (name.matches(ENV_NAME) && value.isNotEmpty()) name to value else null
+                }
+                .toMap()
+        }.getOrDefault(emptyMap())
+    }
+
+    private fun persist(entries: Map<String, String>) {
+        val text = buildString {
+            appendLine("# splice api keys — password-equivalent, keep 0600, never commit.")
+            appendLine("# Written by `splice key set` / `<head> login` / a head's token-capture hook.")
+            entries.toSortedMap().forEach { (name, value) -> appendLine("$name = \"$value\"") }
+        }
+        SecureFile.writeAtomic0600(path, text)
+    }
+
+    public companion object {
+        private val ENV_NAME = Regex("[A-Z][A-Z0-9_]*")
+
+        /** keys.toml beside splice.toml: SPLICE_CONFIG's sibling when set, else XDG
+         *  (~/.config/splice). Mirrors TopologyLoader.configPath so test rigs stay hermetic. */
+        public fun defaultPath(envReader: (String) -> String? = System::getenv): Path {
+            val override = envReader("SPLICE_CONFIG")
+            if (override != null) {
+                val expanded =
+                    if (override.startsWith("~/")) {
+                        System.getProperty("user.home") + override.substring(1)
+                    } else {
+                        override
+                    }
+                return Paths.get(expanded).resolveSibling("keys.toml")
+            }
+            val xdg = envReader("XDG_CONFIG_HOME")
+            val base = if (xdg != null) Paths.get(xdg) else Paths.get(System.getProperty("user.home"), ".config")
+            return base.resolve("splice").resolve("keys.toml")
+        }
+    }
+}

--- a/gateway/core/src/main/kotlin/splice/core/launch/ClaudeConfigMaterializer.kt
+++ b/gateway/core/src/main/kotlin/splice/core/launch/ClaudeConfigMaterializer.kt
@@ -64,6 +64,16 @@ public data class MaterializeSpec(
     val loginCommand: String = "",
     // Human label for the head's provider in the /login UX (e.g. "Codex (ChatGPT)", "Grok (xAI)").
     val signInLabel: String = "",
+    // True for browser-OAuth heads; false switches the block reason to the masked-terminal-prompt
+    // wording (api-key heads sign in at a console readPassword, not a browser).
+    val signInViaBrowser: Boolean = true,
+    // api-key heads: capture a BARE provider token pasted as the whole message into the KeyStore,
+    // blocked before it reaches the model context. Null disables capture.
+    val tokenCapture: TokenCaptureSpec? = null,
+    // Install the SessionStart key-missing advertiser. The daemon sets this only while the head's
+    // key is unconfigured and re-materializes on every launch, so the advertiser removes itself
+    // once the key lands. Requires tokenCapture for the paste instruction to be true.
+    val advertiseKeySetup: Boolean = false,
 )
 
 public class ClaudeConfigMaterializer(
@@ -79,13 +89,22 @@ public class ClaudeConfigMaterializer(
         requireIsolatedDir(spec.configDir)
         Files.createDirectories(spec.configDir)
         linkShared(spec.configDir, spec.policy)
-        val loginHook = LoginInterception.wire(
-            spec.configDir,
-            spec.loginCommand,
-            spec.signInLabel,
-            globalCommands = if (shares(spec.policy, Keys.COMMANDS)) globalDir().resolve(Keys.COMMANDS) else null,
+        val hookAdditions = LoginInterception.concat(
+            LoginInterception.wire(
+                spec.configDir,
+                spec.loginCommand,
+                spec.signInLabel,
+                globalCommands = if (shares(spec.policy, Keys.COMMANDS)) globalDir().resolve(Keys.COMMANDS) else null,
+                viaBrowser = spec.signInViaBrowser,
+                tokenCapture = spec.tokenCapture,
+            ),
+            if (spec.advertiseKeySetup && spec.tokenCapture != null) {
+                LoginInterception.keySetupAdvertiser(spec.configDir, spec.tokenCapture, spec.loginCommand)
+            } else {
+                emptyMap()
+            },
         )
-        writeSettings(spec, loginHook)
+        writeSettings(spec, hookAdditions)
         val mcpCount = writeClaudeJson(
             spec.configDir,
             spec.modelOptionsCache,
@@ -151,7 +170,7 @@ public class ClaudeConfigMaterializer(
         Files.createSymbolicLink(dst, src)
     }
 
-    private fun writeSettings(spec: MaterializeSpec, loginHook: JsonObject?) {
+    private fun writeSettings(spec: MaterializeSpec, hookAdditions: Map<String, List<JsonObject>>) {
         val allow = spec.availableModelIds
         val dst = spec.configDir.resolve(Keys.SETTINGS)
         val global =
@@ -159,7 +178,7 @@ public class ClaudeConfigMaterializer(
         val existing = breakSettingsSymlinkAndRead(dst)
         val savedModel = existing[Keys.MODEL]?.jsonPrimitive?.content
         val model = if (savedModel != null && savedModel in allow) savedModel else spec.defaultModel
-        val hooks = LoginInterception.mergeInto(global[Keys.HOOKS], loginHook)
+        val hooks = LoginInterception.mergeInto(global[Keys.HOOKS], hookAdditions)
         val merged = buildJsonObject {
             global.forEach { (k, v) -> if (isCarriedGlobalKey(k)) put(k, v) }
             putJsonArray(Keys.AVAILABLE_MODELS) { allow.forEach { add(it) } }

--- a/gateway/core/src/main/kotlin/splice/core/launch/LoginHookScripts.kt
+++ b/gateway/core/src/main/kotlin/splice/core/launch/LoginHookScripts.kt
@@ -1,0 +1,87 @@
+// NEW: the bash hook script TEXTS for the /login interception, api-key token capture, and
+// key-missing advertiser (split from LoginInterception, detekt TooManyFunctions — that file
+// keeps the wiring/merging, this one keeps the generated bash). No python dependency anywhere:
+// scripts glob the raw hook JSON; the capture regex relies on the token charset being
+// JSON-escape-free (word chars + dashes), so raw-JSON matching is exact.
+package splice.core.launch
+
+// The custom /login command body: submits the sentinel the hook catches. [signInLabel] names
+// the head's provider so the UX reads right per head.
+internal fun loginCommandMd(signInLabel: String, sentinel: String): String =
+    """
+    |---
+    |description: Sign in to $signInLabel for this splice head
+    |---
+    |$sentinel
+    """.trimMargin() + "\n"
+
+internal fun loginHookScript(loginCommand: String, signInLabel: String, viaBrowser: Boolean, sentinel: String): String =
+    buildString {
+        val d = "$" // keep the shell $ out of Kotlin interpolation
+        val lead =
+            if (viaBrowser) {
+                "Opening your browser to sign in to $signInLabel — finish there, then continue. " +
+                    "If it did not open, run: $loginCommand"
+            } else {
+                "A masked terminal prompt is asking for your $signInLabel API key — finish there, then continue. " +
+                    "If it did not appear, run: $loginCommand"
+            }
+        appendLine("#!/usr/bin/env bash")
+        appendLine("# NEW (splice): /login interception — route to this head's $signInLabel sign-in,")
+        appendLine("# not Claude Code's disabled Anthropic login. Runs detached; blocks the model turn.")
+        appendLine("input=\"$d(cat)\"")
+        appendLine("case \"${d}input\" in")
+        appendLine("  *$sentinel*|*'\"prompt\":\"/login\"'*|*'\"prompt\": \"/login\"'*)")
+        appendLine("    nohup $loginCommand >/dev/null 2>&1 &")
+        append("    printf '%s' '{\"decision\":\"block\",\"reason\":")
+        append("\"$lead\"}'")
+        appendLine()
+        appendLine("    ;;")
+        appendLine("esac")
+        appendLine("exit 0")
+    }
+
+// The capture regex is quote-anchored: the token must be the ENTIRE prompt string in the hook
+// JSON, so a token quoted inside prose never matches (discussing a key is safe).
+internal fun captureHookScript(spec: TokenCaptureSpec): String = buildString {
+    val d = "$" // keep the shell $ out of Kotlin interpolation
+    appendLine("#!/usr/bin/env bash")
+    appendLine("# NEW (splice): api-key capture — a BARE ${spec.providerLabel} token pasted as the whole")
+    appendLine("# message is stored to keys.toml (0600) via `splice key set --stdin` and BLOCKED before")
+    appendLine("# it reaches the model context, so it never travels upstream. The session transcript")
+    appendLine("# still records the paste; the fully masked path is `<head> login`.")
+    appendLine("input=\"$d(cat)\"")
+    append("if [[ ${d}input =~ ")
+    append("\\\"prompt\\\"[[:space:]]*:[[:space:]]*\\\"(${spec.tokenPattern})\\\" ]]; then")
+    appendLine()
+    appendLine("  token=\"$d{BASH_REMATCH[1]}\"")
+    appendLine("  if printf '%s' \"${d}token\" | splice key set ${spec.envVar} --stdin >/dev/null 2>&1; then")
+    appendLine("    nohup splice restart >/dev/null 2>&1 &")
+    append("    printf '%s' '{\"decision\":\"block\",\"reason\":")
+    append("\"${spec.providerLabel} key received — stored to ~/.config/splice/keys.toml (0600) ")
+    append("and the daemon is restarting. It was NOT forwarded to the model. Note: this session log ")
+    append("still contains the pasted line; the fully masked path is <head> login.\"}'")
+    appendLine()
+    appendLine("  else")
+    append("    printf '%s' '{\"decision\":\"block\",\"reason\":")
+    append("\"${spec.providerLabel} key detected but storing it failed — ")
+    append("run <head> login in a terminal instead.\"}'")
+    appendLine()
+    appendLine("  fi")
+    appendLine("fi")
+    appendLine("exit 0")
+}
+
+// Installed only while the key is missing (the daemon re-materializes on every launch and
+// removes it once configured), so printing unconditionally is correct.
+internal fun keySetupScript(spec: TokenCaptureSpec, loginCommand: String): String = buildString {
+    appendLine("#!/usr/bin/env bash")
+    appendLine("# NEW (splice): key-missing advertiser for ${spec.envVar} — installed only while unconfigured.")
+    append("printf '%s' '")
+    append("splice: ${spec.envVar} is not configured for this head. Tell the user ONCE, plainly: ")
+    append("paste your ${spec.providerLabel} API key as your next message and splice will store it ")
+    append("to keys.toml without it reaching the model, or run $loginCommand in a terminal for a ")
+    append("fully masked prompt. Then wait.")
+    appendLine("'")
+    appendLine("exit 0")
+}

--- a/gateway/core/src/main/kotlin/splice/core/launch/LoginInterception.kt
+++ b/gateway/core/src/main/kotlin/splice/core/launch/LoginInterception.kt
@@ -1,9 +1,14 @@
-// NEW: materializes the /login interception for a head. Claude Code's built-in Anthropic /login is
-// disabled in the head's launch env (DISABLE_LOGIN_COMMAND), and it's a local-jsx command no hook can
-// reach anyway; so we (1) drop a custom commands/login.md — which is why the head's `commands` must be
-// a REAL dir, not a whole-dir symlink to global — that submits a unique sentinel, and (2) install a
-// UserPromptSubmit hook that catches the sentinel, runs the head's codex (ChatGPT) sign-in detached,
-// and blocks the model turn. `wire()` returns the settings.json hook entry to merge, or null.
+// NEW: materializes the /login interception + api-key token capture for a head. Claude Code's
+// built-in Anthropic /login is disabled in the head's launch env (DISABLE_LOGIN_COMMAND), and
+// it's a local-jsx command no hook can reach anyway; so we (1) drop a custom commands/login.md —
+// which is why the head's `commands` must be a REAL dir, not a whole-dir symlink to global — that
+// submits a unique sentinel, and (2) install a UserPromptSubmit hook that catches the sentinel,
+// runs the head's sign-in detached, and blocks the model turn. For api-key heads we additionally
+// (3) install a token-capture hook: a BARE provider token pasted as the whole message is stored
+// to keys.toml via `splice key set --stdin` and BLOCKED before it ever reaches the model context
+// (so it never travels upstream through the gateway), and (4) — only while the key is missing —
+// a SessionStart advertiser that tells the model to offer the paste flow. The bash texts live in
+// LoginHookScripts.kt; wire() returns the settings.json hook entries to merge, keyed by event.
 package splice.core.launch
 
 import kotlinx.serialization.json.JsonArray
@@ -22,45 +27,98 @@ import java.nio.file.attribute.PosixFilePermissions
 import kotlin.io.path.isDirectory
 import kotlin.io.path.isSymbolicLink
 
+/** What an api-key head captures from the prompt box. [tokenPattern] is a bash ERE matched as
+ *  the WHOLE prompt (quote-anchored in the hook JSON) — a token embedded in prose never matches,
+ *  so discussing a key never triggers capture. */
+public data class TokenCaptureSpec(
+    val envVar: String, // e.g. OPENROUTER_API_KEY
+    val tokenPattern: String, // e.g. sk-or-[A-Za-z0-9_-]{20,}
+    val providerLabel: String, // e.g. "OpenRouter"
+)
+
 internal object LoginInterception {
     private const val LOGIN_MD = "login.md"
     private const val LOGIN_HOOK_SH = "splice-login-hook.sh"
+    private const val CAPTURE_HOOK_SH = "splice-key-capture-hook.sh"
+    private const val KEYSETUP_HOOK_SH = "splice-keysetup-hook.sh"
     private const val LOGIN_SENTINEL = "SPLICE_CODEX_LOGIN"
     private const val USER_PROMPT_SUBMIT = "UserPromptSubmit"
+    private const val SESSION_START = "SessionStart"
     private const val HOOK_TIMEOUT_SECONDS = 15
 
-    // The custom /login command: submits the sentinel the hook catches. [signInLabel] names the
-    // head's provider (e.g. "Codex (ChatGPT)", "Grok (xAI)") so the UX reads right per head.
-    private fun loginCommandMd(signInLabel: String): String =
-        """
-        |---
-        |description: Sign in to $signInLabel for this splice head
-        |---
-        |$LOGIN_SENTINEL
-        """.trimMargin() + "\n"
-
     /**
-     * Materialize the /login command + hook. [signInLabel] names the provider for the UX text.
-     * [globalCommands] is the operator's ~/.claude/commands to re-link into the head's real commands
-     * dir when the policy shares them, or null to skip. Best-effort: I/O failure skips it (null).
+     * Materialize the /login command + hooks. [signInLabel] names the provider for the UX text;
+     * [viaBrowser] false switches the block reason to the masked-terminal-prompt wording (api-key
+     * heads). [tokenCapture] adds the bare-token capture hook. [globalCommands] is the operator's
+     * ~/.claude/commands to re-link into the head's real commands dir when the policy shares them,
+     * or null to skip. Best-effort: I/O failure skips it (empty map).
      */
-    fun wire(configDir: Path, loginCommand: String, signInLabel: String, globalCommands: Path?): JsonObject? {
-        if (loginCommand.isBlank()) return null
+    fun wire(
+        configDir: Path,
+        loginCommand: String,
+        signInLabel: String,
+        globalCommands: Path?,
+        viaBrowser: Boolean = true,
+        tokenCapture: TokenCaptureSpec? = null,
+    ): Map<String, List<JsonObject>> {
+        if (loginCommand.isBlank() && tokenCapture == null) return emptyMap()
         return runCatchingCancellable {
-            writeCommandsDir(configDir, signInLabel, globalCommands)
-            hookEntry(writeHookScript(configDir, loginCommand, signInLabel))
-        }.getOrNull()
+            buildMap {
+                val upsHooks = mutableListOf<JsonObject>()
+                if (loginCommand.isNotBlank()) {
+                    writeCommandsDir(configDir, signInLabel, globalCommands)
+                    val script = writeHookScript(
+                        configDir,
+                        LOGIN_HOOK_SH,
+                        loginHookScript(loginCommand, signInLabel, viaBrowser, LOGIN_SENTINEL),
+                    )
+                    upsHooks += hookEntry(script, HOOK_TIMEOUT_SECONDS)
+                }
+                if (tokenCapture != null) {
+                    val script = writeHookScript(configDir, CAPTURE_HOOK_SH, captureHookScript(tokenCapture))
+                    upsHooks += hookEntry(script, HOOK_TIMEOUT_SECONDS)
+                }
+                if (upsHooks.isNotEmpty()) put(USER_PROMPT_SUBMIT, upsHooks)
+            }
+        }.getOrElse { emptyMap() }
     }
 
-    /** Merge [entry] into the operator's global UserPromptSubmit hooks (preserving any existing). */
-    fun mergeInto(globalHooks: JsonElement?, entry: JsonObject?): JsonObject? {
+    /** The SessionStart advertiser — installed by the materializer ONLY while the key is missing
+     *  (the daemon checks at every launch), so it can print unconditionally. */
+    fun keySetupAdvertiser(
+        configDir: Path,
+        spec: TokenCaptureSpec,
+        loginCommand: String,
+    ): Map<String, List<JsonObject>> =
+        runCatchingCancellable {
+            val script = writeHookScript(configDir, KEYSETUP_HOOK_SH, keySetupScript(spec, loginCommand))
+            mapOf(SESSION_START to listOf(hookEntry(script, HOOK_TIMEOUT_SECONDS)))
+        }.getOrElse { emptyMap() }
+
+    /** Concatenate two hook-addition maps per event — a plain map `+` would silently overwrite
+     *  a duplicate event key (e.g. capture hook + login hook both landing on UserPromptSubmit). */
+    fun concat(
+        a: Map<String, List<JsonObject>>,
+        b: Map<String, List<JsonObject>>,
+    ): Map<String, List<JsonObject>> =
+        (a.keys + b.keys).associateWith { k -> a[k].orEmpty() + b[k].orEmpty() }
+
+    /** Merge [additions] (event -> entries) into the operator's global hooks, preserving any
+     *  existing entries per event. */
+    fun mergeInto(globalHooks: JsonElement?, additions: Map<String, List<JsonObject>>): JsonObject? {
         val base = globalHooks as? JsonObject
-        if (entry == null) return base
+        if (additions.isEmpty()) return base
+        val events = (base?.keys.orEmpty() + additions.keys).toSet()
+        if (events.isEmpty()) return null
         return buildJsonObject {
-            base?.forEach { (k, v) -> if (k != USER_PROMPT_SUBMIT) put(k, v) }
-            putJsonArray(USER_PROMPT_SUBMIT) {
-                (base?.get(USER_PROMPT_SUBMIT) as? JsonArray)?.forEach { add(it) }
-                add(entry)
+            for (event in events) {
+                val existing = (base?.get(event) as? JsonArray).orEmpty()
+                val added = additions[event].orEmpty()
+                if (existing.isEmpty() && added.isEmpty()) continue
+                putJsonArray(event) {
+                    existing.forEach { add(it) }
+                    added.forEach { add(it) }
+                }
             }
         }
     }
@@ -70,7 +128,7 @@ internal object LoginInterception {
         if (dst.isSymbolicLink()) Files.delete(dst)
         Files.createDirectories(dst)
         if (globalCommands != null) linkGlobalCommandsInto(dst, globalCommands)
-        Files.writeString(dst.resolve(LOGIN_MD), loginCommandMd(signInLabel))
+        Files.writeString(dst.resolve(LOGIN_MD), loginCommandMd(signInLabel, LOGIN_SENTINEL))
     }
 
     private fun linkGlobalCommandsInto(dst: Path, globalCommands: Path) {
@@ -88,38 +146,20 @@ internal object LoginInterception {
         Files.createSymbolicLink(dst, src)
     }
 
-    private fun writeHookScript(configDir: Path, loginCommand: String, signInLabel: String): Path {
-        val script = configDir.resolve(LOGIN_HOOK_SH)
-        Files.writeString(script, hookScript(loginCommand, signInLabel))
+    private fun writeHookScript(configDir: Path, name: String, content: String): Path {
+        val script = configDir.resolve(name)
+        Files.writeString(script, content)
         runCatchingCancellable { Files.setPosixFilePermissions(script, PosixFilePermissions.fromString("rwx------")) }
         return script
     }
 
-    private fun hookEntry(script: Path): JsonObject = buildJsonObject {
+    private fun hookEntry(script: Path, timeoutSeconds: Int): JsonObject = buildJsonObject {
         putJsonArray("hooks") {
             addJsonObject {
                 put("type", "command")
                 put("command", script.toString())
-                put("timeout", HOOK_TIMEOUT_SECONDS)
+                put("timeout", timeoutSeconds)
             }
         }
-    }
-
-    // No python dependency — globs the raw hook JSON for the unique sentinel (or a raw /login prompt).
-    private fun hookScript(loginCommand: String, signInLabel: String): String = buildString {
-        val d = "$" // keep the shell $ out of Kotlin interpolation
-        appendLine("#!/usr/bin/env bash")
-        appendLine("# NEW (splice): /login interception — route to this head's $signInLabel sign-in,")
-        appendLine("# not Claude Code's disabled Anthropic login. Runs detached; blocks the model turn.")
-        appendLine("input=\"$d(cat)\"")
-        appendLine("case \"${d}input\" in")
-        appendLine("  *$LOGIN_SENTINEL*|*'\"prompt\":\"/login\"'*|*'\"prompt\": \"/login\"'*)")
-        appendLine("    nohup $loginCommand >/dev/null 2>&1 &")
-        append("    printf '%s' '{\"decision\":\"block\",\"reason\":")
-        append("\"Opening your browser to sign in to $signInLabel — finish there, then continue. ")
-        appendLine("If it did not open, run: $loginCommand\"}'")
-        appendLine("    ;;")
-        appendLine("esac")
-        appendLine("exit 0")
     }
 }

--- a/gateway/core/src/test/kotlin/ClaudeConfigMaterializerTest.kt
+++ b/gateway/core/src/test/kotlin/ClaudeConfigMaterializerTest.kt
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.io.TempDir
 import splice.core.launch.ClaudeConfigMaterializer
 import splice.core.launch.ClaudePolicy
 import splice.core.launch.MaterializeSpec
+import splice.core.launch.TokenCaptureSpec
 import java.nio.file.Files
 import java.nio.file.LinkOption.NOFOLLOW_LINKS
 import java.nio.file.Path
@@ -215,5 +216,69 @@ class ClaudeConfigMaterializerTest {
         materializer(tmp).materialize(dir, allPolicy, listOf("m"), "m", optionsCache) // shim: loginCommand=""
         assertFalse(Files.exists(dir.resolve("splice-login-hook.sh")))
         assertTrue(dir.resolve("commands").isSymbolicLink()) // stays a plain shared symlink
+    }
+
+    @Test
+    fun `api-key head wires capture hook plus masked-prompt login wording`(@TempDir tmp: Path) {
+        seedGlobal(tmp)
+        val dir = tmp.resolve(".claude-openrouter")
+        materializer(tmp).materialize(
+            MaterializeSpec(
+                configDir = dir,
+                policy = allPolicy,
+                availableModelIds = listOf("m"),
+                defaultModel = "m",
+                modelOptionsCache = optionsCache,
+                statuslineCommand = statusline,
+                loginCommand = "claudeor login",
+                signInLabel = "OpenRouter",
+                signInViaBrowser = false,
+                tokenCapture = TokenCaptureSpec("OPENROUTER_API_KEY", "sk-or-[A-Za-z0-9_-]{20,}", "OpenRouter"),
+            ),
+        )
+        // login.md + login hook exist, with the MASKED-PROMPT wording (no browser anywhere)
+        val loginHook = dir.resolve("splice-login-hook.sh").readText()
+        assertTrue(loginHook.contains("masked terminal prompt"))
+        assertFalse(loginHook.contains("browser"))
+        // capture hook: env name, quote-anchored pattern, store via splice key set --stdin, blocked
+        val capture = dir.resolve("splice-key-capture-hook.sh").readText()
+        assertTrue(capture.contains("OPENROUTER_API_KEY"))
+        assertTrue(capture.contains("sk-or-[A-Za-z0-9_-]{20,}"))
+        assertTrue(capture.contains("splice key set OPENROUTER_API_KEY --stdin"))
+        assertTrue(capture.contains("\\\"prompt\\\""))
+        // settings.json wires BOTH UserPromptSubmit hooks
+        val settings = Json.parseToJsonElement(dir.resolve("settings.json").readText()).jsonObject
+        val ups = settings["hooks"]!!.jsonObject["UserPromptSubmit"]!!.jsonArray.toString()
+        assertTrue(ups.contains("splice-login-hook.sh"))
+        assertTrue(ups.contains("splice-key-capture-hook.sh"))
+        // no advertiser unless asked
+        assertFalse(settings["hooks"]!!.jsonObject.containsKey("SessionStart"))
+    }
+
+    @Test
+    fun `advertiseKeySetup installs the SessionStart advertiser`(@TempDir tmp: Path) {
+        seedGlobal(tmp)
+        val dir = tmp.resolve(".claude-openrouter")
+        materializer(tmp).materialize(
+            MaterializeSpec(
+                configDir = dir,
+                policy = allPolicy,
+                availableModelIds = listOf("m"),
+                defaultModel = "m",
+                modelOptionsCache = optionsCache,
+                statuslineCommand = statusline,
+                loginCommand = "claudeor login",
+                signInLabel = "OpenRouter",
+                signInViaBrowser = false,
+                tokenCapture = TokenCaptureSpec("OPENROUTER_API_KEY", "sk-or-[A-Za-z0-9_-]{20,}", "OpenRouter"),
+                advertiseKeySetup = true,
+            ),
+        )
+        val script = dir.resolve("splice-keysetup-hook.sh").readText()
+        assertTrue(script.contains("OPENROUTER_API_KEY"))
+        assertTrue(script.contains("OpenRouter"))
+        val settings = Json.parseToJsonElement(dir.resolve("settings.json").readText()).jsonObject
+        val ss = settings["hooks"]!!.jsonObject["SessionStart"]!!.jsonArray.toString()
+        assertTrue(ss.contains("splice-keysetup-hook.sh"))
     }
 }

--- a/gateway/core/src/test/kotlin/KeyStoreTest.kt
+++ b/gateway/core/src/test/kotlin/KeyStoreTest.kt
@@ -1,0 +1,93 @@
+// NEW: KeyStore — the durable api-key store behind `splice key set` / `<head> login` /
+// token capture. Round-trip, precedence-irrelevant mechanics (that lives in the provider test),
+// parse tolerance, and the 0600 + SPLICE_CONFIG-sibling path contract.
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import splice.core.config.KeyStore
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermissions
+
+class KeyStoreTest {
+
+    private fun store(tmp: Path) = KeyStore(tmp.resolve("keys.toml"))
+
+    @Test
+    fun `write then read round-trips and lists names only`(@TempDir tmp: Path) {
+        val s = store(tmp)
+        s.write("OPENROUTER_API_KEY", "sk-or-v1-abc123")
+        s.write("MOONSHOT_API_KEY", "sk-moon-456")
+        assertEquals("sk-or-v1-abc123", s.read("OPENROUTER_API_KEY"))
+        assertEquals(setOf("OPENROUTER_API_KEY", "MOONSHOT_API_KEY"), s.names())
+    }
+
+    @Test
+    fun `file is owner-only 0600 from creation`(@TempDir tmp: Path) {
+        val s = store(tmp)
+        s.write("OPENROUTER_API_KEY", "sk-or-v1-abc123")
+        val perms = Files.getPosixFilePermissions(s.path)
+        assertEquals(PosixFilePermissions.fromString("rw-------"), perms)
+    }
+
+    @Test
+    fun `rewrite preserves siblings and last assignment wins`(@TempDir tmp: Path) {
+        val s = store(tmp)
+        s.write("A_KEY", "one")
+        s.write("B_KEY", "two")
+        s.write("A_KEY", "three")
+        assertEquals("three", s.read("A_KEY"))
+        assertEquals("two", s.read("B_KEY"))
+    }
+
+    @Test
+    fun `tolerates comments blanks quotes and junk lines`(@TempDir tmp: Path) {
+        Files.writeString(
+            tmp.resolve("keys.toml"),
+            "# comment\n\nOPENROUTER_API_KEY = 'sk-or-single'\nMOONSHOT_API_KEY = \"sk-moon-double\"\njunk line\n",
+        )
+        val s = store(tmp)
+        assertEquals("sk-or-single", s.read("OPENROUTER_API_KEY"))
+        assertEquals("sk-moon-double", s.read("MOONSHOT_API_KEY"))
+        assertEquals(2, s.names().size)
+    }
+
+    @Test
+    fun `missing file reads as empty`(@TempDir tmp: Path) {
+        val s = store(tmp)
+        assertNull(s.read("OPENROUTER_API_KEY"))
+        assertTrue(s.names().isEmpty())
+    }
+
+    @Test
+    fun `unset removes only the named key`(@TempDir tmp: Path) {
+        val s = store(tmp)
+        s.write("A_KEY", "one")
+        s.write("B_KEY", "two")
+        assertTrue(s.unset("A_KEY"))
+        assertNull(s.read("A_KEY"))
+        assertEquals("two", s.read("B_KEY"))
+        assertTrue(!s.unset("NEVER_SET"))
+    }
+
+    @Test
+    fun `invalid names and empty values are rejected`(@TempDir tmp: Path) {
+        val s = store(tmp)
+        assertThrows(IllegalArgumentException::class.java) { s.write("lowercase", "x") }
+        assertThrows(IllegalArgumentException::class.java) { s.write("HAS-DASH", "x") }
+        assertThrows(IllegalArgumentException::class.java) { s.write("OK_NAME", "  ") }
+    }
+
+    @Test
+    fun `defaultPath follows SPLICE_CONFIG sibling then XDG then home`() {
+        val withOverride = KeyStore.defaultPath { k -> if (k == "SPLICE_CONFIG") "/tmp/rig/splice.toml" else null }
+        assertEquals(Path.of("/tmp/rig/keys.toml"), withOverride)
+        val withXdg = KeyStore.defaultPath { k -> if (k == "XDG_CONFIG_HOME") "/tmp/xdg" else null }
+        assertEquals(Path.of("/tmp/xdg/splice/keys.toml"), withXdg)
+        val withNothing = KeyStore.defaultPath { null }
+        assertEquals(Path.of(System.getProperty("user.home"), ".config", "splice", "keys.toml"), withNothing)
+    }
+}

--- a/gateway/provider-openai/src/main/kotlin/splice/provider/openai/ApiKeyAuthProvider.kt
+++ b/gateway/provider-openai/src/main/kotlin/splice/provider/openai/ApiKeyAuthProvider.kt
@@ -1,6 +1,7 @@
-// NEW: generic api-key auth for OpenAI-platform + any OpenAI-compatible vendor. Key from env or a
-// file (bare line or {"api_key":...}). No refresh (api keys don't expire like OAuth); refresh()
-// returns the same key. Shared by OpenAiChatProvider and an openai-platform Responses provider.
+// NEW: generic api-key auth for OpenAI-platform + any OpenAI-compatible vendor. Key from env, a
+// file (bare line or {"api_key":...}), or the shared KeyStore (~/.config/splice/keys.toml) — in
+// that precedence order. No refresh (api keys don't expire like OAuth); refresh() returns the
+// same key. Shared by OpenAiChatProvider and an openai-platform Responses provider.
 package splice.provider.openai
 
 import kotlinx.serialization.json.Json
@@ -8,6 +9,7 @@ import kotlinx.serialization.json.jsonObject
 import splice.core.auth.AuthDescription
 import splice.core.auth.Credentials
 import splice.core.auth.RefreshableAuthProvider
+import splice.core.config.KeyStore
 import splice.core.util.runCatchingCancellable
 import splice.core.util.str
 import java.nio.file.Files
@@ -17,6 +19,10 @@ public class ApiKeyAuthProvider(
     private val envVar: String,
     private val keyFile: Path? = null,
     private val envReader: (String) -> String? = System::getenv,
+    // Resolved once at construction (daemon restart moves it); the FILE is re-read per call, so
+    // a `splice key set` lands on the very next request without a restart. Tests inject a hermetic
+    // store — the default points at the operator's real ~/.config/splice/keys.toml.
+    private val keyStore: KeyStore = KeyStore(KeyStore.defaultPath(envReader)),
 ) : RefreshableAuthProvider {
 
     private val json = Json { ignoreUnknownKeys = true }
@@ -24,6 +30,10 @@ public class ApiKeyAuthProvider(
     override suspend fun credentials(): Credentials? = readKey()?.let { Credentials.ApiKey(it) }
 
     override suspend fun refresh(): Credentials? = credentials()
+
+    /** Non-suspend presence peek for launch-time decisions (the SessionStart advertiser is
+     *  installed only while this is false). Same read chain as credentials(). */
+    public fun hasKeyNow(): Boolean = readKey() != null
 
     override suspend fun describe(): AuthDescription {
         val key = readKey()
@@ -45,8 +55,14 @@ public class ApiKeyAuthProvider(
 
     private fun readKey(): String? {
         envReader(envVar)?.takeIf { it.isNotEmpty() }?.let { return it }
-        val file = keyFile ?: return null
-        return runCatchingCancellable {
+        keyFile?.let { file -> readKeyFile(file)?.let { return it } }
+        // Durable fallback: `splice key set` / `<head> login` / token-capture wrote it once and
+        // every later request picks it up — the export-then-restart dance is no longer load-bearing.
+        return keyStore.read(envVar)
+    }
+
+    private fun readKeyFile(file: Path): String? =
+        runCatchingCancellable {
             if (!Files.exists(file)) return@runCatchingCancellable null
             val text = Files.readString(file).trim()
             if (text.startsWith("{")) {
@@ -57,7 +73,6 @@ public class ApiKeyAuthProvider(
         }.onFailure {
             System.err.println("[api-key-auth] failed to read $file: $it — treating as no key configured")
         }.getOrNull()
-    }
 
     private companion object {
         const val MASK_MIN = 8

--- a/gateway/provider-openai/src/test/kotlin/openai/ApiKeyAuthProviderTest.kt
+++ b/gateway/provider-openai/src/test/kotlin/openai/ApiKeyAuthProviderTest.kt
@@ -1,0 +1,78 @@
+// NEW: ApiKeyAuthProvider precedence — env > auth.file > KeyStore — and the launch-time peek.
+// The KeyStore fallback is what makes `splice key set` / `<head> login` / token capture durable:
+// a daemon started WITHOUT the env var still authenticates, from any shell, after one store.
+package openai
+
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import splice.core.config.KeyStore
+import splice.provider.openai.ApiKeyAuthProvider
+import java.nio.file.Files
+import java.nio.file.Path
+
+class ApiKeyAuthProviderTest {
+
+    private fun provider(
+        env: Map<String, String> = emptyMap(),
+        keyFile: Path? = null,
+        store: KeyStore,
+    ) = ApiKeyAuthProvider(
+        envVar = "OPENROUTER_API_KEY",
+        keyFile = keyFile,
+        envReader = { k -> env[k] },
+        keyStore = store,
+    )
+
+    @Test
+    fun `env wins over file and store`(@TempDir tmp: Path) = runBlocking {
+        val store = KeyStore(tmp.resolve("keys.toml")).apply { write("OPENROUTER_API_KEY", "sk-store") }
+        val file = tmp.resolve("key").also { Files.writeString(it, "sk-file") }
+        val p = provider(mapOf("OPENROUTER_API_KEY" to "sk-env"), file, store)
+        assertEquals("sk-env", (p.credentials() as splice.core.auth.Credentials.ApiKey).key)
+    }
+
+    @Test
+    fun `auth file beats store when env is absent`(@TempDir tmp: Path) = runBlocking {
+        val store = KeyStore(tmp.resolve("keys.toml")).apply { write("OPENROUTER_API_KEY", "sk-store") }
+        val file = tmp.resolve("key").also { Files.writeString(it, "sk-file") }
+        val p = provider(emptyMap(), file, store)
+        assertEquals("sk-file", (p.credentials() as splice.core.auth.Credentials.ApiKey).key)
+    }
+
+    @Test
+    fun `store is the durable fallback when env and file are absent`(@TempDir tmp: Path) = runBlocking {
+        val store = KeyStore(tmp.resolve("keys.toml")).apply { write("OPENROUTER_API_KEY", "sk-store") }
+        val p = provider(emptyMap(), null, store)
+        assertEquals("sk-store", (p.credentials() as splice.core.auth.Credentials.ApiKey).key)
+        assertTrue(p.hasKeyNow())
+    }
+
+    @Test
+    fun `blank env value falls through to the store`(@TempDir tmp: Path) = runBlocking {
+        val store = KeyStore(tmp.resolve("keys.toml")).apply { write("OPENROUTER_API_KEY", "sk-store") }
+        val p = provider(mapOf("OPENROUTER_API_KEY" to ""), null, store)
+        assertEquals("sk-store", (p.credentials() as splice.core.auth.Credentials.ApiKey).key)
+    }
+
+    @Test
+    fun `nothing configured reads as absent`(@TempDir tmp: Path) = runBlocking {
+        val p = provider(emptyMap(), null, KeyStore(tmp.resolve("keys.toml")))
+        assertNull(p.credentials())
+        assertFalse(p.hasKeyNow())
+        assertFalse(p.describe().present)
+    }
+
+    @Test
+    fun `store is re-read per call so a later key set lands without restart`(@TempDir tmp: Path) = runBlocking {
+        val store = KeyStore(tmp.resolve("keys.toml"))
+        val p = provider(emptyMap(), null, store)
+        assertNull(p.credentials())
+        store.write("OPENROUTER_API_KEY", "sk-late")
+        assertEquals("sk-late", (p.credentials() as splice.core.auth.Credentials.ApiKey).key)
+    }
+}


### PR DESCRIPTION
Api-key heads (claudeor/OpenRouter first) no longer require exporting the key into the daemon's own environment:

- **KeyStore** (`core.config`): `~/.config/splice/keys.toml`, 0600 via SecureFile.writeAtomic0600, flat `NAME = "value"`, SPLICE_CONFIG-sibling/XDG resolution.
- **ApiKeyAuthProvider** reads env → auth.file → KeyStore, re-reading the store per request: a stored key lands on the **next request from any shell** — the export-then-restart trap (README's #1 first-run pain) stops being load-bearing.
- **`splice key set|list|unset`**: masked console prompt by default, `--stdin`/`--value` for scripts; `splice login` learns the api-key flow, so `claudeor login` works like every other head (masked, never in history/ps/transcript).
- **Token capture**: a BARE `sk-or-…` token pasted as the whole message in a claudeor session is intercepted by a UserPromptSubmit hook, stored via `splice key set --stdin`, and BLOCKED before it reaches the model context — it never travels upstream. The transcript still records the paste; the masked path stays zero-trace. Capture patterns are per-provider, prose-safe shapes only (v1: OpenRouter). SessionStart advertises the flow only while the key is unconfigured (self-removing once it lands).
- doctor/status `authPresent` counts the store.

Full gate green (15 modules, detekt, arch-laws, ast-grep walls); 16 new tests (store, precedence chain, hook materialization, CLI verbs). Capture regex proven both directions (bare matches, prose doesn't).

🤖 Generated with [Claude Code](https://claude.com/claude-code)