### PR TITLE
feat(spikes): P0-XAI — api.x.ai streams faithful Anthropic SSE except block indexing

### DIFF
--- a/dev/campaigns/kotlin-gateway.toml
+++ b/dev/campaigns/kotlin-gateway.toml
@@ -107,8 +107,8 @@ verify = "test -s gateway/spikes/results/pool-cancel.md"
 id = "P0-XAI"
 phase = "P0"
 title = "Spike: xAI anthropic-passthrough fidelity — does api.x.ai /v1/messages stream faithful Anthropic SSE?"
-files = ["gateway/spikes/src/main/kotlin/XaiPassthroughSpike.kt", "gateway/spikes/results/xai-passthrough.md"]
-status = "todo"
+files = ["gateway/spikes/src/test/kotlin/XaiPassthroughSpike.kt", "gateway/spikes/results/xai-passthrough.md"]
+status = "done"
 verify = "test -s gateway/spikes/results/xai-passthrough.md"
 # Context: decides P6-GROK dialect. Needs XAI_API_KEY (or key file ~/.local/share/claude-grok/auth.json)
 # — PREMISE-BLOCK with a note if absent, do not fabricate. Probe: streamed request with a tool +
@@ -119,6 +119,12 @@ verify = "test -s gateway/spikes/results/xai-passthrough.md"
 
 # ── P1 — foundation: campaign, hooks, skeleton, walls, core ──────────────────
 # [2026-07-16] PREMISE-BLOCK (slot law): no XAI_API_KEY in env and no ~/.local/share/claude-grok/auth.json on disk — the fidelity probe cannot be grounded. Not improvising. Stays todo until the operator provides a key; P6-GROK falls back to the proven Responses translators if this never lands.
+# [2026-07-30] FENCE-EDITED: files = ["gateway/spikes/src/main/kotlin/XaiPassthroughSpike.kt", "gateway/spikes/results/xai-passthrough.md"] -> files = ["gateway/spikes/src/test/kotlin/XaiPassthroughSpike.kt", "gateway/spikes/results/xai-passthrough.md"] (by=orchestrator implied; no flag)
+# [2026-07-30] PREMISE-BLOCK OF 2026-07-16 WAS FALSE, on both halves. It read: 'no XAI_API_KEY in env and no ~/.local/share/claude-grok/auth.json on disk — the fidelity probe cannot be grounded'. That file EXISTED, mtime 2026-07-15 — the day BEFORE the block — with an expired token; expired is a different fact from absent, and the note recorded the wrong one. More importantly the probe never needed it: the product's own grok head authenticates from ~/.grok/auth.json via grok-oauth, which was never checked. Operator asked 'we support grok via spacex ai so cant we check that way' — that is exactly what unblocked it. Cost: two weeks on an item a credential search would have cleared in two minutes (CLAUDE.md 9: a missing secret usually means you have not searched).
+# [2026-07-30] VERDICT 2026-07-30: NEAR-FAITHFUL. api.x.ai /v1/messages returns 200 and streams the full Anthropic shape — message_start / content_block_start / content_block_delta / content_block_stop / message_delta / message_stop, thinking blocks with thinking_delta, tool_use opened with real name+id, arguments via input_json_delta, stop_reason=tool_use, message_stop present, usage on both message_start (input/cache/output) and message_delta (output). ONE DEFECT: block indexing. content_block_delta NEVER carries index (19/19 then 18/18 on re-run), and content_block_start/stop pin index=0 for EVERY block — the tool_use block should be index 1, so an index-keyed client merges thinking and tool_use. RECOVERABLE: blocks are strictly sequential (zero deltas outside a start/stop pair, never two open at once, measured), so counting content_block_start and stamping the running index restores fidelity in ~10 lines. THEREFORE P6-GROK = near-passthrough (auth + model map + usage) PLUS an index-normalising SSE shim; the Responses-dialect fallback (server/src/grok/translate-*.mjs) does NOT need porting. P6-GROK must wall the shim: interleaved blocks would break count-the-starts, and this is one model and one turn shape.
+# [2026-07-30] SCOPE OF EVIDENCE, so the next reader does not over-trust it: one request, one model (grok-4-latest, served as grok-4.3), one turn shape (thinking + one tool call). NOT probed: parallel multi-tool rounds, max_tokens truncation, refusal/stop_sequence stop reasons, error frames, long context. The index defect is stable enough to design against (reproduced by two independent clients — curl and XaiPassthroughSpike); the ABSENCE of other defects is not established by a single turn.
+# [2026-07-30] Attribution unavailable: missing in_flight tree snapshot
+# [2026-07-30] STATUS IS done, NOT verified, deliberately. #945 reserves verified for an orchestrator who independently re-ran the gate and read the diff; here builder and verifier are the same seat, and marking my own work verified is precisely the conflation the 2026-07-29 reasoning-cache audit existed to correct. Disclosed rather than assumed. What HAS been done: the item's verify (test -s ...) passes, and the finding reproduced under two independent clients (curl, then XaiPassthroughSpike via gradle). A second seat re-running the spike is all that is needed to promote it.
 
 [[items]]
 id = "P1-CAMP"

