### PR TITLE
docs: state the PR-title convention where authors and agents actually look

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,7 @@
+<!-- TITLE must be Conventional Commits, and CI enforces it (required check `lint`):
+     feat fix docs test build ci chore perf refactor revert release codex
+     Scope optional: fix(walls): ...  Any other type FAILS and blocks the merge. -->
+
 ## What / why
 
 ## Gates

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,25 @@ existed it was authored but NEVER executed by automation — only the ast-grep w
 Green means all of them. A wall block means fix the code, not the wall — never trust a filtered
 `gradle | grep` exit; read the real `BUILD SUCCESSFUL` / `GATE: PASS`.
 
+## PR titles are linted; branch commits are not
+
+`.github/workflows/pr-title.yml` enforces Conventional Commits on the **PR title** via a REQUIRED
+check. Allowed types, and this is the complete list:
+
+    feat  fix  docs  test  build  ci  chore  perf  refactor  revert  release  codex
+
+Scope optional (`fix(walls): ...`). Anything else fails `lint` and blocks the merge.
+
+WHY THIS IS EASY TO GET WRONG THREE TIMES IN A ROW (it happened, 2026-07-28/29): branch commit
+messages are NOT linted, so `harden(walls):` and `verify(x):` write and review fine locally. The
+title is checked only after the PR exists — and because merges are SQUASHED, the PR title replaces
+your branch commits in `main`, so history shows only compliant types and gives no hint that a wider
+vocabulary was ever tried and rejected. The feedback arrives late and then erases its own evidence.
+
+Pick the type from the list above BEFORE opening the PR. `gh pr create --body ...` bypasses
+`.github/PULL_REQUEST_TEMPLATE.md`, so the template's reminder never reaches an agent — this section
+is the one that does.
+
 ## Enforcement tiers (#924: make drift not compile)
 
 Each failure class this codebase hit is now stopped by the STRONGEST tier that can express it —

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,22 @@ Write-time policy (ast-grep rules) and the commit gate run the SAME checker twic
 `.rules/README.md` for the full rule inventory and authoring doctrine before adding or
 changing a rule.
 
+## PR title
+
+CI (`.github/workflows/pr-title.yml`) enforces Conventional Commits on the **PR title** — it is the
+squash-merge subject, so it becomes `main`'s history verbatim. Only these types pass:
+
+`feat` · `fix` · `docs` · `test` · `build` · `ci` · `chore` · `perf` · `refactor` · `revert` ·
+`release` · `codex`
+
+Scope is optional: `fix(walls): …`. Anything else fails the `lint` check, which is a required check,
+so the PR cannot merge.
+
+**This list is the whole vocabulary.** Inventing a type that reads well — `harden(walls):`,
+`verify(x):`, `style(y):` — fails, and because squash-merge replaces your branch commits with the PR
+title, `main`'s history gives no hint that the wider vocabulary was ever rejected. Branch commit
+messages are not linted; only the title is.
+
 ## No CLA
 
 Contributions are made under the project's [MIT license](LICENSE) — MIT in, MIT out. No


### PR DESCRIPTION
I failed the `lint` check three times in four days — `harden(walls)` on #59, `harden(walls)` on #62,
`verify(reasoning-cache)` on #66. That isn't three slips, it's a missing contract.

**The list is enforced and stated nowhere.** Not `CONTRIBUTING.md`, not `AGENTS.md`, and the PR
template that *does* exist covers gates and notes but never mentions the title. The only way to learn
the vocabulary is to have a PR rejected.

## Two properties make it worse than an ordinary undocumented rule

1. **Branch commits aren't linted.** `harden(walls): …` writes, reviews and commits cleanly. The
   rejection arrives only once the PR exists — long after the work read finished.
2. **Merges are squashed**, so the PR title *replaces* your branch commits in `main`. History
   therefore contains only compliant types and gives no hint that a wider vocabulary was ever tried
   and refused. The feedback is late, and then it erases its own evidence.

## A correction to my own diagnosis

While investigating I claimed the repo's commits use `harden(` freely and the linter was out of date.
**Wrong.** `harden`/`verify` appear *nowhere* in `main`'s history — they were only ever in my branch
commits, which the squash discards. The linter is not stale; I was inventing types.

So the fix is **not** widening the allowlist to fit my habit. That's weakening a convention to
accommodate the person who broke it — the same shape as raising a detekt threshold to fit a change.
**The allowlist is untouched.**

## Stated in three places, chosen by who reads them

| where | for whom |
|---|---|
| `CONTRIBUTING.md` | contributors — canonical |
| `.github/PULL_REQUEST_TEMPLATE.md` | humans in the web UI (comment at the top) |
| `AGENTS.md` | **agents** — because `gh pr create --body …` bypasses the template entirely, which is how every PR this session was opened. The template's reminder has never once been shown to me. |

That last row is the actual answer to "don't we have a PR template?" — yes, and it cannot reach the
tool that creates the PRs.

No behaviour change, no workflow change. `npm run gate`: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017moZDSgapZqJVkzZszuWas