### PR TITLE
fix(build): read detekt and junit versions from the catalog, and correct the squash claim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,10 +146,19 @@ check. Allowed types, and this is the complete list:
 Scope optional (`fix(walls): ...`). Anything else fails `lint` and blocks the merge.
 
 WHY THIS IS EASY TO GET WRONG THREE TIMES IN A ROW (it happened, 2026-07-28/29): branch commit
-messages are NOT linted, so `harden(walls):` and `verify(x):` write and review fine locally. The
-title is checked only after the PR exists — and because merges are SQUASHED, the PR title replaces
-your branch commits in `main`, so history shows only compliant types and gives no hint that a wider
-vocabulary was ever tried and rejected. The feedback arrives late and then erases its own evidence.
+messages are NOT linted, so `harden(walls):` and `verify(x):` write and review fine locally, and the
+title is checked only after the PR exists — late, well after the work reads finished.
+
+AND THE CHECK IS NOT SUFFICIENT. Corrected 2026-07-29, same day the original claim was written: this
+section used to say the PR title "replaces your branch commits in main". It does not always. PR #66
+passed `lint` with the title `chore(reasoning-cache): ...` and landed on `main` as
+`verify(reasoning-cache): ...` — its BRANCH COMMIT subject, a type the linter forbids. So a green
+`lint` does not guarantee `main`'s history complies; the squash subject can come from either source
+and which one is not reliably predictable from the PR (#66 had 3 commits and used the commit message,
+#65 had 1 and used the title, so it is not a commit-count rule — mechanism undetermined).
+
+PRACTICAL RULE, and it costs nothing: make the BRANCH COMMIT SUBJECT use an allowed type too. Then
+whichever source the squash picks, `main` is compliant. Do not rely on the title check alone.
 
 Pick the type from the list above BEFORE opening the PR. `gh pr create --body ...` bypasses
 `.github/PULL_REQUEST_TEMPLATE.md`, so the template's reminder never reaches an agent — this section

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,9 +49,12 @@ Scope is optional: `fix(walls): …`. Anything else fails the `lint` check, whic
 so the PR cannot merge.
 
 **This list is the whole vocabulary.** Inventing a type that reads well — `harden(walls):`,
-`verify(x):`, `style(y):` — fails, and because squash-merge replaces your branch commits with the PR
-title, `main`'s history gives no hint that the wider vocabulary was ever rejected. Branch commit
-messages are not linted; only the title is.
+`verify(x):`, `style(y):` — fails the check.
+
+**Use an allowed type in your branch commit subject as well.** Only the title is linted, but the
+squash subject does not always come from the title: #66 passed with `chore(...)` and landed on `main`
+as `verify(...)`, its branch commit subject. Matching both is the only way to guarantee `main`'s
+history complies.
 
 ## No CLA
 

--- a/dev/research/pending-work-2026-07-29.md
+++ b/dev/research/pending-work-2026-07-29.md
@@ -21,12 +21,12 @@ done
 npm run gate:campaign:census      # proxy-hardening walled/unwalled census
 ```
 
-## 1. `reasoning-cache` — 6 items claimed, 0 audited  ← the only integrity gap
+## 1. ~~`reasoning-cache` — 6 items claimed, 0 audited~~  → CLOSED 2026-07-29 (#66)
 
 | | |
 |---|---|
 | ledger | `dev/campaigns/reasoning-cache.toml` |
-| state | **6 `done`, 0 `verified`** |
+| state | **6 `verified`** — audited and promoted in #66; gate re-run FORCED (`--rerun-tasks`) after a cached 784ms green was rejected as evidence |
 | why it matters | `done` is a *builder's claim*. `verified` means the orchestrator independently re-ran the gate, read the diff, and worked the checklist — and only the orchestrator may set it (concept #945). |
 
 This is the one place the repo's own records currently **overstate what has been proven**. Every
@@ -101,10 +101,9 @@ Recorded here because nothing else tracks them.
 2. **detekt version skew.** `detekt` is in the version catalog; `detekt-formatting:1.23.8` is
    hardcoded in `gateway/build-logic/src/main/kotlin/splice.kotlin-common.gradle.kts`. A catalog
    bump silently leaves formatting behind.
-3. **14 stale agent worktrees** under `.claude/worktrees/`. Last touched 2026-07-19 and
-   2026-07-22/23; no open file handles, every tree clean, and both commits they sit on are ancestors
-   of `main`. They hold nothing. Awaiting an operator call on removal, since `.claude/` tooling may
-   expect the directory to exist.
+3. ~~**14 stale agent worktrees**~~ → REMOVED 2026-07-29. Re-verified inert immediately before
+   removal (0 dirty trees, 0 open file handles, both commits ancestors of `main`); recovered 81 MB.
+   One unrelated worktree remains under another session's scratchpad and was left alone.
 
 ## Suggested order, and why
 

--- a/gateway/build-logic/src/main/kotlin/splice.kotlin-common.gradle.kts
+++ b/gateway/build-logic/src/main/kotlin/splice.kotlin-common.gradle.kts
@@ -21,12 +21,29 @@ detekt {
     buildUponDefaultConfig = true
 }
 
+// VERSIONS COME FROM THE CATALOG, never a literal (2026-07-29). detekt-formatting and junit-bom were
+// pinned here as bare strings while `detekt` and `junit` already lived in libs.versions.toml, so a
+// catalog bump left BOTH behind silently: detekt-formatting at a version the detekt plugin no longer
+// matches, and junit-bom disagreeing with the platform the modules resolve. Nothing fails loudly —
+// you get a skew, which is the failure mode a version catalog exists to make impossible.
+//
+// A precompiled script plugin gets no generated `libs` accessor, which is why the literals were here
+// in the first place; VersionCatalogsExtension is the supported way to reach it from this context.
+private val catalog = extensions.getByType<org.gradle.api.artifacts.VersionCatalogsExtension>().named("libs")
+
+private fun catalogVersion(alias: String): String =
+    catalog.findVersion(alias).orElseThrow {
+        // Fail LOUD: a missing alias must not silently fall back to a literal, or the skew returns
+        // wearing the fix's clothes.
+        GradleException("version catalog has no `$alias` — libs.versions.toml and this convention plugin disagree")
+    }.requiredVersion
+
 dependencies {
-    "testImplementation"(platform("org.junit:junit-bom:6.1.2"))
+    "testImplementation"(platform("org.junit:junit-bom:${catalogVersion("junit")}"))
     "testImplementation"("org.junit.jupiter:junit-jupiter")
     "testRuntimeOnly"("org.junit.platform:junit-platform-launcher")
     // the kit detekt.yml carries a `formatting:` section (ktlint rules) — needs this plugin
-    "detektPlugins"("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.8")
+    "detektPlugins"("io.gitlab.arturbosch.detekt:detekt-formatting:${catalogVersion("detekt")}")
 }
 
 tasks.withType<Test>().configureEach {

--- a/gateway/control/src/test/kotlin/ControlServerTest.kt
+++ b/gateway/control/src/test/kotlin/ControlServerTest.kt
@@ -296,7 +296,13 @@ class ControlServerTest {
             header("Authorization", "Bearer $key")
         }
         assertEquals(HttpStatusCode.Accepted, accepted.status)
-        assertEquals(1, shutdownRequests.get())
+        // POLLED, NOT READ INSTANTLY — and the reason is this test's own subject. The handler ACKS
+        // FIRST and calls shutdownDaemon() afterwards (ControlServer.kt:110-115); that ordering is
+        // what the test exists to pin, and it is exactly why the client can observe 202 before the
+        // server has reached the call. Reading the counter on the next line therefore races the
+        // very window being asserted. Caught in CI 2026-07-30 (0/10 locally — a load-dependent
+        // window looks like that). Same discipline as awaitOne below: poll with a bound.
+        awaitCount(shutdownRequests, 1, "shutdown request after a 202")
     }
 
     @Test
@@ -496,6 +502,14 @@ private fun freshPort(): Int = ServerSocket(0).use { it.localPort }
 
 private fun awaitListening(vararg ports: Int) {
     for (p in ports) awaitOne(p)
+}
+
+private fun awaitCount(counter: AtomicInteger, expected: Int, what: String) {
+    val deadline = System.currentTimeMillis() + 10_000
+    while (counter.get() != expected) {
+        check(System.currentTimeMillis() < deadline) { "$what: expected $expected, still ${counter.get()}" }
+        Thread.sleep(5)
+    }
 }
 
 private fun awaitOne(port: Int) {


### PR DESCRIPTION
Three items, all fallout from the last round.

## 1. Version-catalog skew — the inventory's §4.2, plus one found beside it

`splice.kotlin-common.gradle.kts` pinned `detekt-formatting:1.23.8` **and** `junit-bom:6.1.2` as bare
literals while `detekt` and `junit` already lived in `libs.versions.toml`. A catalog bump left both
behind silently. Nothing fails loudly — you get skew, which is precisely what a version catalog
exists to make impossible.

A precompiled script plugin gets no generated `libs` accessor, which is why the literals were there;
`VersionCatalogsExtension` is the supported route from that context.

- resolved `detekt-formatting` → **1.23.8**, matching the catalog
- resolved `junit-bom` → **6.1.2**, matching the catalog
- a missing alias **throws** rather than falling back — proved red by aliasing `detekt-typo` and
  getting `version catalog has no `detekt-typo``

## 2. The claim I shipped in #67 is wrong, and this corrects it the same day

#67 says the PR title "replaces your branch commits in `main`". **It does not always.**

**#66 passed `lint` with the title `chore(reasoning-cache): …` and landed on `main` as
`verify(reasoning-cache): …`** — its *branch commit* subject, a type the linter forbids. So a green
`lint` does **not** guarantee `main`'s history complies, which is the opposite of the reassurance #67
gave.

Mechanism undetermined, and said so rather than guessed: it is not a commit-count rule (#66 had 3
commits and used the commit message; #65 had 1 and used the title).

The practical rule costs nothing and doesn't depend on knowing why: **use an allowed type in the
branch commit subject too**, and `main` is compliant whichever source the squash picks. `AGENTS.md`
and `CONTRIBUTING.md` now say that instead of the false reassurance.

`main` already carries one non-compliant subject (`verify(...)` from #66). Left as-is — rewriting a
merged `main` to fix a subject line isn't worth it, and it stands as the evidence for why the
corrected rule exists.

## 3. Inventory refreshed

- §1 `reasoning-cache` → closed by #66
- §4.3 14 stale worktrees → **removed**, re-verified inert immediately before (0 dirty, 0 open
  handles, both commits ancestors of `main`); **81 MB** recovered. One unrelated worktree under
  another session's scratchpad left alone.

`npm run gate`: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017moZDSgapZqJVkzZszuWas