--- a/gateway/spikes/results/xai-passthrough.md
+++ b/gateway/spikes/results/xai-passthrough.md
@@ -40,10 +40,12 @@ Two problems, same root:
    and tool_use blocks into one.
 
 **It is cheaply recoverable, and that is what decides the verdict.** The blocks are strictly
-sequential: zero deltas arrive outside a `start`/`stop` pair, and no two blocks are ever open at
-once (measured — all 19 deltas fall inside exactly one open block). So correct indices can be
-reconstructed by counting `content_block_start` occurrences and stamping the running index onto
-`start`, every `delta`, and `stop`.
+sequential, and the probe now VERIFIES that rather than observing it (review of #70): it walks the
+stream tracking open blocks and asserts `maxOpen <= 1`, zero deltas outside a `start`/`stop` pair,
+and no unclosed block at the end. The run below reports `strictly sequential blocks: true (max
+concurrently open: 1, orphan deltas: 0)`, and the assertion FAILS the spike if a future run
+interleaves. So correct indices can be reconstructed by counting `content_block_start` occurrences
+and stamping the running index onto `start`, every `delta`, and `stop`.
 
 That is a ~10-line stateful rewrite over the SSE stream, not a dialect port.
 
@@ -59,6 +61,17 @@ That is a ~10-line stateful rewrite over the SSE stream, not a dialect port.
   fixture asserting the reconstruction and fail loudly if x.ai ever interleaves.
 
 ## Scope of this evidence, stated honestly
+
+Both checked-in artifacts (this receipt and `xai-passthrough.raw.txt`) now come from ONE run — the
+2026-08-01 re-run after the review of #70. They previously disagreed (26 vs 25 events, 19 vs 18
+deltas) because the raw file had been overwritten by a later run than the one the prose described;
+there was no way to tell which supported the verdict. The numbers below are that single run's.
+
+Thinking is now explicitly requested in the probe body (`"thinking":{"type":"enabled",...}`) and
+asserted present. Previously the receipt claimed thinking fidelity while the request never asked
+for it, so the claim could not be reproduced from the test. The probe also now asserts HTTP 200, a
+non-empty event list and a `message_stop`, so a 500 or a malformed stream fails instead of quietly
+writing a receipt.
 
 One request, one model (`grok-4-latest`, served as `grok-4.3`), one turn shape (thinking + one tool
 call). Not probed: multi-tool parallel rounds, `max_tokens` truncation, refusal/`stop_sequence`

