### PR TITLE
fix(responses): continuation rounds no longer re-request reasoning summaries

### DIFF
--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesFold.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesFold.kt
@@ -86,13 +86,26 @@ public class ResponsesFoldController(
 
 /** DTO-faithful continuation shared by fold and re-anchor: decode the prior request, extend ONLY
  *  its `input` with [extraItems], re-encode through the same closed serializer. No request FIELD
- *  is added — the #924 closed DTO is untouched, so byte-identity off both paths is trivial. */
+ *  is added — the #924 closed DTO is untouched, so byte-identity off both paths is trivial.
+ *  The summary request is STRIPPED (2026-07-26, operator report): continuation rounds replay
+ *  reasoning the server already summarized in round 1, and re-asking `summary: detailed` makes
+ *  the summarizer re-title the same content with the same generic section titles — which the
+ *  mirror commits as duplicated reasoning blocks in adjacent turns (measured 89-102 dupes per
+ *  claudex session; codex-rs/KiloCode/opencode don't re-request it). Effort, context, and the
+ *  encrypted-content include stay — continuity is untouched; only the summary RE-REQUEST dies. */
 internal fun continuationRequest(previous: JsonObject, extraItems: List<JsonObject>): JsonObject {
     val base = responsesRequestJson.decodeFromJsonElement(ResponsesRequest.serializer(), previous)
     val nextInput = buildJsonArray {
         base.input.forEach { add(it) }
         extraItems.forEach { add(it) }
     }
-    val next = base.copy(input = nextInput)
+    val next = base.copy(
+        input = nextInput,
+        reasoning = base.reasoning?.withoutSummary(),
+        streamOptions = null,
+    )
     return responsesRequestJson.encodeToJsonElement(ResponsesRequest.serializer(), next) as JsonObject
 }
+
+private fun JsonObject.withoutSummary(): JsonObject =
+    JsonObject(filterKeys { it != "summary" })

--- a/gateway/dialect-openai-responses/src/test/kotlin/ResponsesFoldTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ResponsesFoldTest.kt
@@ -21,6 +21,7 @@ import splice.core.turn.TurnOutcome
 import splice.core.turn.Usage
 import splice.dialect.responses.FoldConfig
 import splice.dialect.responses.ResponsesFoldController
+import splice.dialect.responses.continuationRequest
 import splice.spi.FoldRound
 import splice.core.reasoning.decodeReasoningEnvelope as coreDecode
 
@@ -116,5 +117,31 @@ class ResponsesFoldTest {
     fun `tier window - a tier above maxTier is released as-is`() {
         // tier 7 fingerprint = 518*7 - 2 = 3624, above the default maxTierN 6.
         assertNull(controller.continuation(round(3624, listOf(envelopeFor("rs")))))
+    }
+
+    @Test
+    fun `continuation strips the summary re-request but keeps effort and context`() {
+        // 2026-07-26: continuation rounds replay reasoning the server already summarized; re-asking
+        // summary: detailed re-titles the same content and lands as duplicated reasoning blocks.
+        val withSummary = Json.parseToJsonElement(
+            """{"model":"gpt-5.6-luna","input":[{"role":"user","content":"solve it"}],
+                "store":false,"stream":true,
+                "reasoning":{"effort":"high","summary":"detailed","context":"all_turns"},
+                "stream_options":{"reasoning_summary_delivery":"sequential_cutoff"}}""",
+        ).jsonObject
+        val next = continuationRequest(withSummary, emptyList())
+        val reasoning = next["reasoning"]!!.jsonObject
+        assertNull(reasoning["summary"])
+        assertEquals("high", reasoning["effort"]?.jsonPrimitive?.content)
+        assertEquals("all_turns", reasoning["context"]?.jsonPrimitive?.content)
+        assertNull(next["stream_options"])
+        assertEquals("solve it", next["input"]!!.jsonArray.first().jsonObject["content"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `continuation without a reasoning block stays reasoning-free`() {
+        val next = continuationRequest(priorRequest, emptyList())
+        assertNull(next["reasoning"]?.jsonObject?.get("summary"))
+        assertNull(next["stream_options"])
     }
 }


### PR DESCRIPTION
**Root cause of the duplicated reasoning traces** (operator report 2026-07-26; measured 89–102 duplicated summary sections across claudex sessions): every fold / reanchor / tool_search continuation re-sent `reasoning.summary=detailed` via `continuationRequest`'s `base.copy`. The continuation replays reasoning the server already summarized in round 1, and re-asking for a detailed summary makes the summarizer re-title that same content with the same generic section titles — which the mirror commits as duplicated thinking blocks in adjacent turns.

**Why this is the request, not the dedup:** four direct probes against the live ChatGPT backend (plain continuation, reanchor-shaped, fold-shaped, with/without `sequential_cutoff`) produced **zero** restated sections — the backend doesn't restate on its own. The duplicate comes from re-requesting the summary on rounds whose input already carries summarized reasoning. codex-rs/KiloCode/opencode don't re-request it.

**The fix** (one seam, all three continuation paths): `continuationRequest` strips the `summary` key from `reasoning` and drops `stream_options` on continuation rounds. Effort, `context=all_turns`, and the encrypted-content include are untouched — reasoning continuity is unchanged.

Tests: continuation strips summary but keeps effort/context; reasoning-free requests stay reasoning-free. Full gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)