### PR TITLE
ci: add full-history gitleaks secret scan

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,33 @@
+# Full-history gitleaks secret scan — fails the build if a secret was EVER
+# committed, even if added and later removed.
+#
+# Inlined mirror of torad-labs/github-operator reusable-secret-scan.yml: this
+# repo is public and GitHub does not let public repos consume reusable workflows
+# hosted in a private repo. Keep in sync with the library version.
+name: secret-scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: secret-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0 # scan the whole history, not just the tip
+          persist-credentials: false
+      - name: gitleaks (fail on any committed secret)
+        run: |
+          docker run --rm -v "$PWD:/repo" ghcr.io/gitleaks/gitleaks:v8.21.2 \
+            git /repo --redact --no-banner --exit-code 1

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,12 @@
+# Repo-local gitleaks config (auto-loaded from the scan root). Extends the default
+# ruleset — this file only narrows false-positive classes, never disables rules.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "splice fixture shapes that pattern-match generic-api-key but are not credentials"
+regexes = [
+  # Oracle/contract fixture cache keys: "splice-" + md5 hex. Exact value shape —
+  # cannot mask an arbitrary real secret on the same line.
+  '''"prompt_cache_key":\s*"splice-[0-9a-f]{32}"''',
+]

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,23 @@
+# Vetted false positives (2026-07-28 triage, PR #63). Every fingerprint below was
+# inspected by hand: 13 are `prompt_cache_key: "splice-<md5>"` cache keys in oracle/
+# contract fixtures (future ones are allowlisted by regex in .gitleaks.toml), one is
+# the phrase 'pinned public key' in a manifest.py comment, and the canonical.json /
+# GrokProviderTest pair was vetted in the 2026-07-19 pre-publication audit
+# (audit-splice-public-refs-gitleaks-20260719). A NEW finding must be triaged, not
+# appended here blindly.
+561d7ec0eb8a2bef8d724832211a3896b2af3bd1:dev/campaigns/proxy-hardening/oracle/fixtures/bigout.json:generic-api-key:29
+561d7ec0eb8a2bef8d724832211a3896b2af3bd1:dev/campaigns/proxy-hardening/oracle/fixtures/failed.json:generic-api-key:29
+561d7ec0eb8a2bef8d724832211a3896b2af3bd1:dev/campaigns/proxy-hardening/oracle/fixtures/basic.json:generic-api-key:29
+561d7ec0eb8a2bef8d724832211a3896b2af3bd1:dev/campaigns/proxy-hardening/oracle/fixtures/overflow_sse.json:generic-api-key:29
+561d7ec0eb8a2bef8d724832211a3896b2af3bd1:dev/campaigns/proxy-hardening/oracle/fixtures/prefill.json:generic-api-key:29
+561d7ec0eb8a2bef8d724832211a3896b2af3bd1:dev/campaigns/proxy-hardening/oracle/fixtures/toolcall.json:generic-api-key:29
+561d7ec0eb8a2bef8d724832211a3896b2af3bd1:dev/campaigns/proxy-hardening/oracle/fixtures/nonstream_tool.json:generic-api-key:29
+561d7ec0eb8a2bef8d724832211a3896b2af3bd1:dev/campaigns/proxy-hardening/oracle/fixtures/compactish.json:generic-api-key:29
+561d7ec0eb8a2bef8d724832211a3896b2af3bd1:dev/campaigns/proxy-hardening/oracle/fixtures/replaystream.json:generic-api-key:29
+561d7ec0eb8a2bef8d724832211a3896b2af3bd1:dev/campaigns/proxy-hardening/oracle/fixtures/multipart.json:generic-api-key:29
+561d7ec0eb8a2bef8d724832211a3896b2af3bd1:dev/campaigns/proxy-hardening/oracle/fixtures/truncated.json:generic-api-key:29
+c0a91614361f847917972c29c56a209286b5ce4c:gateway/dialect-openai-responses/src/test/resources/contract/responses-codex-profile.json:generic-api-key:42
+c0a91614361f847917972c29c56a209286b5ce4c:gateway/dialect-openai-responses/src/test/resources/contract/responses-tool-search.json:generic-api-key:55
+2c8f0a4d5074ca9a3525544e896770417390249f:gateway/dialect-openai-responses/src/test/resources/contract/responses-canonical.json:generic-api-key:14
+dd2a6783fd349d253b4e1fd70cd36f33471b4bc7:gateway/provider-grok/src/test/kotlin/grok/GrokProviderTest.kt:generic-api-key:73
+5910ee1866fa962cac25fd9c17b416b869a654f8:dev/campaigns/manifest.py:generic-api-key:116


### PR DESCRIPTION
The 2026-07-28 fleet parity audit (torad-labs/github-operator, policy/MATRIX.md) found splice is the only high-traffic repo — and the only public one — with no secret scanning among its 15 workflows. This adds the fleet-standard full-history gitleaks scan.

Inlined rather than `workflow_call`: GitHub does not let public repos consume reusable workflows hosted in a private repo. The header marks it as a mirror of `reusable-secret-scan.yml` in the operator library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BXygHQJex2qQCJntQP1mgJ