--- a/gateway/spikes/results/xai-passthrough.md
+++ b/gateway/spikes/results/xai-passthrough.md
@@ -1,0 +1,81 @@
+# P0-XAI receipt: does api.x.ai /v1/messages stream faithful Anthropic SSE? (2026-07-30)
+
+**Verdict: near-faithful — passthrough plus a small index-normalising shim. Do NOT port the
+Responses translators.**
+
+One streamed request to `https://api.x.ai/v1/messages`, Anthropic-shaped, with a tool and thinking
+enabled. HTTP 200 in 3.4s, 26 SSE events. Credential: grok-oauth from `~/.grok/auth.json` — the same
+file the grok head already ships against.
+
+## What is faithful
+
+| contract | observed |
+|---|---|
+| event sequence | `message_start → content_block_start → content_block_delta → content_block_stop → message_delta → message_stop` |
+| thinking blocks | yes — `content_block_start` opens `{"type":"thinking","signature":"","thinking":""}`, streamed via `thinking_delta` |
+| tool_use streaming | yes — block opens with the real `name` (`get_weather`) and an `id`, arguments stream as `input_json_delta` (2 events) |
+| `stop_reason` | `tool_use` — correct for a turn that ends in a tool call |
+| `message_stop` | present |
+| usage | `message_start.usage` carries `input_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`, `output_tokens`; `message_delta.usage` carries `output_tokens` |
+
+That is the whole Anthropic streaming shape, including the two parts most likely to be wrong
+(thinking and tool-call streaming).
+
+## The one defect — block indexing
+
+Two problems, same root:
+
+1. **`content_block_delta` never carries `index`.** 19 of 19 delta events omit it. Anthropic's
+   contract puts `index` on every delta.
+2. **`content_block_start` / `content_block_stop` pin `index` at 0 for every block.** Raw bytes:
+
+   ```
+   {"type":"content_block_start","index":0,"content_block":{"type":"thinking",...}}
+   {"type":"content_block_stop","index":0}
+   {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"call-ecc569ee-…"}}
+   {"type":"content_block_stop","index":0}
+   ```
+
+   The `tool_use` block should be `index: 1`. A client that keys blocks by index merges the thinking
+   and tool_use blocks into one.
+
+**It is cheaply recoverable, and that is what decides the verdict.** The blocks are strictly
+sequential: zero deltas arrive outside a `start`/`stop` pair, and no two blocks are ever open at
+once (measured — all 19 deltas fall inside exactly one open block). So correct indices can be
+reconstructed by counting `content_block_start` occurrences and stamping the running index onto
+`start`, every `delta`, and `stop`.
+
+That is a ~10-line stateful rewrite over the SSE stream, not a dialect port.
+
+## What this means for P6-GROK
+
+- **Grok head = near-passthrough**: auth + model map + usage instrumentation, **plus** an
+  index-normalising SSE shim.
+- **The fallback is not needed.** `server/src/grok/translate-{request,response}.mjs` — the proven
+  Responses-dialect translators the ledger named as the unfaithful-path fallback — do not have to be
+  ported.
+- **The shim needs a wall.** Interleaved blocks would break the count-the-starts reconstruction. This
+  probe observed strictly-sequential blocks on one model, one turn shape. P6-GROK should pin a
+  fixture asserting the reconstruction and fail loudly if x.ai ever interleaves.
+
+## Scope of this evidence, stated honestly
+
+One request, one model (`grok-4-latest`, served as `grok-4.3`), one turn shape (thinking + one tool
+call). Not probed: multi-tool parallel rounds, `max_tokens` truncation, refusal/`stop_sequence`
+stop reasons, error frames, or long-context behaviour. The index defect is stable enough to design
+against; the *absence* of other defects is not established by a single turn.
+
+## Why this ran at all
+
+The ledger carried a `PREMISE-BLOCK` from 2026-07-16: *"no XAI_API_KEY in env and no
+`~/.local/share/claude-grok/auth.json` on disk — the fidelity probe cannot be grounded."*
+
+Both halves were wrong at the time of writing. `~/.local/share/claude-grok/auth.json` existed with
+mtime **2026-07-15**, the day before the block — its token was expired, which is a different fact
+than absence. And the probe never needed that file: the product's own grok head authenticates from
+`~/.grok/auth.json` via grok-oauth, which was never checked.
+
+The block cost two weeks on an item that a two-minute credential search would have unblocked.
+
+Reproduce: `./gradlew :spikes:test -PrunSpikes --tests 'XaiPassthroughSpike*'` (skips, never fakes,
+when no live token is present).

--- a/gateway/spikes/results/xai-passthrough.raw.txt
+++ b/gateway/spikes/results/xai-passthrough.raw.txt
@@ -1,0 +1,7 @@
+status: 200
+events: 25
+sequence: message_start -> content_block_start -> content_block_delta -> content_block_stop -> message_delta -> message_stop
+block types: [thinking, tool_use]
+content_block_start index values: [0, 0]
+content_block_delta missing index: 18/18
+stop_reason: tool_use

--- a/gateway/spikes/results/xai-passthrough.raw.txt
+++ b/gateway/spikes/results/xai-passthrough.raw.txt
@@ -1,7 +1,8 @@
 status: 200
-events: 25
+events: 26
 sequence: message_start -> content_block_start -> content_block_delta -> content_block_stop -> message_delta -> message_stop
 block types: [thinking, tool_use]
 content_block_start index values: [0, 0]
-content_block_delta missing index: 18/18
+content_block_delta missing index: 19/19
+strictly sequential blocks: true (max concurrently open: 1, orphan deltas: 0)
 stop_reason: tool_use

--- a/gateway/spikes/src/test/kotlin/XaiPassthroughSpike.kt
+++ b/gateway/spikes/src/test/kotlin/XaiPassthroughSpike.kt
@@ -1,0 +1,92 @@
+// NEW: P0-XAI spike — does api.x.ai /v1/messages stream FAITHFUL Anthropic SSE?
+// The answer decides P6-GROK's dialect: faithful => the grok head is near-passthrough (auth +
+// model map + usage instrumentation only); unfaithful => port the proven Responses translators
+// (server/src/grok/translate-{request,response}.mjs).
+//
+// CREDENTIAL: grok-oauth, ~/.grok/auth.json (tokens.access_token) — the SAME file the grok head
+// itself uses. The ledger's 2026-07-16 PREMISE-BLOCK looked only for XAI_API_KEY and
+// ~/.local/share/claude-grok/auth.json and concluded the probe "cannot be grounded". The second
+// path DID exist that day (mtime 2026-07-15, token expired), and the oauth file the product
+// already ships against was never checked. Skips — never fabricates — when no live token exists.
+//
+// Receipt: gateway/spikes/results/xai-passthrough.md
+// Run: ./gradlew :spikes:test -PrunSpikes --tests 'XaiPassthroughSpike*'
+import java.io.File
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+
+private const val ENDPOINT = "https://api.x.ai/v1/messages"
+private const val MODEL = "grok-4-latest"
+
+private val json = Json { ignoreUnknownKeys = true }
+
+/** The live grok-oauth access token, or null when absent/expired — the spike then SKIPS. */
+private fun liveToken(): String? {
+    val f = File(System.getProperty("user.home"), ".grok/auth.json")
+    if (!f.isFile) return null
+    val root = runCatching { json.parseToJsonElement(f.readText()).jsonObject }.getOrNull() ?: return null
+    val expires = root["expires"]?.jsonPrimitive?.content?.toDoubleOrNull() ?: return null
+    val expiresMs = if (expires > 1e11) expires else expires * 1000
+    if (expiresMs <= System.currentTimeMillis()) return null
+    return root["tokens"]?.jsonObject?.get("access_token")?.jsonPrimitive?.content
+}
+
+class XaiPassthroughSpike {
+
+    @Test
+    fun `api-x-ai v1 messages streams anthropic sse`() {
+        val token = liveToken()
+        assumeTrue(token != null, "no live grok-oauth token in ~/.grok/auth.json — spike skipped, not faked")
+
+        val body = """
+            {"model":"$MODEL","max_tokens":256,"stream":true,
+             "tools":[{"name":"get_weather","description":"Get weather","input_schema":
+               {"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}],
+             "messages":[{"role":"user","content":"Use the get_weather tool for Paris, then say DONE."}]}
+        """.trimIndent()
+
+        val res = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(20)).build().send(
+            HttpRequest.newBuilder(URI.create(ENDPOINT))
+                .timeout(Duration.ofSeconds(60))
+                .header("Authorization", "Bearer $token")
+                .header("Content-Type", "application/json")
+                .header("anthropic-version", "2023-06-01")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build(),
+            HttpResponse.BodyHandlers.ofString(),
+        )
+
+        val events = res.body().split("\n\n").mapNotNull { block ->
+            block.lineSequence().firstOrNull { it.startsWith("data: ") }
+                ?.removePrefix("data: ")
+                ?.let { runCatching { json.parseToJsonElement(it).jsonObject }.getOrNull() }
+        }
+        val typeOf = { e: JsonObject -> e["type"]?.jsonPrimitive?.content }
+
+        // What the receipt records. Deliberately assertion-light: a spike answers a question, it
+        // does not gate CI — the walls that pin the ANSWER land with P6-GROK.
+        val starts = events.filter { typeOf(it) == "content_block_start" }
+        val deltas = events.filter { typeOf(it) == "content_block_delta" }
+        val findings = buildString {
+            appendLine("status: ${res.statusCode()}")
+            appendLine("events: ${events.size}")
+            appendLine("sequence: ${events.mapNotNull(typeOf).distinct().joinToString(" -> ")}")
+            appendLine("block types: ${starts.mapNotNull { it["content_block"]?.jsonObject?.get("type")?.jsonPrimitive?.content }}")
+            appendLine("content_block_start index values: ${starts.map { it["index"]?.jsonPrimitive?.content }}")
+            appendLine("content_block_delta missing index: ${deltas.count { "index" !in it }}/${deltas.size}")
+            appendLine("stop_reason: ${events.firstOrNull { typeOf(it) == "message_delta" }?.get("delta")?.jsonObject?.get("stop_reason")?.jsonPrimitive?.content}")
+        }
+        println(findings)
+        File("results").mkdirs()
+        File("results/xai-passthrough.raw.txt").writeText(findings)
+    }
+}

--- a/gateway/spikes/src/test/kotlin/XaiPassthroughSpike.kt
+++ b/gateway/spikes/src/test/kotlin/XaiPassthroughSpike.kt
@@ -22,6 +22,8 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 private const val ENDPOINT = "https://api.x.ai/v1/messages"
@@ -48,7 +50,8 @@ class XaiPassthroughSpike {
         assumeTrue(token != null, "no live grok-oauth token in ~/.grok/auth.json — spike skipped, not faked")
 
         val body = """
-            {"model":"$MODEL","max_tokens":256,"stream":true,
+            {"model":"$MODEL","max_tokens":2048,"stream":true,
+             "thinking":{"type":"enabled","budget_tokens":1024},
              "tools":[{"name":"get_weather","description":"Get weather","input_schema":
                {"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}],
              "messages":[{"role":"user","content":"Use the get_weather tool for Paris, then say DONE."}]}
@@ -72,10 +75,42 @@ class XaiPassthroughSpike {
         }
         val typeOf = { e: JsonObject -> e["type"]?.jsonPrimitive?.content }
 
-        // What the receipt records. Deliberately assertion-light: a spike answers a question, it
-        // does not gate CI — the walls that pin the ANSWER land with P6-GROK.
+        // THE INVARIANT THE VERDICT RESTS ON (review of #70). The receipt concludes that correct
+        // indices can be reconstructed by COUNTING content_block_start events. That is only sound
+        // while blocks are strictly sequential: no delta outside an open block, and never two open
+        // at once. Filtering starts and deltas cannot see either violation — an interleaved stream
+        // produced the identical report and passed. This walks the stream and records the verdict.
+        var open = 0
+        var maxOpen = 0
+        var orphanDeltas = 0
+        for (e in events) {
+            when (typeOf(e)) {
+                "content_block_start" -> { open += 1; maxOpen = maxOf(maxOpen, open) }
+                "content_block_stop" -> open -= 1
+                "content_block_delta" -> if (open == 0) orphanDeltas += 1
+            }
+        }
+        val sequential = maxOpen <= 1 && orphanDeltas == 0 && open == 0
+
         val starts = events.filter { typeOf(it) == "content_block_start" }
         val deltas = events.filter { typeOf(it) == "content_block_delta" }
+
+        // A MINIMUM CONTRACT, so a 500 / empty body / malformed SSE fails instead of silently
+        // writing a receipt (review of #70). Everything the verdict claims is asserted; what the
+        // spike merely OBSERVES (index values, stop_reason) stays in the report.
+        assertEquals(200, res.statusCode(), "the spike's verdict assumes a live 200")
+        assertTrue(events.isNotEmpty(), "no SSE events parsed — the receipt would be evidence-free")
+        assertTrue(events.any { typeOf(it) == "message_stop" }, "the stream must terminate")
+        assertTrue(starts.isNotEmpty(), "no content blocks to reason about")
+        assertTrue(
+            sequential,
+            "blocks were NOT strictly sequential (maxOpen=$maxOpen orphanDeltas=$orphanDeltas " +
+                "unclosed=$open) — the count-the-starts reconstruction the receipt proposes is unsound",
+        )
+        assertTrue(
+            starts.any { it["content_block"]?.jsonObject?.get("type")?.jsonPrimitive?.content == "thinking" },
+            "the receipt claims thinking fidelity, so the run must actually contain a thinking block",
+        )
         val findings = buildString {
             appendLine("status: ${res.statusCode()}")
             appendLine("events: ${events.size}")
@@ -83,6 +118,7 @@ class XaiPassthroughSpike {
             appendLine("block types: ${starts.mapNotNull { it["content_block"]?.jsonObject?.get("type")?.jsonPrimitive?.content }}")
             appendLine("content_block_start index values: ${starts.map { it["index"]?.jsonPrimitive?.content }}")
             appendLine("content_block_delta missing index: ${deltas.count { "index" !in it }}/${deltas.size}")
+            appendLine("strictly sequential blocks: $sequential (max concurrently open: $maxOpen, orphan deltas: $orphanDeltas)")
             appendLine("stop_reason: ${events.firstOrNull { typeOf(it) == "message_delta" }?.get("delta")?.jsonObject?.get("stop_reason")?.jsonPrimitive?.content}")
         }
         println(findings)


### PR DESCRIPTION
Your question — *"we support grok via spacex ai so cant we check that way?"* — unblocked a two-week-old
`PREMISE-BLOCK` that turned out to be **false on both halves**.

The 2026-07-16 note read: *"no XAI_API_KEY in env and no `~/.local/share/claude-grok/auth.json` on disk
— the fidelity probe cannot be grounded."*

- That file **existed**, mtime **2026-07-15** — the day *before* the block. Its token was expired,
  which is a different fact from absent, and the note recorded the wrong one.
- More importantly the probe never needed it: the product's own grok head authenticates from
  `~/.grok/auth.json` via grok-oauth, **which was never checked**.

## Verdict: near-faithful

HTTP 200, 3.4s, and the full Anthropic streaming shape is present:

| contract | observed |
|---|---|
| sequence | `message_start → content_block_start → content_block_delta → content_block_stop → message_delta → message_stop` |
| thinking | opens `{"type":"thinking",…}`, streams `thinking_delta` |
| tool_use | opens with real `name` + `id`, args stream as `input_json_delta` |
| `stop_reason` | `tool_use` — correct |
| usage | `message_start`: input/cache/output · `message_delta`: output |

The two parts most likely to be wrong — thinking and tool-call streaming — are correct.

## The one defect: block indexing

`content_block_delta` **never** carries `index` (19/19, then 18/18 on an independent re-run), and
`content_block_start`/`stop` pin `index: 0` for **every** block:

```
{"type":"content_block_start","index":0,"content_block":{"type":"thinking",…}}
{"type":"content_block_stop","index":0}
{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"call-ecc569ee-…"}}
{"type":"content_block_stop","index":0}
```

The `tool_use` block should be `index: 1`. An index-keyed client merges thinking and tool_use.

**Cheaply recoverable, and that decides the verdict.** Blocks are strictly sequential — zero deltas
outside a `start`/`stop` pair, never two open at once (measured) — so counting `content_block_start`
and stamping the running index restores fidelity in ~10 lines.

## What this decides for P6-GROK

- grok head = **near-passthrough** (auth + model map + usage) **plus an index-normalising shim**
- the fallback the ledger named — porting `server/src/grok/translate-{request,response}.mjs` — is
  **not needed**
- P6-GROK must **wall the shim**: interleaved blocks would break count-the-starts

## Honesty notes

- **Fence corrected.** The item named `src/main/kotlin/`; spikes here live in `src/test/kotlin` gated
  by `-PrunSpikes`. The spike **skips rather than fabricates** with no live token.
- **Status is `done`, not `verified`,** and the ledger says why: builder and verifier are the same
  seat, and self-marking is the conflation the reasoning-cache audit existed to correct. The verify
  passes and the finding reproduced under two independent clients; a second seat re-running the spike
  promotes it.
- **Evidence scope stated in the receipt:** one request, one model, one turn shape. Not probed:
  parallel multi-tool rounds, truncation, refusal stop reasons, error frames, long context. The index
  defect is stable enough to design against; the *absence* of other defects is not established.

`npm run gate`: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017moZDSgapZqJVkzZszuWas