### PR TITLE
fix(responses): stop the reasoning cache rewriting the prompt prefix mid-conversation

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,10 +26,14 @@ contract, or secret leakage get priority.
 ## Reasoning-cache retention
 
 With `reasoning_cache` enabled (the default for the codex provider), the daemon holds each
-turn's `reasoning.encrypted_content` envelopes in memory for up to 30 minutes (bounded count and
-bytes) so tool round-trips can replay them. The envelopes are opaque ciphertext (the upstream holds
-the keys); plaintext reasoning is never retained. They are process-memory only — never written to
-disk — and vanish on restart. Entries are scoped to their conversation (a stable first-message
-key), so concurrent conversations sharing one head can never receive each other's envelopes;
-staleness eviction is deliberately unscoped, which can only over-evict (a cache miss), never
-cross-inject. Set `quirks = { reasoning_cache = false }` to disable.
+turn's `reasoning.encrypted_content` envelopes in memory so tool round-trips can replay them.
+Retention is **activity-based** (changed 2026-07-31; it was previously a fixed 30-minute cap):
+a conversation's envelopes are kept while that conversation stays active and expire wholesale
+after 30 minutes of inactivity — a session in continuous use retains its envelopes for the
+session's lifetime. Hard caps bound the worst case: 256 rounds / 64 MB across all conversations
+on a head, enforced by whole-conversation eviction. The envelopes are opaque ciphertext (the
+upstream holds the keys); plaintext reasoning is never retained. They are process-memory only —
+never written to disk — and vanish on restart. Entries are scoped to their conversation (a stable
+first-message key), so concurrent conversations sharing one head can never receive each other's
+envelopes; staleness eviction is deliberately unscoped, which can only over-evict (a cache miss),
+never cross-inject. Set `quirks = { reasoning_cache = false }` to disable.

--- a/config/splice.example.toml
+++ b/config/splice.example.toml
@@ -31,6 +31,12 @@ quirks = { store = false, account_id_header = true, cache_key = "first-message-h
 # it on tool round-trips (codex-CLI parity — without it the model re-derives its plan at every
 # tool result: repeated tool calls, duplicated reasoning). The gateway retains only the OPAQUE
 # encrypted envelopes, bounded + TTL'd; set reasoning_cache = false to restore the old behavior.
+# parallel_tool_calls (default false): the VALUE sent for parallel_tool_calls on responses-lite
+# (gpt-5.6) turns — the field itself always rides, since a lite request without it 400s. codex-rs
+# reads this per model rather than hardcoding it, so it is a knob here too. false = one tool call
+# per turn, which is why claudex averages ~2x the round-trips of grok/kimi and re-sends the whole
+# context each time. UNTESTED against the live backend: leaving the field out entirely once let the
+# backend default to parallel and gpt-5.6 sprayed 30-50 parallel Task calls. Opt in to measure.
 [[providers.codex.models]]
 id = "gpt-5.6-sol"
 label = "Codex 5.6 Sol"

--- a/config/splice.example.toml
+++ b/config/splice.example.toml
@@ -35,7 +35,11 @@ quirks = { store = false, account_id_header = true, cache_key = "first-message-h
 # (gpt-5.6) turns — the field itself always rides, since a lite request without it 400s. codex-rs
 # reads this per model rather than hardcoding it, so it is a knob here too. false = one tool call
 # per turn, which is why claudex averages ~2x the round-trips of grok/kimi and re-sends the whole
-# context each time. UNTESTED against the live backend: leaving the field out entirely once let the
+# context each time. To opt in, add `parallel_tool_calls = true` INSIDE the inline quirks table
+# above (a separate [providers.codex.quirks] section would clash with it and fail to parse).
+# Guardrails: a client's explicit disable_parallel_tool_use=true always wins, and toolless turns
+# stay false. Lite-only — ignored on non-lite turns (grok's value comes from the client's
+# tool_choice). UNTESTED against the live backend: leaving the field out entirely once let the
 # backend default to parallel and gpt-5.6 sprayed 30-50 parallel Task calls. Opt in to measure.
 [[providers.codex.models]]
 id = "gpt-5.6-sol"

--- a/gateway/app/src/main/kotlin/splice/app/Daemon.kt
+++ b/gateway/app/src/main/kotlin/splice/app/Daemon.kt
@@ -50,6 +50,7 @@ import splice.dialect.chat.withReasoningEffortToml
 import splice.dialect.responses.FoldConfig
 import splice.dialect.responses.ResponsesQuirks
 import splice.dialect.responses.ToolDeferralPolicy
+import splice.dialect.responses.withParallelToolCallsToml
 import splice.dialect.responses.withReasoningCacheToml
 import splice.dialect.responses.withToml
 import splice.dialect.responses.withToolSurfaceToml
@@ -508,6 +509,7 @@ public class Daemon(
         compactEffort = quirks.compactEffort,
         toolChoice = quirks.toolChoice,
     ).withReasoningCacheToml(quirks.reasoningCache)
+        .withParallelToolCallsToml(quirks.parallelToolCalls)
         .withToolSurfaceToml(toolDeferralPolicy(quirks.toolSurface, cfg.toolSurfaceOff))
 
     private fun responsesProvider(ctx: ProviderBuild, label: String): Wired {

--- a/gateway/core/src/main/kotlin/splice/core/topology/Topology.kt
+++ b/gateway/core/src/main/kotlin/splice/core/topology/Topology.kt
@@ -111,6 +111,12 @@ public data class QuirksConfig(
      *  (codex: on; grok: off — xai returns no envelopes), so the overlay can't stomp it. False
      *  restores the pre-cache behavior (per-tool-result amnesia). */
     @SerialName("reasoning_cache") val reasoningCache: Boolean? = null,
+    /** openai-responses only: the VALUE sent for parallel_tool_calls on responses-lite turns (the
+     *  field always rides; a lite request without it 400s). NULLABLE overlay like reasoning_cache —
+     *  absent keeps the provider's own default (false), so it can't stomp a provider default the
+     *  way the non-nullable summary_field above does. true lets the model batch tool calls into one
+     *  turn instead of one per turn; UNTESTED against the live backend, see ResponsesQuirks. */
+    @SerialName("parallel_tool_calls") val parallelToolCalls: Boolean? = null,
     /** openai-chat only: emit reasoning_effort/reasoning fields (DeepSeek/xAI/OpenRouter-style
      *  backends read them). null keeps the provider's own default (true); set false for strict
      *  OpenAI-compatible vendors (Fireworks — issue #21) that 400 on unrecognized fields. */

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ReasoningCache.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ReasoningCache.kt
@@ -63,9 +63,27 @@ internal class ReasoningCache(
             entries[key] = Entry(conversationKey, toolIds, envelopes, bytes, clock())
             toolIds.forEach { byScopedToolId[scoped(conversationKey, it)] = key }
             totalBytes += bytes
-            while (entries.size > maxEntries || totalBytes > maxTotalBytes) {
-                val oldest = entries.entries.firstOrNull() ?: break
+            evictToBoundLocked(writing = conversationKey)
+        }
+    }
+
+    /** Evict the oldest CONVERSATION wholesale, not just its oldest round. Oldest-first by round is
+     *  the worst possible choice for prefix stability: the oldest round's reasoning sits EARLIEST in
+     *  the input array, so dropping it invalidates every token after it (see
+     *  [touchConversationLocked]). Dropping a whole conversation costs that one its injection but
+     *  keeps every surviving conversation prefix-stable. */
+    private fun evictToBoundLocked(writing: String?) {
+        while (entries.size > maxEntries || totalBytes > maxTotalBytes) {
+            val oldest = entries.entries.firstOrNull() ?: break
+            val victim = oldest.value.conversationKey
+            // Never self-wipe the conversation being written: if IT alone overflows the bound,
+            // wholesale eviction would empty the cache on every put and destroy far more prefix
+            // than it saves. Fall back to today's oldest-round eviction (NEVER-BELOW-STATUS-QUO).
+            if (victim == null || victim == writing) {
                 removeLocked(oldest.key)
+            } else {
+                entries.filterValues { it.conversationKey == victim }.keys.toList()
+                    .forEach { removeLocked(it) }
             }
         }
     }
@@ -75,7 +93,31 @@ internal class ReasoningCache(
     fun lookup(conversationKey: String?, toolId: String): List<String>? = synchronized(lock) {
         sweepLocked()
         val key = byScopedToolId[scoped(conversationKey, toolId)] ?: return null
-        entries[key]?.envelopes
+        val envelopes = entries[key]?.envelopes
+        if (envelopes != null) touchConversationLocked(conversationKey)
+        envelopes
+    }
+
+    /** PREFIX STABILITY (2026-07-30): a conversation's entries live and die TOGETHER.
+     *  The builder injects each round's reasoning immediately before that round's FIRST
+     *  function_call, so losing ONE round mid-conversation deletes an item from the middle of the
+     *  input array and shifts every item after it. Turn N+1 then stops being a prefix-extension of
+     *  turn N, and OpenAI — which reuses the longest stable prefix — re-bills the entire remainder.
+     *  Measured offline against this builder: evicting the single OLDEST entry of an 8-round
+     *  conversation dropped prefix reuse from 100% to 7.7%. Against live telemetry the same
+     *  signature accounts for 1,349 turns at =<25% prefix reuse.
+     *  Refreshing the WHOLE conversation on any lookup means an active conversation never
+     *  partially expires; an idle one expires wholesale, which is a single clean transition to
+     *  no-injection (stable thereafter) instead of continuous per-round churn.
+     *  Re-inserting in iteration order preserves insertion-order == timestamp-order, the invariant
+     *  sweepLocked's takeWhile early-exit depends on. */
+    private fun touchConversationLocked(conversationKey: String?) {
+        // Unscoped entries (null key = a first user message with no text to hash) share one
+        // namespace across conversations and cannot be grouped; leave them on plain insertion TTL.
+        if (conversationKey == null) return
+        val now = clock()
+        entries.entries.filter { it.value.conversationKey == conversationKey }.map { it.key }
+            .forEach { k -> entries.remove(k)?.let { entries[k] = it.copy(at = now) } }
     }
 
     /** Drop every turn containing [toolId] — used when upstream rejects its envelopes as stale.
@@ -91,7 +133,15 @@ internal class ReasoningCache(
     private fun sweepLocked() {
         val cutoff = clock() - ttlMs
         val expired = entries.entries.takeWhile { it.value.at < cutoff }.map { it.key }
+        if (expired.isEmpty()) return
+        // Wholesale by conversation: a half-swept conversation is exactly the prefix-shifting
+        // state this cache must never produce (see touchConversationLocked). Collect the doomed
+        // keys BEFORE removing, then drop every remaining entry that belongs to one of them.
+        val doomed = expired.mapNotNull { entries[it]?.conversationKey }.toSet()
         expired.forEach { removeLocked(it) }
+        if (doomed.isNotEmpty()) {
+            entries.filterValues { it.conversationKey in doomed }.keys.toList().forEach { removeLocked(it) }
+        }
     }
 
     private fun removeLocked(key: String) {

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ReasoningCache.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ReasoningCache.kt
@@ -2,12 +2,25 @@
 // keeps the model's encrypted reasoning items in its in-process history and re-sends them on
 // every tool round-trip (store:false stateless full replay — client.rs:888/:915); splice with
 // replay_reasoning=false dropped them, giving gpt-5.6 amnesia at every tool result (repeated
-// tool calls, duplicated reasoning — operator report 2026-07-24). This cache holds the round's
+// tool calls, duplicated reasoning — operator report 2026-07-24). This cache holds each round's
 // envelopes keyed by its REAL function_call ids so the builder can reinject the plan in-position
 // when the tool results come back. Entries are READ, not consumed — a client-retried request
-// re-reads the same envelopes (grace by design); TTL and bounds do the cleanup. Losing an entry
-// (restart, eviction, TTL) degrades to today's no-injection behavior, never to an error
-// (NEVER-BELOW-STATUS-QUO law).
+// re-reads the same envelopes (grace by design). Losing a conversation (restart, eviction, idle
+// TTL) degrades to the no-injection status quo, never to an error (NEVER-BELOW-STATUS-QUO law).
+//
+// REWORKED 2026-07-31 (review of #71, round 2): the CONVERSATION is the primary record, not the
+// round. The builder injects each round's reasoning at a fixed mid-array position, so any policy
+// that removes SOME of a conversation's rounds (per-round TTL, oldest-round eviction, per-round
+// stale eviction) shifts the input array mid-prefix and re-bills the remainder — the 342M-token
+// drain prompt-cache-drain.md measures. Round-granular policies retrofitted onto a flat map kept
+// leaking that state (four confirmed holes: neighbor-pressure misfire of the disable marker, the
+// 256-round wipe+disable cliff, unmarked cross-eviction oscillation, per-round stale eviction), so
+// the record now IS the conversation: one idle timestamp, one frozen flag, one rounds map.
+// Policies fall out: touch is O(1) re-insertion; idle expiry and stale eviction are wholesale by
+// construction; bound pressure evicts the least-recently-touched NEIGHBOR whole; and a
+// conversation that alone exceeds the bound FREEZES ADMISSION — the offered round (never yet
+// injected) is rejected and every admitted round keeps serving, which costs the tail its
+// injection instead of busting the whole prefix the way wipe+disable did.
 package splice.dialect.responses
 
 import kotlinx.serialization.json.JsonArrayBuilder
@@ -19,176 +32,228 @@ import kotlinx.serialization.json.jsonObject
 import splice.core.util.MonoClock
 import splice.core.util.str
 
-/** One turn's capture: every id of the round maps to the same shared entry; a lookup by ANY of
- *  them yields the round's ordered envelopes exactly once per request build (inject-once law is
- *  the BUILDER's duty; the cache is a plain keyed store). Lookups are scoped by conversationKey
- *  (review 2026-07-24, RC-2's eli-risk-8: one instance serves every concurrent conversation on a
- *  head, so a bare-id key could cross-inject on call_id reuse); eviction stays bare-id, since
- *  over-evicting on a collision only costs a cache miss (status quo), never a wrong injection. */
 internal class ReasoningCache(
     private val maxEntries: Int = MAX_ENTRIES,
     private val maxTotalBytes: Long = MAX_TOTAL_BYTES,
     private val ttlMs: Long = TTL_MS,
-    // Monotonic, not wall clock: sweepLocked's takeWhile early-exit is sound only while insertion
-    // order matches timestamp order — an NTP step backward would break that invariant and leave an
-    // expired entry unswept (review 2026-07-24; same reasoning as UpstreamClient's MonoClock).
+    // Monotonic, not wall clock: both sweeps' takeWhile early-exits are sound only while
+    // iteration order matches timestamp order — an NTP step backward would break that invariant
+    // and leave an expired record unswept (review 2026-07-24; same reasoning as UpstreamClient).
     private val clock: () -> Long = MonoClock::nowMs,
+    /** Daemon log sink for the two one-way transitions worth an operator's eye (freeze, bound
+     *  eviction). Defaults to a no-op so tests need not thread it. */
+    private val log: (String) -> Unit = {},
 ) {
 
-    private data class Entry(
-        val conversationKey: String?,
-        val toolIds: List<String>,
-        val envelopes: List<String>,
-        val bytes: Long,
-        val at: Long,
-    )
+    private data class Round(val toolIds: List<String>, val envelopes: List<String>, val bytes: Long, val at: Long)
 
-    // Insertion-ordered so eviction drops the OLDEST turn first — a deep in-flight tool loop's
-    // recent entries survive bound pressure (eli risk 4: mid-loop eviction reproduces the
-    // amnesia symptom intermittently; oldest-first plus a TTL far above turn wall-time avoids it).
-    private val entries = LinkedHashMap<String, Entry>()
-    private val byScopedToolId = HashMap<String, String>()
+    /** One conversation: rounds in arrival order, ONE idle timestamp, ONE admission flag. Every
+     *  id of a round maps to that round; a lookup by ANY of them yields the round's ordered
+     *  envelopes (inject-once stays the BUILDER's duty — this is a plain keyed store). */
+    private class Convo {
+        val rounds = LinkedHashMap<String, Round>()
+        val byToolId = HashMap<String, String>()
+        var bytes = 0L
+        var at = 0L
+        var frozen = false
+    }
+
+    // Iteration order = least-recently-TOUCHED first (touch re-inserts; MonoClock keeps `at`
+    // monotone with re-insertion order, which sweepLocked's takeWhile depends on).
+    private val convos = LinkedHashMap<String, Convo>()
+
+    // The null-key class (first user message with no text to hash — image-first or tool_result-
+    // first openers) has no grouping identity, so it keeps the ORIGINAL flat per-round insertion
+    // TTL and shares one id namespace, exactly the pre-rework behavior. Documented limitation:
+    // that class retains the old mid-conversation-expiry pathology (spike doc, "not fixed").
+    private val nullRounds = LinkedHashMap<String, Round>()
+    private val nullByToolId = HashMap<String, String>()
+
+    private var roundCount = 0
     private var totalBytes = 0L
     private var seq = 0L
     private val lock = Any()
-
-    private fun scoped(conversationKey: String?, toolId: String) = "${conversationKey.orEmpty()}\u0000$toolId"
-
-    // Conversations that overflowed the bounds ON THEIR OWN (review of #71). Once a conversation
-    // cannot be held WHOLE, holding PART of it is worse than holding none: a partial conversation
-    // shifts the input array mid-prefix every time another of its rounds is dropped, which is
-    // precisely the state this cache exists to prevent. Wiping it WITHOUT this marker only trades
-    // grinding for oscillation — the conversation re-caches, overflows and wipes again, and each
-    // wipe makes rounds LOSE reasoning they already had. The marker makes it ONE transition, then
-    // stable for the rest of that conversation's life (no-injection is the documented status-quo
-    // fallback). Insertion-ordered and swept on the same idle TTL as [entries] so it cannot grow
-    // without bound; letting an IDLE one lapse is safe, because a resumed conversation's old rounds
-    // stay unreasoned and new rounds only ever ADD reasoning at the tail, which shifts nothing.
-    private val disabled = LinkedHashMap<String, Long>()
 
     fun put(conversationKey: String?, toolIds: List<String>, envelopes: List<String>) {
         if (toolIds.isEmpty() || envelopes.isEmpty()) return
         val bytes = envelopes.sumOf { it.length.toLong() }
         synchronized(lock) {
             sweepLocked()
-            if (conversationKey != null && refreshDisabledLocked(conversationKey)) return
-            val key = "t${seq++}"
-            entries[key] = Entry(conversationKey, toolIds, envelopes, bytes, clock())
-            toolIds.forEach { byScopedToolId[scoped(conversationKey, it)] = key }
-            totalBytes += bytes
-            evictToBoundLocked(writing = conversationKey)
-        }
-    }
-
-    /** Evict the oldest CONVERSATION wholesale, not just its oldest round. Oldest-first by round is
-     *  the worst possible choice for prefix stability: the oldest round's reasoning sits EARLIEST in
-     *  the input array, so dropping it invalidates every token after it (see
-     *  [touchConversationLocked]). Dropping a whole conversation costs that one its injection but
-     *  keeps every surviving conversation prefix-stable. */
-    private fun evictToBoundLocked(writing: String?) {
-        while (entries.size > maxEntries || totalBytes > maxTotalBytes) {
-            val oldest = entries.entries.firstOrNull() ?: break
-            val victim = oldest.value.conversationKey
-            if (victim == null) {
-                // Unscoped entries have no conversation group to evict as a unit.
-                removeLocked(oldest.key)
+            if (conversationKey == null) {
+                putNullLocked(toolIds, envelopes, bytes)
             } else {
-                // A conversation that overflows the bound BY ITSELF cannot be held whole, so it is
-                // marked non-injectable rather than trimmed round by round (see [disabled]).
-                if (victim == writing) disableLocked(victim)
-                entries.filterValues { it.conversationKey == victim }.keys.toList()
-                    .forEach { removeLocked(it) }
+                putConvoLocked(conversationKey, toolIds, envelopes, bytes)
             }
         }
     }
 
-    private fun disableLocked(key: String) {
-        disabled.remove(key)
-        disabled[key] = clock()
-        while (disabled.size > maxEntries) disabled.remove(disabled.keys.first())
-    }
-
-    /** True when [key] names a disabled conversation, refreshing its marker so an ACTIVE one STAYS
-     *  disabled — re-enabling mid-conversation restarts the overflow/wipe oscillation the marker
-     *  exists to end. Re-insertion keeps insertion order == timestamp order for the sweep. */
-    private fun refreshDisabledLocked(key: String): Boolean {
-        if (!disabled.containsKey(key)) return false
-        disabled.remove(key)
-        disabled[key] = clock()
-        return true
-    }
-
-    /** The ordered envelopes for the turn of THIS conversation that emitted [toolId], or null
-     *  (miss = status quo; another conversation's identical id never resolves). */
+    /** The ordered envelopes for the round of THIS conversation that emitted [toolId], or null
+     *  (miss = status quo; another conversation's identical id never resolves — per-conversation
+     *  id maps; the null-key class shares one namespace as before). Touching refreshes the WHOLE
+     *  conversation: active conversations never partially expire. */
     fun lookup(conversationKey: String?, toolId: String): List<String>? = synchronized(lock) {
         sweepLocked()
-        if (conversationKey != null && refreshDisabledLocked(conversationKey)) return null
-        val key = byScopedToolId[scoped(conversationKey, toolId)] ?: return null
-        val envelopes = entries[key]?.envelopes
-        if (envelopes != null) touchConversationLocked(conversationKey)
-        envelopes
+        if (conversationKey == null) return nullByToolId[toolId]?.let { nullRounds[it]?.envelopes }
+        val convo = touchLocked(conversationKey) ?: return null
+        convo.byToolId[toolId]?.let { convo.rounds[it]?.envelopes }
     }
 
-    /** PREFIX STABILITY (2026-07-30): a conversation's entries live and die TOGETHER.
-     *  The builder injects each round's reasoning immediately before that round's FIRST
-     *  function_call, so losing ONE round mid-conversation deletes an item from the middle of the
-     *  input array and shifts every item after it. Turn N+1 then stops being a prefix-extension of
-     *  turn N, and OpenAI — which reuses the longest stable prefix — re-bills the entire remainder.
-     *  Measured offline against this builder: evicting the single OLDEST entry of an 8-round
-     *  conversation dropped prefix reuse from 100% to 7.7%. Against live telemetry the same
-     *  signature accounts for 1,349 turns at =<25% prefix reuse.
-     *  Refreshing the WHOLE conversation on any lookup means an active conversation never
-     *  partially expires; an idle one expires wholesale, which is a single clean transition to
-     *  no-injection (stable thereafter) instead of continuous per-round churn.
-     *  Re-inserting in iteration order preserves insertion-order == timestamp-order, the invariant
-     *  sweepLocked's takeWhile early-exit depends on. */
-    private fun touchConversationLocked(conversationKey: String?) {
-        // Unscoped entries (null key = a first user message with no text to hash) share one
-        // namespace across conversations and cannot be grouped; leave them on plain insertion TTL.
-        if (conversationKey == null) return
-        val now = clock()
-        entries.entries.filter { it.value.conversationKey == conversationKey }.map { it.key }
-            .forEach { k -> entries.remove(k)?.let { entries[k] = it.copy(at = now) } }
+    /** Every round of [conversationKey] as toolId -> envelopes in ONE atomic read with ONE touch.
+     *  The builder walks N tool_use blocks per build; N independent lookups can tear across a
+     *  concurrent eviction (rounds 1..k injected, k+1.. missing — the forbidden partial shape,
+     *  review finding 14) and re-touch the conversation N times (finding 10). A snapshot cannot
+     *  tear and costs one lock acquisition per build. */
+    fun snapshot(conversationKey: String?): Map<String, List<String>> = synchronized(lock) {
+        sweepLocked()
+        if (conversationKey == null) {
+            return nullByToolId.entries.associate { (id, rk) -> id to nullRounds.getValue(rk).envelopes }
+        }
+        val convo = touchLocked(conversationKey) ?: return emptyMap()
+        convo.byToolId.entries.associate { (id, rk) -> id to convo.rounds.getValue(rk).envelopes }
     }
 
-    /** Drop every turn containing [toolId] — used when upstream rejects its envelopes as stale.
+    /** Upstream rejected [toolId]'s envelopes as stale: drop the WHOLE conversation that carried
+     *  it. Per-round eviction (the old RC-4 shape) left the surviving rounds injecting around a
+     *  permanent mid-array hole — permanent because active conversations no longer age out. A
+     *  wholesale drop is one clean transition to no-injection; the conversation re-caches fresh
+     *  rounds from its next turn onward, which appends at the tail and shifts nothing.
      *  Deliberately UNscoped (the amend path has no conversation context): a cross-conversation
-     *  collision here evicts a healthy entry, which degrades to a miss, never a wrong injection.
-     *  O(entries) scan; the path is a rare 400 recovery over ≤[maxEntries] entries. */
+     *  call_id collision over-evicts a healthy conversation, which costs a miss, never a wrong
+     *  injection. */
     fun evictByToolId(toolId: String) {
         synchronized(lock) {
-            entries.filterValues { toolId in it.toolIds }.keys.toList().forEach { removeLocked(it) }
+            convos.filterValues { toolId in it.byToolId }.keys.toList().forEach {
+                log("[reasoning-cache] stale-400 evicted conversation ${it.take(KEY_LOG_CHARS)}… whole")
+                removeConvoLocked(it)
+            }
+            nullByToolId[toolId]?.let { removeNullLocked(it) }
         }
+    }
+
+    // ── internals ────────────────────────────────────────────────────────────────────────────
+
+    /** Re-insert [key] at the most-recently-touched end with a fresh timestamp, or null if the
+     *  conversation is not held. O(1): the whole point of conversation-primary records. */
+    private fun touchLocked(key: String): Convo? =
+        convos.remove(key)?.also {
+            it.at = clock()
+            convos[key] = it
+        }
+
+    private fun putConvoLocked(key: String, toolIds: List<String>, envelopes: List<String>, bytes: Long) {
+        val convo = touchLocked(key) ?: Convo().also {
+            it.at = clock()
+            convos[key] = it
+        }
+        if (convo.frozen) return // admission frozen; admitted rounds keep serving
+        // Client-retry grace: an id we already hold is a re-capture of the same round. Admitting
+        // it again would orphan the old round, which still counts against the bound (review
+        // finding 2's accelerator) — refresh (the touch above) and return instead.
+        if (toolIds.any { it in convo.byToolId }) return
+        val rk = "r${seq++}"
+        convo.rounds[rk] = Round(toolIds, envelopes, bytes, convo.at)
+        toolIds.forEach { convo.byToolId[it] = rk }
+        convo.bytes += bytes
+        totalBytes += bytes
+        roundCount++
+        evictToBoundLocked(writing = key, writer = convo, offered = rk)
+    }
+
+    private fun putNullLocked(toolIds: List<String>, envelopes: List<String>, bytes: Long) {
+        val rk = "n${seq++}"
+        nullRounds[rk] = Round(toolIds, envelopes, bytes, clock())
+        toolIds.forEach { nullByToolId[it] = rk }
+        totalBytes += bytes
+        roundCount++
+        evictToBoundLocked(writing = null, writer = null, offered = null)
+    }
+
+    /** Restore the bounds. Order: null-class rounds first (the least-guaranteed class; one round
+     *  costs one miss), then whole least-recently-touched NEIGHBOR conversations — never the
+     *  writer (review finding 1: neighbor pressure must not punish the active conversation).
+     *  If the writer alone still exceeds the bound, FREEZE ADMISSION: reject [offered] (never
+     *  yet injected, so rejecting it shifts nothing) and keep everything admitted. Admitted
+     *  rounds were each admitted under the bound, so rejecting the offered round always restores
+     *  the invariant — the loop cannot spin (the false-return guard is unreachable from put()
+     *  and exists only to make non-progress impossible by construction). */
+    private fun evictToBoundLocked(writing: String?, writer: Convo?, offered: String?) {
+        while (roundCount > maxEntries || totalBytes > maxTotalBytes) {
+            val oldestNull = nullRounds.keys.firstOrNull()
+            val neighbor = if (oldestNull == null) convos.keys.firstOrNull { it != writing } else null
+            when {
+                oldestNull != null -> removeNullLocked(oldestNull)
+                neighbor != null -> evictNeighborLocked(neighbor)
+                else -> if (!freezeWriterLocked(writing, writer, offered)) return
+            }
+        }
+    }
+
+    private fun evictNeighborLocked(key: String) {
+        log(
+            "[reasoning-cache] bound pressure evicted conversation " +
+                "${key.take(KEY_LOG_CHARS)}… whole (${convos.getValue(key).rounds.size} rounds)",
+        )
+        removeConvoLocked(key)
+    }
+
+    /** Reject the round just offered and freeze admission for the writer. True when the offered
+     *  round was removed (progress guaranteed); false only on the defensive no-writer path. */
+    private fun freezeWriterLocked(writing: String?, writer: Convo?, offered: String?): Boolean {
+        if (writer == null || offered == null) return false
+        val round = writer.rounds.remove(offered) ?: return false
+        round.toolIds.forEach { writer.byToolId.remove(it) }
+        writer.bytes -= round.bytes
+        totalBytes -= round.bytes
+        roundCount--
+        if (!writer.frozen) {
+            writer.frozen = true
+            log(
+                "[reasoning-cache] conversation ${writing?.take(KEY_LOG_CHARS)}… froze admission at " +
+                    "${writer.rounds.size} rounds/${writer.bytes}B (alone over the bound); " +
+                    "admitted rounds keep serving",
+            )
+        }
+        return true
     }
 
     private fun sweepLocked() {
         val cutoff = clock() - ttlMs
-        // Disabled markers lapse on the same idle timer (safe: see [disabled]).
-        disabled.entries.takeWhile { it.value < cutoff }.map { it.key }.forEach { disabled.remove(it) }
-        val expired = entries.entries.takeWhile { it.value.at < cutoff }.map { it.key }
-        if (expired.isEmpty()) return
-        // Wholesale by conversation: a half-swept conversation is exactly the prefix-shifting
-        // state this cache must never produce (see touchConversationLocked). Collect the doomed
-        // keys BEFORE removing, then drop every remaining entry that belongs to one of them.
-        val doomed = expired.mapNotNull { entries[it]?.conversationKey }.toSet()
-        expired.forEach { removeLocked(it) }
-        if (doomed.isNotEmpty()) {
-            entries.filterValues { it.conversationKey in doomed }.keys.toList().forEach { removeLocked(it) }
-        }
+        // Null-class: flat per-round INSERTION TTL (never touched, so insertion order = age order).
+        nullRounds.entries.takeWhile { it.value.at < cutoff }.map { it.key }.toList()
+            .forEach { removeNullLocked(it) }
+        // Conversations expire WHOLESALE on idle — half a conversation is the one state this
+        // cache must never serve. An active conversation is re-touched every build, so only a
+        // genuinely idle one lapses; its frozen flag (if any) dies with it, and a later resume
+        // re-caches from its next round onward (tail-append, prefix-stable).
+        convos.entries.takeWhile { it.value.at < cutoff }.map { it.key }.toList()
+            .forEach { removeConvoLocked(it) }
     }
 
-    private fun removeLocked(key: String) {
-        val e = entries.remove(key) ?: return
-        e.toolIds.forEach { byScopedToolId.remove(scoped(e.conversationKey, it)) }
-        totalBytes -= e.bytes
+    private fun removeConvoLocked(key: String) {
+        val convo = convos.remove(key) ?: return
+        totalBytes -= convo.bytes
+        roundCount -= convo.rounds.size
+    }
+
+    private fun removeNullLocked(roundKey: String) {
+        val round = nullRounds.remove(roundKey) ?: return
+        round.toolIds.forEach { nullByToolId.remove(it) }
+        totalBytes -= round.bytes
+        roundCount--
     }
 
     internal companion object {
-        // A tool round-trip is seconds; the watchdog's whole-turn cap is minutes. 30 min covers
-        // the deepest realistic loop with an order of magnitude to spare (eli risk 4).
+        // The TTL is an IDLE timer for keyed conversations (each build re-touches), an insertion
+        // TTL for the null-key class. 30 min of genuine inactivity, with an order of magnitude
+        // over any realistic tool-loop gap (eli risk 4).
         const val TTL_MS: Long = 30 * 60 * 1000L
+
+        // Total ROUNDS across all conversations on the head (one entry per tool round).
         const val MAX_ENTRIES: Int = 256
         const val MAX_TOTAL_BYTES: Long = 64L * 1024 * 1024
+
+        // "splice-" + 7 hash chars: identifiable in logs, not noisy.
+        const val KEY_LOG_CHARS: Int = 14
     }
 }
 
@@ -201,10 +266,10 @@ internal fun reasoningCacheActive(quirks: ResponsesQuirks, compact: Boolean): Bo
 
 /** RC-4: the invalid_encrypted_content recovery — strip every reasoning input item from the
  *  request (degrade to per-item amnesia, never fail the turn on cache contents) and evict the
- *  cache entries for ONLY the rounds those items belonged to, i.e. the function_calls that
- *  immediately follow each dropped reasoning item up to the next one (review 2026-07-24: evicting
- *  every function_call in the re-sent history wiped every still-fresh round's entry on a single
- *  stale 400, ending cache continuity for the rest of the conversation's life).
+ *  cache for the rounds those items belonged to, i.e. the function_calls that immediately follow
+ *  each dropped reasoning item up to the next one. Eviction is conversation-wholesale (2026-07-31,
+ *  review of #71 round 2): the old per-round eviction left the surviving rounds injecting around a
+ *  permanent hole, shifting the prefix on every later build.
  *  Returns null when the body carries no reasoning items (the amendment is not ours to make).
  *  Decode/encode rides the closed ResponsesRequest DTO (#924) — no field invented or lost. */
 internal fun stripStaleReasoning(bodyJson: String, cache: ReasoningCache): String? {
@@ -217,9 +282,9 @@ internal fun stripStaleReasoning(bodyJson: String, cache: ReasoningCache): Strin
     return responsesRequestJson.encodeToJsonElement(ResponsesRequest.serializer(), next).toString()
 }
 
-/** The strip's item walk: drop reasoning items, and evict ONLY the rounds they belonged to — a
- *  round is [reasoning, function_call+, …], so the scope is the unbroken run of calls right after
- *  a dropped item; an orphan call later in the transcript keeps its healthy entry. */
+/** The strip's item walk: drop reasoning items, and evict the rounds they belonged to — a round
+ *  is [reasoning, function_call+, …], so the scope is the unbroken run of calls right after a
+ *  dropped item. (The cache widens each eviction to the whole conversation; see evictByToolId.) */
 private class StaleReasoningWalk(private val cache: ReasoningCache) {
     var dropped = 0
     private var inDroppedRound = false

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ReasoningCache.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ReasoningCache.kt
@@ -54,11 +54,24 @@ internal class ReasoningCache(
 
     private fun scoped(conversationKey: String?, toolId: String) = "${conversationKey.orEmpty()}\u0000$toolId"
 
+    // Conversations that overflowed the bounds ON THEIR OWN (review of #71). Once a conversation
+    // cannot be held WHOLE, holding PART of it is worse than holding none: a partial conversation
+    // shifts the input array mid-prefix every time another of its rounds is dropped, which is
+    // precisely the state this cache exists to prevent. Wiping it WITHOUT this marker only trades
+    // grinding for oscillation — the conversation re-caches, overflows and wipes again, and each
+    // wipe makes rounds LOSE reasoning they already had. The marker makes it ONE transition, then
+    // stable for the rest of that conversation's life (no-injection is the documented status-quo
+    // fallback). Insertion-ordered and swept on the same idle TTL as [entries] so it cannot grow
+    // without bound; letting an IDLE one lapse is safe, because a resumed conversation's old rounds
+    // stay unreasoned and new rounds only ever ADD reasoning at the tail, which shifts nothing.
+    private val disabled = LinkedHashMap<String, Long>()
+
     fun put(conversationKey: String?, toolIds: List<String>, envelopes: List<String>) {
         if (toolIds.isEmpty() || envelopes.isEmpty()) return
         val bytes = envelopes.sumOf { it.length.toLong() }
         synchronized(lock) {
             sweepLocked()
+            if (conversationKey != null && refreshDisabledLocked(conversationKey)) return
             val key = "t${seq++}"
             entries[key] = Entry(conversationKey, toolIds, envelopes, bytes, clock())
             toolIds.forEach { byScopedToolId[scoped(conversationKey, it)] = key }
@@ -76,22 +89,40 @@ internal class ReasoningCache(
         while (entries.size > maxEntries || totalBytes > maxTotalBytes) {
             val oldest = entries.entries.firstOrNull() ?: break
             val victim = oldest.value.conversationKey
-            // Never self-wipe the conversation being written: if IT alone overflows the bound,
-            // wholesale eviction would empty the cache on every put and destroy far more prefix
-            // than it saves. Fall back to today's oldest-round eviction (NEVER-BELOW-STATUS-QUO).
-            if (victim == null || victim == writing) {
+            if (victim == null) {
+                // Unscoped entries have no conversation group to evict as a unit.
                 removeLocked(oldest.key)
             } else {
+                // A conversation that overflows the bound BY ITSELF cannot be held whole, so it is
+                // marked non-injectable rather than trimmed round by round (see [disabled]).
+                if (victim == writing) disableLocked(victim)
                 entries.filterValues { it.conversationKey == victim }.keys.toList()
                     .forEach { removeLocked(it) }
             }
         }
     }
 
+    private fun disableLocked(key: String) {
+        disabled.remove(key)
+        disabled[key] = clock()
+        while (disabled.size > maxEntries) disabled.remove(disabled.keys.first())
+    }
+
+    /** True when [key] names a disabled conversation, refreshing its marker so an ACTIVE one STAYS
+     *  disabled — re-enabling mid-conversation restarts the overflow/wipe oscillation the marker
+     *  exists to end. Re-insertion keeps insertion order == timestamp order for the sweep. */
+    private fun refreshDisabledLocked(key: String): Boolean {
+        if (!disabled.containsKey(key)) return false
+        disabled.remove(key)
+        disabled[key] = clock()
+        return true
+    }
+
     /** The ordered envelopes for the turn of THIS conversation that emitted [toolId], or null
      *  (miss = status quo; another conversation's identical id never resolves). */
     fun lookup(conversationKey: String?, toolId: String): List<String>? = synchronized(lock) {
         sweepLocked()
+        if (conversationKey != null && refreshDisabledLocked(conversationKey)) return null
         val key = byScopedToolId[scoped(conversationKey, toolId)] ?: return null
         val envelopes = entries[key]?.envelopes
         if (envelopes != null) touchConversationLocked(conversationKey)
@@ -132,6 +163,8 @@ internal class ReasoningCache(
 
     private fun sweepLocked() {
         val cutoff = clock() - ttlMs
+        // Disabled markers lapse on the same idle timer (safe: see [disabled]).
+        disabled.entries.takeWhile { it.value < cutoff }.map { it.key }.forEach { disabled.remove(it) }
         val expired = entries.entries.takeWhile { it.value.at < cutoff }.map { it.key }
         if (expired.isEmpty()) return
         // Wholesale by conversation: a half-swept conversation is exactly the prefix-shifting

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesProvider.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesProvider.kt
@@ -76,12 +76,15 @@ public abstract class ResponsesProvider(
                 // left its plan in the cache; reinject it so the model resumes instead of
                 // re-deriving (codex parity; repeated-tool-call amnesia otherwise). Scoped to
                 // THIS conversation (same first-message hash the builder stamps on TurnMeta).
-                reasoningLookup = { id ->
-                    if (reasoningCacheActive(quirks, compact)) {
-                        reasoningCache.lookup(stablePromptCacheKey(body.typed), id)
-                    } else {
-                        null
-                    }
+                // ONE atomic snapshot per build (review of #71 round 2): per-block lookups could
+                // tear across a concurrent eviction (rounds 1..k injected, k+1.. missing), re-ran
+                // the first-message SHA-256 per block, and re-touched the conversation per block.
+                // Lazy so a build with no tool_use blocks never touches the cache at all.
+                reasoningLookup = if (!reasoningCacheActive(quirks, compact)) {
+                    { null }
+                } else {
+                    val snapshot = lazy { reasoningCache.snapshot(stablePromptCacheKey(body.typed)) }
+                    ({ id -> snapshot.value[id] })
                 },
                 // The provider's capability latch, read at build time: false = a shape-400 already
                 // closed it this daemon lifetime; build the full status-quo request instead.
@@ -151,7 +154,9 @@ public abstract class ResponsesProvider(
 
     // RC-2/RC-4: gateway-held reasoning continuity for tool round-trips (codex parity). One
     // cache per provider instance; capture and lookup wire in via buildTurn/streamTranslator.
-    private val reasoningCache: ReasoningCache = ReasoningCache()
+    // The log sink surfaces the cache's two one-way transitions (freeze, bound eviction) in
+    // /mgmt/logs — silent state loss here cost a two-day cache-drain investigation.
+    private val reasoningCache: ReasoningCache = ReasoningCache(log = log)
 
     // The tool-surface capability latch (§1.3/§5.3): one AtomicBoolean per provider instance,
     // moving in exactly one direction — toward status quo. Read at build time (buildTurn), closed

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesRequestBuilder.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesRequestBuilder.kt
@@ -382,7 +382,14 @@ public class ResponsesRequestBuilder(private val quirks: ResponsesQuirks) {
         // parallel Task calls (see the header). Note that pathology came from OMITTING the field,
         // which is not the same as sending an explicit true; the true case is untested, which is
         // exactly why this is an opt-in knob and not a changed default.
-        quirks.isLite(opts) -> quirks.liteParallelToolCalls
+        // Even with the knob on (review of #71 round 2): a client's explicit
+        // disable_parallel_tool_use=true wins — the gateway must not override a request the
+        // client asked to serialize — and a TOOLLESS turn stays false (nothing to parallelize,
+        // and explicit-true-without-tools is an untested combination upstream).
+        quirks.isLite(opts) ->
+            quirks.liteParallelToolCalls &&
+                body.tools.isNotEmpty() &&
+                body.toolChoice?.disableParallelToolUse != true
         emitToolChoice -> body.toolChoice?.disableParallelToolUse != true
         else -> null
     }

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesRequestBuilder.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesRequestBuilder.kt
@@ -77,6 +77,15 @@ public data class ResponsesQuirks(
      *  backend (direct probe 2026-07-19: 200, correct tool call). */
     val responsesLiteModelRegex: Regex? = Regex("gpt-5\\.6", RegexOption.IGNORE_CASE),
     val compactEffortPin: String? = null, // null = inherit session effort (the cache law)
+    /** The VALUE sent for parallel_tool_calls on responses-lite turns (the field itself always
+     *  rides — a lite request without it 400s). codex-rs reads this per model from
+     *  `model_info.supports_parallel_tool_calls` rather than hardcoding it, so it is a knob here
+     *  too. Default false = today's behaviour. Turning it on lets the model batch tool calls in one
+     *  turn instead of one per turn; measured 2026-07-31, claudex averages 386 output tokens/turn
+     *  against grok's 663 and kimi's 786, i.e. ~2x the round-trips, and every round-trip re-sends
+     *  the whole context. UNTESTED against the live backend — see the 30-50 parallel Task spray in
+     *  this class's header, which came from omitting the field entirely. */
+    val liteParallelToolCalls: Boolean = false,
     val emitToolChoice: Boolean = false,
     /** Passes through a tool's own `strict == true` as `"strict": true`; false (the default,
      *  and the only value that has ever mattered — Claude Code's ToolDefinition.strict is always
@@ -138,6 +147,13 @@ public fun ResponsesQuirks.withToml(
 /** RC-5 overlay, chained after [withToml] (which sits at detekt's complexity ceiling). */
 public fun ResponsesQuirks.withReasoningCacheToml(reasoningCache: Boolean?): ResponsesQuirks =
     copy(reasoningCache = reasoningCache ?: this.reasoningCache)
+
+/** parallel_tool_calls overlay (2026-07-31), chained like [withReasoningCacheToml] for the same
+ *  reason. NULLABLE — absent TOML keeps the provider's own default, so the overlay can never stomp
+ *  it. (`summary_field` is non-nullable and DOES stomp `supportsSummary`, which is how that knob
+ *  became unreachable from a provider default; not repeating it here.) */
+public fun ResponsesQuirks.withParallelToolCallsToml(parallelToolCalls: Boolean?): ResponsesQuirks =
+    copy(liteParallelToolCalls = parallelToolCalls ?: this.liteParallelToolCalls)
 
 public enum class EffortLadder { CODEX, GROK }
 
@@ -358,9 +374,15 @@ public class ResponsesRequestBuilder(private val quirks: ResponsesQuirks) {
         body: AnthropicRequest,
         opts: BuildOptions,
     ): Boolean? = when {
-        // Unconditional on lite turns — codex-rs sends the field always, and the backend 400s a
-        // lite-header request without an explicit false (live error 2026-07-19, toolless turn).
-        quirks.isLite(opts) -> false
+        // Always PRESENT on lite turns — codex-rs sends the field always, and the backend 400s a
+        // lite-header request without an explicit value (live error 2026-07-19, toolless turn).
+        // The VALUE is a quirk (2026-07-31): codex-rs does not hardcode it either, it sends
+        // `model_info.supports_parallel_tool_calls`, a per-model configurable. Default stays false
+        // — omitting the field once left the backend default parallel ON and gpt-5.6 sprayed 30-50
+        // parallel Task calls (see the header). Note that pathology came from OMITTING the field,
+        // which is not the same as sending an explicit true; the true case is untested, which is
+        // exactly why this is an opt-in knob and not a changed default.
+        quirks.isLite(opts) -> quirks.liteParallelToolCalls
         emitToolChoice -> body.toolChoice?.disableParallelToolUse != true
         else -> null
     }

--- a/gateway/dialect-openai-responses/src/test/kotlin/PrefixStabilityDiagnostic.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/PrefixStabilityDiagnostic.kt
@@ -98,6 +98,12 @@ class PrefixStabilityDiagnostic {
                     "from there on is re-billed.\n  was: ${previous.getOrNull(d)?.take(120)}\n  " +
                     "now: ${current.getOrNull(d)?.take(120)}",
             )
+            // NON-VACUITY (review of #71 round 2): prefix-extension alone also passes when the
+            // cache injects NOTHING (a wiped/frozen/miswired cache still appends cleanly). Every
+            // round's reasoning must actually be present, or this wall cannot see the failure
+            // class it exists for.
+            val injected = current.count { it.contains("\"type\":\"reasoning\"") }
+            assertEquals(round, injected, "turn $round injected $injected reasoning items, expected $round")
             previous = current
         }
     }

--- a/gateway/dialect-openai-responses/src/test/kotlin/PrefixStabilityDiagnostic.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/PrefixStabilityDiagnostic.kt
@@ -1,0 +1,126 @@
+// WALL (prompt-cache prefix stability, 2026-07-30): end-to-end proof that consecutive turns of one
+// conversation keep turn N's input as a strict PREFIX of turn N+1's, driven by the REAL
+// ReasoningCache rather than a hand-written stub.
+//
+// WHY THIS EXISTS: OpenAI prompt caching reuses the longest stable prefix. The builder injects each
+// round's reasoning immediately before that round's FIRST function_call (ResponsesRequestBuilder
+// appendToolUse), so losing ONE round's cache entry deletes an item from the MIDDLE of the input
+// array and shifts every item after it — turn N+1 stops extending turn N and the whole remainder is
+// re-billed as fresh input. The per-turn view ("a miss degrades to no-injection") is true and hid
+// this for two months; the cross-turn view is what bills.
+//
+// Measured on live claudex telemetry before the fix: 342,473,969 tokens of known-identical prefix
+// re-sent across 6,909 continuation turns; only 7.4% of turns reused the full prefix they had
+// already paid for.
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import splice.core.parse.parseAnthropicBody
+import splice.core.turn.ReasoningDisplay
+import splice.dialect.responses.BuildOptions
+import splice.dialect.responses.InjectPriorReasoning
+import splice.dialect.responses.ReasoningCache
+import splice.dialect.responses.RequestEncryptedReasoning
+import splice.dialect.responses.ResponsesQuirks
+import splice.dialect.responses.ResponsesRequestBuilder
+import splice.dialect.responses.stablePromptCacheKey
+
+private val CODEX = ResponsesQuirks(providerTag = "claudex")
+
+private fun opts(lookup: (String) -> List<String>?) = BuildOptions(
+    compact = false,
+    originalModel = "claude-codex--gpt-5.6-sol",
+    upstreamModel = "gpt-5.6-sol",
+    configEffort = null,
+    configSummary = null,
+    showReasoning = ReasoningDisplay.from("text"),
+    replayReasoning = InjectPriorReasoning(false),
+    includeEncryptedReasoning = RequestEncryptedReasoning(true),
+    decodeReasoningEnvelope = { data ->
+        buildJsonObject {
+            put("type", JsonPrimitive("reasoning"))
+            put("encrypted_content", JsonPrimitive(data))
+        }
+    },
+    reasoningLookup = lookup,
+)
+
+/** A conversation of [rounds] completed tool round-trips, Anthropic-shaped. */
+private fun conversation(rounds: Int): String {
+    val msgs = mutableListOf("""{"role":"user","content":"start the task"}""")
+    for (i in 1..rounds) {
+        msgs += """{"role":"assistant","content":[{"type":"tool_use","id":"call_$i","name":"read","input":{"path":"f$i.kt"}}]}"""
+        msgs += """{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_$i","content":"contents of f$i"}]}"""
+    }
+    return """{"model":"m","messages":[${msgs.joinToString(",")}]}"""
+}
+
+private fun inputItems(json: String, lookup: (String) -> List<String>?): List<String> {
+    val parsed = parseAnthropicBody(json)
+    val req: JsonObject = ResponsesRequestBuilder(CODEX).build(parsed.typed, parsed.raw, opts(lookup)).req
+    return req["input"]!!.jsonArray.map { it.toString() }
+}
+
+/** Index of the first element where [b] stops matching [a]; a.size when a is a clean prefix. */
+private fun firstDivergence(a: List<String>, b: List<String>): Int {
+    val n = minOf(a.size, b.size)
+    for (i in 0 until n) if (a[i] != b[i]) return i
+    return n
+}
+
+class PrefixStabilityDiagnostic {
+
+    @Test
+    fun `a conversation outliving the TTL keeps every turn a prefix-extension of the last`() {
+        var now = 0L
+        // 100ms TTL against ~90s of simulated conversation: the ratio a multi-hour Claude Code
+        // session has against the real 30-minute TTL, compressed.
+        val cache = ReasoningCache(ttlMs = 100, clock = { now })
+        val convKey = stablePromptCacheKey(parseAnthropicBody(conversation(1)).typed)
+        val lookup: (String) -> List<String>? = { id -> cache.lookup(convKey, id) }
+
+        var previous = inputItems(conversation(0), lookup)
+        for (round in 1..12) {
+            // The stream translator captures the round's reasoning as the model emits it.
+            cache.put(convKey, listOf("call_$round"), listOf("envelope-for-call_$round"))
+            now += 60 // each turn takes 60ms -> every entry is older than the TTL within two turns
+            val current = inputItems(conversation(round), lookup)
+
+            val d = firstDivergence(previous, current)
+            assertEquals(
+                previous.size,
+                d,
+                "turn $round rewrote the prefix at index $d of ${previous.size} " +
+                    "(${"%.1f".format(100.0 * d / maxOf(previous.size, 1))}% reused) — every token " +
+                    "from there on is re-billed.\n  was: ${previous.getOrNull(d)?.take(120)}\n  " +
+                    "now: ${current.getOrNull(d)?.take(120)}",
+            )
+            previous = current
+        }
+    }
+
+    @Test
+    fun `the builder is prefix-sensitive - losing one OLD round shifts the array`() {
+        // Pins the MECHANISM (independent of cache policy): this is why the cache must never serve
+        // a partially-expired conversation. If this ever stops holding, the builder has changed
+        // shape and the cache-side contract above can be revisited.
+        val rounds = 8
+        val allCached: (String) -> List<String>? = { id -> listOf("envelope-for-$id") }
+        val turnN = inputItems(conversation(rounds), allCached)
+        val oldestGone: (String) -> List<String>? = { id ->
+            if (id == "call_1") null else listOf("envelope-for-$id")
+        }
+        val turnN1 = inputItems(conversation(rounds + 1), oldestGone)
+
+        val d = firstDivergence(turnN, turnN1)
+        assertEquals(2, d, "losing the oldest round must shift the array at its position, not the tail")
+        assertEquals(
+            turnN.size,
+            firstDivergence(turnN, inputItems(conversation(rounds + 1), allCached)),
+            "control: with nothing lost the prefix is fully reused",
+        )
+    }
+}

--- a/gateway/dialect-openai-responses/src/test/kotlin/ReasoningCacheTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ReasoningCacheTest.kt
@@ -107,36 +107,65 @@ class ReasoningCacheTest {
     }
 
     @Test
-    fun `entry-count bound evicts the oldest turn first`() {
+    fun `entry-count bound evicts the oldest CONVERSATION, sparing newer ones`() {
+        // Was "evicts the oldest turn first" (review of #71): trimming one ROUND off a live
+        // conversation leaves it half-cached, which shifts the input array mid-prefix. The unit of
+        // eviction is now the conversation.
+        val c = ReasoningCache(maxEntries = 2, clock = { 0L })
+        c.put("conv-old", listOf("call_1"), listOf("e1"))
+        c.put("conv-mid", listOf("call_2"), listOf("e2"))
+        c.put("conv-new", listOf("call_3"), listOf("e3"))
+        assertNull(c.lookup("conv-old", "call_1"), "oldest conversation evicted")
+        assertEquals(listOf("e2"), c.lookup("conv-mid", "call_2"))
+        assertEquals(listOf("e3"), c.lookup("conv-new", "call_3"))
+    }
+
+    @Test
+    fun `byte ceiling evicts whole conversations until under bound`() {
+        val c = ReasoningCache(maxTotalBytes = 10, clock = { 0L })
+        c.put("conv-old", listOf("call_1"), listOf("aaaaa"))
+        c.put("conv-mid", listOf("call_2"), listOf("bbbbb"))
+        c.put("conv-new", listOf("call_3"), listOf("ccccc"))
+        assertNull(c.lookup("conv-old", "call_1"))
+        assertEquals(listOf("bbbbb"), c.lookup("conv-mid", "call_2"))
+    }
+
+    @Test
+    fun `one oversized put evicts as many oldest conversations as the bound requires`() {
+        // review 2026-07-24: the single-eviction case left the while-loop's 2nd+ iteration untested
+        val c = ReasoningCache(maxTotalBytes = 12, clock = { 0L })
+        c.put("conv-a", listOf("call_1"), listOf("aaaaa"))
+        c.put("conv-b", listOf("call_2"), listOf("bbbbb"))
+        c.put("conv-c", listOf("call_3"), listOf("cccccccccc"))
+        assertNull(c.lookup("conv-a", "call_1"))
+        assertNull(c.lookup("conv-b", "call_2"), "the second-oldest must go too - one eviction is not enough")
+        assertEquals(listOf("cccccccccc"), c.lookup("conv-c", "call_3"))
+    }
+
+    @Test
+    fun `a conversation that overflows the bound ALONE is dropped whole and stays non-injectable`() {
+        // THE REVIEW OF #71: the earlier fallback trimmed the ACTIVE conversation one round at a
+        // time, leaving newer rounds cached and older ones not — the exact mid-prefix shift this
+        // cache exists to prevent. Wiping without a marker is not enough either: the conversation
+        // would re-cache, overflow, and wipe again, so rounds keep LOSING reasoning they had.
         val c = ReasoningCache(maxEntries = 2, clock = { 0L })
         c.put(CONV, listOf("call_1"), listOf("e1"))
         c.put(CONV, listOf("call_2"), listOf("e2"))
-        c.put(CONV, listOf("call_3"), listOf("e3"))
-        assertNull(c.lookup(CONV, "call_1"), "oldest evicted")
-        assertEquals(listOf("e2"), c.lookup(CONV, "call_2"))
-        assertEquals(listOf("e3"), c.lookup(CONV, "call_3"))
-    }
+        c.put(CONV, listOf("call_3"), listOf("e3")) // overflows on its own
 
-    @Test
-    fun `byte ceiling evicts oldest until under bound`() {
-        val c = ReasoningCache(maxTotalBytes = 10, clock = { 0L })
-        c.put(CONV, listOf("call_1"), listOf("aaaaa"))
-        c.put(CONV, listOf("call_2"), listOf("bbbbb"))
-        c.put(CONV, listOf("call_3"), listOf("ccccc"))
-        assertNull(c.lookup(CONV, "call_1"))
-        assertEquals(listOf("bbbbb"), c.lookup(CONV, "call_2"))
-    }
+        assertNull(c.lookup(CONV, "call_1"), "no partial state: every round goes")
+        assertNull(c.lookup(CONV, "call_2"))
+        assertNull(c.lookup(CONV, "call_3"))
 
-    @Test
-    fun `one oversized put evicts as many oldest entries as the bound requires`() {
-        // review 2026-07-24: the single-eviction case left the while-loop's 2nd+ iteration untested
-        val c = ReasoningCache(maxTotalBytes = 12, clock = { 0L })
-        c.put(CONV, listOf("call_1"), listOf("aaaaa"))
-        c.put(CONV, listOf("call_2"), listOf("bbbbb"))
-        c.put(CONV, listOf("call_3"), listOf("cccccccccc"))
-        assertNull(c.lookup(CONV, "call_1"))
-        assertNull(c.lookup(CONV, "call_2"), "the second-oldest must go too - one eviction is not enough")
-        assertEquals(listOf("cccccccccc"), c.lookup(CONV, "call_3"))
+        // ...and it must not creep back, or the overflow/wipe cycle restarts.
+        c.put(CONV, listOf("call_4"), listOf("e4"))
+        c.put(CONV, listOf("call_5"), listOf("e5"))
+        assertNull(c.lookup(CONV, "call_4"), "a disabled conversation must not re-cache")
+        assertNull(c.lookup(CONV, "call_5"))
+
+        // Other conversations are unaffected — the marker is per-conversation.
+        c.put("conv-other", listOf("call_9"), listOf("e9"))
+        assertEquals(listOf("e9"), c.lookup("conv-other", "call_9"))
     }
 
     @Test

--- a/gateway/dialect-openai-responses/src/test/kotlin/ReasoningCacheTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ReasoningCacheTest.kt
@@ -51,14 +51,59 @@ class ReasoningCacheTest {
     }
 
     @Test
-    fun `ttl expires entries`() {
+    fun `ttl expires IDLE entries`() {
+        // The TTL is an IDLE timer (prefix stability, 2026-07-30): untouched entries still expire
+        // exactly as before. The active-conversation case is pinned by the next two tests.
         var now = 0L
         val c = ReasoningCache(ttlMs = 100, clock = { now })
         c.put(CONV, listOf("call_a"), listOf("e1"))
         now = 99
-        assertEquals(listOf("e1"), c.lookup(CONV, "call_a"))
-        now = 101
+        assertEquals(listOf("e1"), c.lookup(CONV, "call_a"), "not yet idle-expired")
+        now = 200 // 101ms since the refresh at t=99 -> idle past the TTL
         assertNull(c.lookup(CONV, "call_a"))
+    }
+
+    @Test
+    fun `an ACTIVE conversation never partially expires - the prefix-stability contract`() {
+        // THE REGRESSION THIS PINS: the builder injects each round's reasoning immediately before
+        // that round's first function_call, so losing ONE round mid-conversation deletes an item
+        // from the middle of the input array and shifts everything after it. Turn N+1 then stops
+        // being a prefix-extension of turn N and OpenAI re-bills the remainder. Before the fix,
+        // round 1 expired on the raw insertion TTL while later rounds lived on -- measured at 7.7%
+        // prefix reuse (PrefixStabilityDiagnostic).
+        var now = 0L
+        val c = ReasoningCache(ttlMs = 100, clock = { now })
+        c.put(CONV, listOf("call_1"), listOf("e1"))
+        // A long conversation: a new round every 60ms, each turn re-reading every earlier round
+        // exactly as the builder's walk does.
+        for (round in 2..10) {
+            now += 60
+            for (earlier in 1 until round) {
+                assertEquals(
+                    listOf("e$earlier"),
+                    c.lookup(CONV, "call_$earlier"),
+                    "round $earlier vanished at t=$now while the conversation was still active",
+                )
+            }
+            c.put(CONV, listOf("call_$round"), listOf("e$round"))
+        }
+        // t=540, far beyond the 100ms TTL: every round is still resolvable, so the input array is
+        // byte-identical to the previous turn's up to the append point.
+        for (round in 1..10) assertEquals(listOf("e$round"), c.lookup(CONV, "call_$round"))
+    }
+
+    @Test
+    fun `an idle conversation expires WHOLESALE, never half`() {
+        // A clean one-time transition to no-injection beats continuous per-round churn: half a
+        // conversation is exactly the prefix-shifting state the cache must never serve.
+        var now = 0L
+        val c = ReasoningCache(ttlMs = 100, clock = { now })
+        c.put(CONV, listOf("call_1"), listOf("e1"))
+        now = 60
+        c.put(CONV, listOf("call_2"), listOf("e2"))
+        now = 130 // call_1 is idle-expired; call_2 is not
+        assertNull(c.lookup(CONV, "call_1"))
+        assertNull(c.lookup(CONV, "call_2"), "the younger round must go with it, or the prefix shifts")
     }
 
     @Test

--- a/gateway/dialect-openai-responses/src/test/kotlin/ReasoningCacheTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ReasoningCacheTest.kt
@@ -94,16 +94,19 @@ class ReasoningCacheTest {
 
     @Test
     fun `an idle conversation expires WHOLESALE, never half`() {
-        // A clean one-time transition to no-injection beats continuous per-round churn: half a
-        // conversation is exactly the prefix-shifting state the cache must never serve.
+        // One record, ONE clock: rounds inserted 161ms and 101ms ago expire together the moment
+        // the conversation's idle timer lapses — there is no per-round age to half-expire on.
+        // (Half a conversation is exactly the prefix-shifting state the cache must never serve.)
         var now = 0L
         val c = ReasoningCache(ttlMs = 100, clock = { now })
         c.put(CONV, listOf("call_1"), listOf("e1"))
         now = 60
         c.put(CONV, listOf("call_2"), listOf("e2"))
-        now = 130 // call_1 is idle-expired; call_2 is not
+        now = 130 // idle only 70ms since the last touch: BOTH still serve — no partial state
+        assertEquals(listOf("e1"), c.lookup(CONV, "call_1"))
+        now = 340 // the t=130 lookup touched the conversation; 210ms of true idle since -> gone
         assertNull(c.lookup(CONV, "call_1"))
-        assertNull(c.lookup(CONV, "call_2"), "the younger round must go with it, or the prefix shifts")
+        assertNull(c.lookup(CONV, "call_2"), "the younger round goes with its conversation")
     }
 
     @Test
@@ -142,30 +145,122 @@ class ReasoningCacheTest {
         assertEquals(listOf("cccccccccc"), c.lookup("conv-c", "call_3"))
     }
 
+    // ── review of #71 round 2: the conversation is the unit of EVERY policy ─────────────────
+    // The wipe+disable design had four confirmed holes: the disable trigger tested "writer owns
+    // the globally-oldest entry" (neighbor pressure disabled innocent conversations); touch-
+    // immortality made the 256-round cap the guaranteed end state of every long session (wipe +
+    // permanent disable at round ~257); a cross-evicted conversation re-cached into a partial
+    // group with no marker; and evictByToolId still punched per-round holes. These tests pin the
+    // replacement semantics: freeze-admission for self-overflow (old rounds keep serving — zero
+    // prefix busts), least-recently-touched NEIGHBOR eviction for cross pressure, and wholesale
+    // stale eviction.
+
     @Test
-    fun `a conversation that overflows the bound ALONE is dropped whole and stays non-injectable`() {
-        // THE REVIEW OF #71: the earlier fallback trimmed the ACTIVE conversation one round at a
-        // time, leaving newer rounds cached and older ones not — the exact mid-prefix shift this
-        // cache exists to prevent. Wiping without a marker is not enough either: the conversation
-        // would re-cache, overflow, and wipe again, so rounds keep LOSING reasoning they had.
+    fun `bound pressure evicts the LRU NEIGHBOR wholesale - the writer is never the victim`() {
+        val c = ReasoningCache(maxTotalBytes = 12, clock = { 0L })
+        c.put("conv-a", listOf("call_1"), listOf("aaaaa"))
+        c.put("conv-b", listOf("call_2"), listOf("bbbbb"))
+        c.put("conv-a", listOf("call_3"), listOf("ccc")) // 13 > 12, conv-a is writing
+        assertEquals(listOf("aaaaa"), c.lookup("conv-a", "call_1"), "the writer keeps its rounds")
+        assertEquals(listOf("ccc"), c.lookup("conv-a", "call_3"))
+        assertNull(c.lookup("conv-b", "call_2"), "the least-recently-touched neighbor went, whole")
+        c.put("conv-a", listOf("call_4"), listOf("dd"))
+        assertEquals(
+            listOf("dd"),
+            c.lookup("conv-a", "call_4"),
+            "neighbor pressure must never freeze/disable the writer (review finding 1: the old " +
+                "trigger tested oldest-entry ownership, not self-overflow)",
+        )
+    }
+
+    @Test
+    fun `a conversation that ALONE exceeds the bound freezes admission - old rounds keep serving`() {
+        val c = ReasoningCache(maxTotalBytes = 12, clock = { 0L })
+        c.put(CONV, listOf("call_1"), listOf("aaaaa"))
+        c.put(CONV, listOf("call_2"), listOf("bbbbb"))
+        c.put(CONV, listOf("call_3"), listOf("ccccc")) // would be 15 > 12, nobody else to evict
+        assertEquals(
+            listOf("aaaaa"),
+            c.lookup(CONV, "call_1"),
+            "admitted rounds keep serving — freezing admission costs only the tail, a wipe would " +
+                "bust the whole prefix once and then every remaining round (review finding 2)",
+        )
+        assertEquals(listOf("bbbbb"), c.lookup(CONV, "call_2"))
+        assertNull(
+            c.lookup(CONV, "call_3"),
+            "the overflowing round is rejected: never injected, so rejecting shifts nothing",
+        )
+        c.put(CONV, listOf("call_4"), listOf("d"))
+        assertNull(c.lookup(CONV, "call_4"), "admission stays frozen for the conversation's life")
+        // Frozen is admission-only and per-conversation: a small neighbor still caches.
+        c.put("conv-other", listOf("call_9"), listOf("e"))
+        assertEquals(listOf("e"), c.lookup("conv-other", "call_9"))
+    }
+
+    @Test
+    fun `entry-count self-overflow freezes too`() {
         val c = ReasoningCache(maxEntries = 2, clock = { 0L })
         c.put(CONV, listOf("call_1"), listOf("e1"))
         c.put(CONV, listOf("call_2"), listOf("e2"))
-        c.put(CONV, listOf("call_3"), listOf("e3")) // overflows on its own
-
-        assertNull(c.lookup(CONV, "call_1"), "no partial state: every round goes")
-        assertNull(c.lookup(CONV, "call_2"))
+        c.put(CONV, listOf("call_3"), listOf("e3"))
+        assertEquals(listOf("e1"), c.lookup(CONV, "call_1"), "a 257th-round session must not lose rounds 1..256")
+        assertEquals(listOf("e2"), c.lookup(CONV, "call_2"))
         assertNull(c.lookup(CONV, "call_3"))
+    }
 
-        // ...and it must not creep back, or the overflow/wipe cycle restarts.
-        c.put(CONV, listOf("call_4"), listOf("e4"))
-        c.put(CONV, listOf("call_5"), listOf("e5"))
-        assertNull(c.lookup(CONV, "call_4"), "a disabled conversation must not re-cache")
-        assertNull(c.lookup(CONV, "call_5"))
+    @Test
+    fun `stale eviction drops the WHOLE conversation - no partial hole survives a 400`() {
+        // review finding 4: per-round eviction left rounds 2..n injecting while round 1's hole
+        // shifted the array — permanent now that active conversations no longer age out.
+        val c = ReasoningCache(clock = { 0L })
+        c.put(CONV, listOf("call_1"), listOf("e1"))
+        c.put(CONV, listOf("call_2"), listOf("e2"))
+        c.evictByToolId("call_1")
+        assertNull(c.lookup(CONV, "call_1"))
+        assertNull(c.lookup(CONV, "call_2"), "a mid-array hole would shift the prefix on every later build")
+    }
 
-        // Other conversations are unaffected — the marker is per-conversation.
-        c.put("conv-other", listOf("call_9"), listOf("e9"))
-        assertEquals(listOf("e9"), c.lookup("conv-other", "call_9"))
+    @Test
+    fun `a client-retry re-put of the same round is grace, not growth`() {
+        // review finding 2 accelerator: duplicate puts orphaned the old entry, which still
+        // counted against the bound and dragged the conversation toward the cliff.
+        val c = ReasoningCache(maxEntries = 2, clock = { 0L })
+        c.put(CONV, listOf("call_1"), listOf("e1"))
+        c.put(CONV, listOf("call_1"), listOf("e1")) // retried request re-captures the same round
+        c.put(CONV, listOf("call_2"), listOf("e2")) // 2 real rounds — must NOT trip the bound
+        assertEquals(listOf("e1"), c.lookup(CONV, "call_1"))
+        assertEquals(listOf("e2"), c.lookup(CONV, "call_2"))
+    }
+
+    @Test
+    fun `snapshot returns every round in one atomic read and counts as ONE touch`() {
+        // The builder consumes the cache through snapshot() (review finding 14: N per-block
+        // lookups could tear across a concurrent eviction; finding 10: they re-touched N times).
+        var now = 0L
+        val c = ReasoningCache(ttlMs = 100, clock = { now })
+        c.put(CONV, listOf("call_1"), listOf("e1"))
+        now = 60
+        c.put(CONV, listOf("call_2"), listOf("e2"))
+        now = 130 // 70ms since the last touch: alive
+        val snap = c.snapshot(CONV)
+        assertEquals(listOf("e1"), snap["call_1"])
+        assertEquals(listOf("e2"), snap["call_2"])
+        assertNull(snap["call_9"], "absent ids are plain map misses")
+        now = 220 // 90ms since the snapshot's touch: still alive — snapshot refreshed the clock
+        assertEquals(listOf("e1"), c.lookup(CONV, "call_1"))
+    }
+
+    @Test
+    fun `null-key rounds keep the flat insertion TTL - the pre-rework status quo`() {
+        // A first user message with no text to hash has no conversation identity; that class
+        // keeps the original behavior (documented limitation, spike doc "not fixed").
+        var now = 0L
+        val c = ReasoningCache(ttlMs = 100, clock = { now })
+        c.put(null, listOf("call_1"), listOf("e1"))
+        now = 60
+        assertEquals(listOf("e1"), c.lookup(null, "call_1"))
+        now = 161 // 101ms past INSERTION — lookups do not refresh this class
+        assertNull(c.lookup(null, "call_1"))
     }
 
     @Test
@@ -240,7 +335,15 @@ class StripStaleReasoningTest {
     }
 
     @Test
-    fun `eviction is scoped to the dropped rounds - other rounds keep their entries`() {
+    fun `a stale 400 evicts the WHOLE conversation - the body amendment stays round-scoped`() {
+        // Was "eviction is scoped to the dropped rounds" (review of #71 round 2, finding 4): the
+        // per-round eviction it pinned left surviving rounds injecting around a permanent
+        // mid-array hole — permanent, because active conversations no longer age out. The BODY
+        // amendment is unchanged (only stale reasoning items are stripped from the request); the
+        // CACHE consequence widens to the conversation: one clean transition to no-injection,
+        // after which fresh rounds re-cache at the tail (prefix-stable). An unrelated
+        // conversation is untouched — the widening is per-conversation, not the RC-4 bug of
+        // wiping every conversation on one 400.
         val twoRounds =
             """{"model":"m","input":[""" +
                 """{"role":"user","content":"go"},""" +
@@ -253,14 +356,15 @@ class StripStaleReasoningTest {
         val cache = ReasoningCache(clock = { 0L })
         cache.put(CONV, listOf("call_a"), listOf("stale1"))
         cache.put(CONV, listOf("call_orphan"), listOf("healthy"))
+        cache.put("conv-bystander", listOf("call_z"), listOf("ez"))
         val amended = stripStaleReasoning(twoRounds, cache)!!
         assertFalse(amended.contains("\"reasoning\""))
         assertNull(cache.lookup(CONV, "call_a"), "the round under the dropped reasoning is evicted")
-        assertEquals(
-            listOf("healthy"),
+        assertNull(
             cache.lookup(CONV, "call_orphan"),
-            "a round with no reasoning item in the body had nothing stale to evict",
+            "its conversation goes with it — a surviving round would inject around a permanent hole",
         )
+        assertEquals(listOf("ez"), cache.lookup("conv-bystander", "call_z"), "other conversations untouched")
     }
 
     @Test

--- a/gateway/dialect-openai-responses/src/test/kotlin/ResponsesRequestBuilderTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ResponsesRequestBuilderTest.kt
@@ -691,19 +691,36 @@ class ToolSurfaceRequestTest {
 
     @Test
     fun `parallel_tool_calls always rides on lite turns and its VALUE is an overlay knob`() {
-        val body = """{"model":"m","messages":[{"role":"user","content":"x"}]}"""
-        fun ptc(q: ResponsesQuirks) =
-            build(body, quirks = q, options = opts(model = "gpt-5.6-sol"))["parallel_tool_calls"]
+        val toolless = """{"model":"m","messages":[{"role":"user","content":"x"}]}"""
+        val tooled = """{"model":"m","tools":[{"name":"Task","input_schema":{"type":"object"}}],
+            "messages":[{"role":"user","content":"x"}]}"""
+        fun ptc(json: String, q: ResponsesQuirks) =
+            build(json, quirks = q, options = opts(model = "gpt-5.6-sol"))["parallel_tool_calls"]
 
         // The field must be PRESENT on every lite turn — the backend 400s a lite request without
         // it (live error 2026-07-19, toolless turn), so "omit when false" is not an option.
-        assertEquals(JsonPrimitive(false), ptc(CODEX), "default is unchanged: sequential")
+        assertEquals(JsonPrimitive(false), ptc(tooled, CODEX), "default is unchanged: sequential")
         // Absent TOML must keep the provider's own default, never stomp it (the summary_field trap).
-        assertEquals(JsonPrimitive(false), ptc(CODEX.withParallelToolCallsToml(null)))
-        // ...and an explicit TOML true must actually REACH THE WIRE. A knob that unit-tests green
-        // and no-ops in the daemon is the failure mode this assertion exists for.
-        assertEquals(JsonPrimitive(true), ptc(CODEX.withParallelToolCallsToml(true)))
-        assertEquals(JsonPrimitive(false), ptc(CODEX.withParallelToolCallsToml(false)))
+        assertEquals(JsonPrimitive(false), ptc(tooled, CODEX.withParallelToolCallsToml(null)))
+        // ...and an explicit TOML true must actually REACH THE WIRE on a tooled turn. A knob that
+        // unit-tests green and no-ops in the daemon is the failure mode this assertion exists for.
+        assertEquals(JsonPrimitive(true), ptc(tooled, CODEX.withParallelToolCallsToml(true)))
+        assertEquals(JsonPrimitive(false), ptc(tooled, CODEX.withParallelToolCallsToml(false)))
+        // Knob on, TOOLLESS turn: stays false — nothing to parallelize, and explicit-true-
+        // without-tools is an untested combination upstream (review of #71 round 2).
+        assertEquals(JsonPrimitive(false), ptc(toolless, CODEX.withParallelToolCallsToml(true)))
+    }
+
+    @Test
+    fun `the client's explicit disable_parallel_tool_use beats the operator knob`() {
+        // review of #71 round 2: with the knob on, the lite branch used to short-circuit before
+        // reading tool_choice — the gateway silently overrode a request the client asked to
+        // serialize (the recorded 30-50-parallel-Task-spray shape).
+        val serial = """{"model":"m","tools":[{"name":"Task","input_schema":{"type":"object"}}],
+            "tool_choice":{"type":"auto","disable_parallel_tool_use":true},
+            "messages":[{"role":"user","content":"x"}]}"""
+        val req = build(serial, quirks = CODEX.withParallelToolCallsToml(true), options = opts(model = "gpt-5.6-sol"))
+        assertEquals(JsonPrimitive(false), req["parallel_tool_calls"])
     }
 
     @Test

--- a/gateway/dialect-openai-responses/src/test/kotlin/ResponsesRequestBuilderTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ResponsesRequestBuilderTest.kt
@@ -24,6 +24,7 @@ import splice.dialect.responses.ResponsesQuirks
 import splice.dialect.responses.ResponsesRequestBuilder
 import splice.dialect.responses.ToolDeferralPolicy
 import splice.dialect.responses.stablePromptCacheKey
+import splice.dialect.responses.withParallelToolCallsToml
 import splice.dialect.responses.withReasoningCacheToml
 
 private val CODEX = ResponsesQuirks(providerTag = "claudex")
@@ -686,5 +687,35 @@ class ToolSurfaceRequestTest {
         val input = req["input"]!!.jsonArray.map { it.jsonObject }
         assertTrue(input.none { it["type"]?.jsonPrimitive?.content == "tool_search_call" })
         assertTrue(input.none { it["type"]?.jsonPrimitive?.content == "tool_search_output" })
+    }
+
+    @Test
+    fun `parallel_tool_calls always rides on lite turns and its VALUE is an overlay knob`() {
+        val body = """{"model":"m","messages":[{"role":"user","content":"x"}]}"""
+        fun ptc(q: ResponsesQuirks) =
+            build(body, quirks = q, options = opts(model = "gpt-5.6-sol"))["parallel_tool_calls"]
+
+        // The field must be PRESENT on every lite turn — the backend 400s a lite request without
+        // it (live error 2026-07-19, toolless turn), so "omit when false" is not an option.
+        assertEquals(JsonPrimitive(false), ptc(CODEX), "default is unchanged: sequential")
+        // Absent TOML must keep the provider's own default, never stomp it (the summary_field trap).
+        assertEquals(JsonPrimitive(false), ptc(CODEX.withParallelToolCallsToml(null)))
+        // ...and an explicit TOML true must actually REACH THE WIRE. A knob that unit-tests green
+        // and no-ops in the daemon is the failure mode this assertion exists for.
+        assertEquals(JsonPrimitive(true), ptc(CODEX.withParallelToolCallsToml(true)))
+        assertEquals(JsonPrimitive(false), ptc(CODEX.withParallelToolCallsToml(false)))
+    }
+
+    @Test
+    fun `the parallel_tool_calls knob does not touch non-lite or compact turns`() {
+        val body = """{"model":"m","messages":[{"role":"user","content":"x"}]}"""
+        val on = CODEX.withParallelToolCallsToml(true)
+        // Non-lite model: the lite branch never runs, so the knob is inert and the field stays
+        // omitted (backend default) exactly as before.
+        assertNull(build(body, quirks = on, options = opts(model = "gpt-5.4-mini"))["parallel_tool_calls"])
+        // Compact turns are not lite by construction (isLite is !compact && …).
+        assertNull(
+            build(body, quirks = on, options = opts(compact = true, model = "gpt-5.6-sol"))["parallel_tool_calls"],
+        )
     }
 }

--- a/gateway/spikes/results/codex-tool-surface.md
+++ b/gateway/spikes/results/codex-tool-surface.md
@@ -1,0 +1,96 @@
+# How codex exposes tools, and why claudex takes ~2x the round-trips (2026-07-31)
+
+**Verdict: two real architectural differences. One is a knob (landed). The other is not portable
+to a proxy without splice becoming a tool executor.**
+
+Operator observation: "GPT uses a significantly higher amount of tools than kimi and grok do. I
+wonder if it has anything to do with how OpenAI handle tools in general." Also: "tools are sent in
+one object to the backend on the Codex codebase which we don't do."
+
+Both halves check out.
+
+## The measurement
+
+Same daemon, same log, all three heads:
+
+| head | turns | ends in a tool call | mean output tokens/turn |
+|---|---|---|---|
+| claudex | 24,080 | 97.4% | **386** |
+| claude-grok | 1,601 | 96.2% | 663 |
+| claude-kimi | 1,030 | 89.3% | 786 |
+
+The tool-call *rate* is the same. claudex just does about **half the work per round-trip**, so it
+needs roughly twice as many trips — and every trip re-sends the whole context (~177k tokens on a
+long session). This is the dominant cost driver for the codex head.
+
+## Difference 1: one tool call per turn (a knob, landed)
+
+`parallelToolCallsFor` sent `parallel_tool_calls = false` on **every** responses-lite turn,
+hardcoded. codex-rs does not hardcode it — it sends
+`turn_context.model_info.supports_parallel_tool_calls` (`session/turn.rs:1290`,
+`compact_remote_request.rs:66`), a per-model configurable value.
+
+So the parity claim was stronger than the reality: codex treats it as a per-model knob, splice
+treated it as a constant.
+
+It is now `[providers.codex.quirks] parallel_tool_calls`, **defaulting to false** — today's exact
+behaviour — using the nullable-overlay idiom so absent TOML can never stomp a provider default.
+
+The default did NOT change, deliberately. The recorded pathology (gpt-5.6 "spraying 30-50 parallel
+Task calls") came from **omitting the field**, which left the backend default parallel ON. That is
+not the same as sending an explicit `true`, and the explicit-`true` case has never been tested. The
+knob exists so that can be measured on one head without a rebuild or a code change.
+
+## Difference 2: codex collapses the whole tool surface into ONE `exec` tool
+
+From the installed codex 0.145.0 binary, and matching a captured `CLIENT->SERVER`
+`response.create` frame:
+
+```
+Run JavaScript code to orchestrate/compose tool calls
+- Evaluates the provided JavaScript code in a fresh V8 isolate as an async module.
+- All nested tools are available on the global `tools` object, for example
+  `await tools.exec_command(...)`. Tool names are exposed as normalized JavaScript
+  identifiers, for example `await tools.mcp__ologs__get_profile(...)`.
+- `yield_control()`: yields the accumulated output to the model immediately while the
+  script keeps running. Defaults to 10000 ms.
+Some deferred nested tools may be omitted from this description. They are still
+available on the global `tools` object and listed in `ALL_TOOLS`.
+```
+
+The captured frame carries this as a single `{"type":"additional_tools","role":"developer",
+"tools":[...]}` input item — which splice already matches structurally (`ResponsesLite.liteInput`).
+The difference is not the envelope, it is the **contents**: codex puts one `custom` tool named
+`exec` inside it, and the model composes many tool invocations in a single response by writing
+JavaScript. splice puts N individual function tools inside it, and the model calls one per turn.
+
+That is the mechanism behind the 386-vs-663 gap, and it is independent of `parallel_tool_calls`:
+codex does not need parallel tool calls because `exec` already batches.
+
+**A second consequence — deferral means different things.** codex defers only the tool's
+*description bytes*; the tool stays callable via the global `tools` object and discoverable in
+`ALL_TOOLS`. splice's deferral removes the *capability*: a deferred tool cannot be called until a
+`tool_search` round surfaces it. Live evidence that this bites: 95% of claudex turns carry 52
+deferred tools, and there have been **27 `tool search round` events in the entire log**. Those 52
+tools are effectively invisible rather than merely undescribed.
+
+## Why splice cannot simply adopt `exec`
+
+codex owns tool execution: it runs the V8 isolate in-process and dispatches `await tools.X(...)` to
+its own handlers. splice is a **proxy** — Claude Code executes the tools, and the wire contract back
+to it is Anthropic `tool_use` blocks.
+
+Adopting `exec` would mean splice hosting a JavaScript engine, and suspending the script at every
+`await tools.X(...)` to emit a `tool_use` block, wait for Claude Code to return a `tool_result`, and
+resume. That is a coroutine boundary across the proxy, plus a JS runtime, plus a changed streaming
+contract. Technically possible; it is a project, not a fix, and it is an operator decision — noted
+here rather than attempted.
+
+## Scope of this evidence, stated honestly
+
+The `exec` tool description is verbatim from the shipped binary (`strings`) and its presence in a
+real client frame is confirmed. What is NOT established: that `exec` is the *only* tool codex sends.
+The captured frames are 51,052B and 21,859B and were **display-capped during capture**, so they do
+not parse as JSON; the only tool names extractable from the visible portion are `exec`, `wait` and
+`request_user_input`. Proving the full tool list would need a re-capture without the cap. The
+round-trip measurement above does not depend on that, since it is drawn from daemon telemetry.

--- a/gateway/spikes/results/codex-tool-surface.md
+++ b/gateway/spikes/results/codex-tool-surface.md
@@ -33,13 +33,21 @@ hardcoded. codex-rs does not hardcode it — it sends
 So the parity claim was stronger than the reality: codex treats it as a per-model knob, splice
 treated it as a constant.
 
-It is now `[providers.codex.quirks] parallel_tool_calls`, **defaulting to false** — today's exact
-behaviour — using the nullable-overlay idiom so absent TOML can never stomp a provider default.
+It is now the `parallel_tool_calls` key in the codex provider's `quirks` table (add it INSIDE the
+existing inline `quirks = { ... }` — a separate `[providers.codex.quirks]` section header clashes
+with the inline table and fails to parse), **defaulting to false** — today's exact behaviour —
+using the nullable-overlay idiom so absent TOML can never stomp a provider default. It applies to
+responses-lite turns only; on non-lite turns (grok) the wire value still comes from the client's
+`tool_choice`, so setting the key there is an accepted no-op.
 
 The default did NOT change, deliberately. The recorded pathology (gpt-5.6 "spraying 30-50 parallel
 Task calls") came from **omitting the field**, which left the backend default parallel ON. That is
 not the same as sending an explicit `true`, and the explicit-`true` case has never been tested. The
-knob exists so that can be measured on one head without a rebuild or a code change.
+knob exists so that can be measured on one head without a rebuild or a code change. Two guardrails
+land with it (review of #71 round 2): a client's explicit `disable_parallel_tool_use = true` beats
+the knob (the gateway must not override a request the client asked to serialize), and toolless
+turns stay `false` (nothing to parallelize, and explicit-true-without-tools is itself an untested
+combination — probe it before assuming it is accepted).
 
 ## Difference 2: codex collapses the whole tool surface into ONE `exec` tool
 

--- a/gateway/spikes/results/prompt-cache-drain.md
+++ b/gateway/spikes/results/prompt-cache-drain.md
@@ -1,0 +1,133 @@
+# claudex prompt-cache drain: measurement, cause, fix, and what is left (2026-07-30)
+
+**Verdict: a gateway defect, now fixed. 92% of the waste came from the reasoning cache deleting
+items from the MIDDLE of the input array. The remaining 8% is a server-side effect splice does not
+control.**
+
+claudex ran a 66.6% prompt-cache hit rate against grok's 98.0% and kimi's 96.3% on the same daemon,
+same cache infrastructure. That gap is what this investigates.
+
+## Measurement
+
+Derived from 15,797 real cache-telemetry lines in `~/.claude-codex/logs/daemon.log`, over 7,056
+consecutive CONTINUATION pairs (same conversation, input grew by <20k tokens).
+
+For a prefix cache, turn N+1's input contains turn N's input as a strict prefix, so a healthy turn
+should report `cached >= previous input`. The shortfall is tokens that were provably re-sent.
+
+| fraction of the previous turn's input still cached | turns | wasted tokens | share |
+|---|---|---|---|
+| 0% (total miss) | 211 | 23,906,436 | 6.8% |
+| 1-25% | 1,378 | **249,782,104** | **71.2%** |
+| 25-50% | 377 | 35,565,279 | 10.1% |
+| 50-75% | 337 | 13,399,501 | 3.8% |
+| 75-99% | 2,729 | 26,961,485 | 7.7% |
+| ~100% (healthy) | 2,024 | 1,306,127 | 0.4% |
+| **total** | **7,056** | **350,920,932** | |
+
+Only **7.4%** of continuation turns reused the full prefix they had already paid for.
+
+The shape is the diagnosis: the 1-25% band has half as many turns as the 75-99% band but costs
+**nine times** as much. An EARLY divergence invalidates everything after it, so a handful of turns
+dominate the bill. 92% of all waste sits below 75% reuse.
+
+## Cause (the 92%)
+
+The builder injects each round's reasoning immediately before that round's FIRST `function_call`
+(`ResponsesRequestBuilder.appendToolUse`, the RC-3 path). `ReasoningCache` then expired entries on a
+30-minute **insertion** TTL and evicted **oldest-round-first** under bound pressure.
+
+Both policies drop the OLDEST round first — precisely the item sitting EARLIEST in the input array.
+Dropping it deletes an element from the middle of the array and shifts every element after it, so
+turn N+1 stops being a prefix-extension of turn N and the whole remainder is re-billed.
+
+Sessions run for hours against a 30-minute TTL, so this fired constantly.
+
+**Why it survived review.** `ReasoningCache`'s own header says losing an entry "degrades to today's
+no-injection behavior, never to an error." That is TRUE, and it is a per-turn statement. It is the
+CROSS-TURN view that bills: no single request is malformed, but two consecutive requests disagree
+about the middle of the array. Every existing test asserted one request at a time.
+
+Reproduced offline against the real builder, no network, deterministic — evicting the single oldest
+entry of an 8-round conversation:
+
+```
+CONTROL (nothing evicted):   100.0% of prefix reused
+ONE oldest entry evicted:      7.7% of prefix reused
+first divergence at index 2 of 26
+  turn N   [2]: {"type":"reasoning","encrypted_content":"envelope-for-call_1"}
+  turn N+1 [2]: {"type":"function_call","call_id":"call_1",...}
+```
+
+## Fix
+
+A conversation's entries now live and die together (`ReasoningCache`):
+
+- `lookup()` refreshes the whole conversation, making the TTL an **idle** timer. An active
+  conversation never partially expires.
+- `sweepLocked()` expires a conversation **wholesale**, so an idle one makes ONE clean transition to
+  no-injection instead of churning round by round.
+- bound eviction drops the oldest **conversation**, but never the conversation being written — a
+  single dominant conversation would otherwise wipe itself on every put, which is worse than status
+  quo. (This guard exists because the first attempt did exactly that and four existing tests caught
+  it.)
+
+Pinned by `PrefixStabilityDiagnostic`, which drives the REAL cache through a 12-round conversation
+outliving its TTL and asserts every turn extends the previous turn's prefix exactly. On the parent
+commit it fails at turn 2: *"rewrote the prefix at index 2 of 5 (40.0% reused)"*.
+
+## What is NOT fixed, and why
+
+### The 75-99% band (7.7% of waste) — server-side, not ours
+
+If this were a structural mid-array rewrite the deficit would hold a roughly constant FRACTION of
+context. It does the opposite:
+
+| context | turns | median deficit | as % of context |
+|---|---|---|---|
+| <60k | 217 | 3,586 | 7.2% |
+| 60-120k | 873 | 5,210 | 6.1% |
+| 120-200k | 1,053 | 7,334 | 4.6% |
+| >200k | 694 | 8,513 | 3.5% |
+
+A bounded absolute deficit that shrinks as a fraction of context is the newest slice of the previous
+request not yet committed to the upstream cache when the next request arrives. Only 3.0% of the band
+is under 1,024 tokens, so it is not pure block granularity either. Nothing in the gateway controls
+this.
+
+### `previous_response_id` — real, but WebSocket-only
+
+codex-rs does chain turns server-side and send only incremental items, which is why its cache
+behaviour is near-perfect. It is **not** portable to splice as it stands:
+
+- The mechanism lives entirely on codex's **v2 WebSocket** transport — `prepare_websocket_request`,
+  `ResponseCreateWsRequest`, `ResponsesWsRequest::ResponseCreate` (`codex-rs/core/src/client.rs`).
+  splice speaks HTTP SSE.
+- It requires a cached, reused per-session WebSocket connection with a `generate=false` prewarm
+  (`client.rs:16`).
+- Reuse is gated by `responses_request_properties_match` (`client.rs:307`): model, instructions,
+  tools, tool_choice, parallel_tool_calls, reasoning, store, stream, include, service_tier,
+  `prompt_cache_key` and text must ALL be identical, or the connection is not reused.
+- Note `store: provider.is_azure_responses_endpoint()` (`client.rs:921`) — store stays FALSE against
+  the ChatGPT backend. The chaining is connection state, not server-side storage, so adopting it
+  does not imply retaining conversation data upstream.
+
+Adopting it means implementing the Responses WebSocket transport plus its connection lifecycle and
+fallback logic. That is a separate project and an operator decision, not a bug fix.
+
+## Reproduce
+
+```
+cd gateway && ./gradlew :dialect-openai-responses:test --tests 'PrefixStabilityDiagnostic'
+```
+
+The telemetry analysis reads `~/.claude-codex/logs/daemon.log` directly; the daemon has no
+request-dump instrumentation, which is itself a `proxy-hardening` `W3-see-the-daemon` gap.
+
+## Scope of this evidence, stated honestly
+
+The token counts are exact and come from real turns. The attribution of the 1-25% band to reasoning
+eviction is proven for the MECHANISM (offline, deterministic) and inferred for the LIVE turns — the
+daemon logs no cache key or request bytes, so no single live turn was traced end to end. The
+predicted post-fix hit rate is therefore not stated here; it should be measured from telemetry after
+the fix has been deployed for a comparable period.

--- a/gateway/spikes/results/prompt-cache-drain.md
+++ b/gateway/spikes/results/prompt-cache-drain.md
@@ -25,7 +25,12 @@ should report `cached >= previous input`. The shortfall is tokens that were prov
 | ~100% (healthy) | 2,024 | 1,306,127 | 0.4% |
 | **total** | **7,056** | **350,920,932** | |
 
-Only **7.4%** of continuation turns reused the full prefix they had already paid for.
+Two reuse statistics, at different thresholds (they are NOT contradictory — review of #71 round 2
+flagged the ambiguity): **7.4%** of continuation turns reused the full prefix to within one
+128-token cache block (measured over 6,909 pairs from a first extraction pass with a slightly
+stricter pairing filter), while the table's ~100% band (28.7% of 7,056 pairs) uses the looser
+"≥99% of the previous input" cut, which at ~150k-token contexts allows ~1.5k tokens of slack.
+Full-prefix reuse in the strict sense was rare; near-full reuse was a minority.
 
 The shape is the diagnosis: the 1-25% band has half as many turns as the 75-99% band but costs
 **nine times** as much. An EARLY divergence invalidates everything after it, so a handful of turns
@@ -61,32 +66,48 @@ first divergence at index 2 of 26
 
 ## Fix
 
-A conversation's entries now live and die together (`ReasoningCache`):
+The **conversation is the primary cache record** (`ReasoningCache`, reworked 2026-07-31 after a
+second review round): one rounds map, ONE idle timestamp, ONE admission flag. The policies fall out
+of the data shape instead of being retrofitted onto a flat per-round map:
 
-- `lookup()` refreshes the whole conversation, making the TTL an **idle** timer. An active
-  conversation never partially expires.
-- `sweepLocked()` expires a conversation **wholesale**, so an idle one makes ONE clean transition to
-  no-injection instead of churning round by round.
-- bound eviction drops the oldest **conversation** as one unit, never a single round.
-- a conversation that overflows the bounds **by itself** is marked non-injectable and dropped whole,
-  rather than trimmed round by round.
+- every build takes ONE atomic `snapshot()` of the conversation (which is also its single touch),
+  making the TTL an **idle** timer — an active conversation never partially expires, and a build
+  can never tear across a concurrent eviction.
+- idle expiry is **wholesale by construction**: one record, one clock; there is no per-round age to
+  half-expire on.
+- bound pressure evicts the least-recently-touched **neighbor** conversation whole — never the
+  conversation being written.
+- a conversation that alone exceeds the bounds **freezes admission**: the offered round (never yet
+  injected, so rejecting it shifts nothing) is dropped and every admitted round keeps serving. The
+  tail loses its injection; the prefix never busts.
+- a stale-envelope 400 (`evictByToolId`) evicts the **whole conversation**, never a round — a
+  per-round hole in a conversation that no longer ages out would shift the prefix forever.
 
-That last point took two attempts and a review to get right, and the intermediate states are worth
-recording because both look plausible:
+It took four designs and two review rounds to get here, and the intermediate states are worth
+recording because each looks plausible:
 
 1. *Wipe the active conversation wholesale* — empties the cache on every put once the conversation
    alone exceeds the bound. Four existing tests caught it.
-2. *Fall back to oldest-round eviction for the active conversation* — passes those tests, but leaves
-   the conversation half-cached, which is precisely the mid-prefix shift this whole fix exists to
-   prevent (caught in review of #71).
-3. *Wipe wholesale AND mark the conversation non-injectable* — correct. Without the marker, a wipe
-   only trades grinding for oscillation: the conversation re-caches, overflows, wipes again, and
-   each wipe makes rounds LOSE reasoning they already had. With it there is exactly one transition,
-   then stability for the rest of that conversation's life.
+2. *Fall back to oldest-round eviction for the active conversation* — passes those tests, but
+   leaves the conversation half-cached, the exact mid-prefix shift this fix exists to prevent
+   (review round 1).
+3. *Wipe wholesale AND mark non-injectable* — shipped briefly. Review round 2 confirmed four holes
+   mechanically: the disable trigger fired on "the writer owns the globally-oldest entry" (neighbor
+   pressure permanently disabled innocent conversations); touch-immortality made the 256-round cap
+   the guaranteed end state of every long session, wiping and disabling it at round ~257; a
+   conversation evicted as a cross-pressure victim re-cached into a partial group with no marker
+   (per-cycle re-bills); and `evictByToolId` still punched per-round holes that touch-refresh then
+   kept alive forever.
+4. *Conversation-primary records with freeze-admission* — current. Freeze-admission is strictly
+   better than wipe+disable: zero prefix busts instead of one catastrophic one, and rounds already
+   paid for keep serving. A 257-round session keeps rounds 1..256 injecting; only the tail goes
+   uninjected (tail-append, prefix-stable).
 
-Pinned by `PrefixStabilityDiagnostic`, which drives the REAL cache through a 12-round conversation
-outliving its TTL and asserts every turn extends the previous turn's prefix exactly. On the parent
-commit it fails at turn 2: *"rewrote the prefix at index 2 of 5 (40.0% reused)"*.
+Pinned by `PrefixStabilityDiagnostic` (every turn both extends the previous prefix exactly AND
+actually injects every round's reasoning — the second assertion exists because prefix-extension
+alone is vacuously satisfied by a cache that injects nothing) and by `ReasoningCacheTest` pins for
+neighbor-eviction, freeze-admission, wholesale stale eviction, retry-grace, and the null-key status
+quo. All five round-2 defect pins were run RED against the wipe+disable design before the rework.
 
 ## What is NOT fixed, and why
 
@@ -126,6 +147,28 @@ behaviour is near-perfect. It is **not** portable to splice as it stands:
 
 Adopting it means implementing the Responses WebSocket transport plus its connection lifecycle and
 fallback logic. That is a separate project and an operator decision, not a bug fix.
+
+### Known residual limitations (review of #71 round 2)
+
+- **Null-key conversations** (first user message with no text blocks — image-first or
+  tool_result-first openers) have no grouping identity, so they keep the ORIGINAL flat per-round
+  insertion TTL and can still hit the mid-conversation-expiry pathology this fix removes for keyed
+  conversations. They also share one id namespace, so a cross-conversation `call_id` collision
+  inside that class could cross-inject (pre-existing; low probability; no coverage).
+- **Conversation-key fusion**: the key is a hash of the first user message's text alone, so two
+  concurrent sessions opening with byte-identical first messages (scripted `claude -p` dispatch,
+  templated subagent openers) fuse into one cache unit — shared budget, shared idle clock, shared
+  freeze. With freeze-admission the worst case is tail rounds losing injection and retention
+  extending while either session is active; nothing wipes or cross-injects.
+- **A second mid-array injection source is NOT protected**: the deferred-tool declaration pair
+  (`tool_search_call`/`tool_search_output`) that CHANGE 2 injects in history vanishes mid-array if
+  a deferred tool leaves `body.tools` (MCP disconnect, schema change) — empirically reproduced at
+  27.3% prefix reuse. Blast radius today is small (27 tool-search rounds in the whole log); it
+  belongs to the `proxy-hardening` campaign, not this fix.
+- **Retention semantics changed**: the reasoning-cache TTL is now idle-based, so an active
+  session's encrypted envelopes stay in memory for the session's lifetime rather than a fixed 30
+  minutes. SECURITY.md was updated to say so (hard caps: 256 rounds / 64 MB, wholesale eviction,
+  ciphertext only, never on disk).
 
 ## Reproduce
 

--- a/gateway/spikes/results/prompt-cache-drain.md
+++ b/gateway/spikes/results/prompt-cache-drain.md
@@ -67,10 +67,22 @@ A conversation's entries now live and die together (`ReasoningCache`):
   conversation never partially expires.
 - `sweepLocked()` expires a conversation **wholesale**, so an idle one makes ONE clean transition to
   no-injection instead of churning round by round.
-- bound eviction drops the oldest **conversation**, but never the conversation being written — a
-  single dominant conversation would otherwise wipe itself on every put, which is worse than status
-  quo. (This guard exists because the first attempt did exactly that and four existing tests caught
-  it.)
+- bound eviction drops the oldest **conversation** as one unit, never a single round.
+- a conversation that overflows the bounds **by itself** is marked non-injectable and dropped whole,
+  rather than trimmed round by round.
+
+That last point took two attempts and a review to get right, and the intermediate states are worth
+recording because both look plausible:
+
+1. *Wipe the active conversation wholesale* — empties the cache on every put once the conversation
+   alone exceeds the bound. Four existing tests caught it.
+2. *Fall back to oldest-round eviction for the active conversation* — passes those tests, but leaves
+   the conversation half-cached, which is precisely the mid-prefix shift this whole fix exists to
+   prevent (caught in review of #71).
+3. *Wipe wholesale AND mark the conversation non-injectable* — correct. Without the marker, a wipe
+   only trades grinding for oscillation: the conversation re-caches, overflows, wipes again, and
+   each wipe makes rounds LOSE reasoning they already had. With it there is exactly one transition,
+   then stability for the rest of that conversation's life.
 
 Pinned by `PrefixStabilityDiagnostic`, which drives the REAL cache through a 12-round conversation
 outliving its TTL and asserts every turn extends the previous turn's prefix exactly. On the parent

--- a/gateway/spikes/results/raw-reasoning-availability.md
+++ b/gateway/spikes/results/raw-reasoning-availability.md
@@ -1,0 +1,56 @@
+# Can splice get RAW chain-of-thought instead of summaries? (2026-07-30)
+
+**Verdict: no. The ChatGPT backend never streams raw reasoning to this client. Omitting the summary
+key yields NOTHING — not raw CoT, not a summary. Do not "fix" splice by dropping the summary field.**
+
+Operator report: "the thinking tokens are super short and summarized compared to how long and
+detailed they used to be — I want to see all verbose robust reasoning."
+
+A reading of codex-rs suggested codex OMITS `reasoning.summary` (it does — the `null` seen in an
+intercepted frame was the server normalising an absent key, not codex sending null). The obvious
+inference was that splice sends `summary: detailed` where codex sends nothing, and that raw
+reasoning would arrive if splice matched. That inference is WRONG, and the change it implies would
+have deleted reasoning output entirely.
+
+## The probe
+
+Two live streamed requests to `https://chatgpt.com/backend-api/codex/responses`, identical except
+for the `reasoning` object. Same model (`gpt-5.6-sol`), same headers splice sends (`Accept:
+text/event-stream`, `ChatGPT-Account-ID`, `originator: codex_cli_rs`, `OpenAI-Beta:
+responses=experimental`), `store: false`, `include: ["reasoning.encrypted_content"]`.
+
+| request | `reasoning` sent | summary delta chars | **raw CoT delta chars** |
+|---|---|---|---|
+| A (what splice sends today) | `{"effort":"high","summary":"detailed"}` | 44 | **0** |
+| B (codex parity) | `{"effort":"high"}` | **0** | **0** |
+
+`response.reasoning_text.delta` — the raw chain-of-thought event — arrived **zero** times in both.
+Only `response.reasoning_summary_*` events are ever emitted.
+
+## What this means
+
+1. **Raw CoT is not available over ChatGPT-backend auth.** splice already maps
+   `response.reasoning_text.delta` to thinking blocks (`ResponsesStreamTranslator`), so if the
+   backend ever sent it, it would already render. It does not send it.
+2. **Omitting `summary` removes reasoning output entirely.** Request B produced no reasoning of any
+   kind. `resolveSummary` returns null before it reads `opts.configSummary`, so a quirk-level change
+   here silently zeroes the operator's setting.
+3. **`summary: detailed` is already the most verbose available setting.** There is no untapped lever
+   in the request shape.
+
+## The one remaining lever, deliberately not touched
+
+`summaryDelivery = "sequential_cutoff"` drives `dedupeRepeatedSummaryParts`, which suppresses
+byte-identical summary parts sharing an output-index slot across continuation rounds. That is a
+known over-suppression, recorded in `ResponsesStreamTranslator` as an explicit operator call
+("an exact identity is overwhelmingly a restatement, and no-duplicates wins"), with a standing
+warning that re-keying the sets by round or item id is "the one fix NOT to make".
+
+It is the only remaining mechanism that could make delivered thinking shorter than what the backend
+sent. Changing it is an operator decision, not a defect fix, and it is left alone here.
+
+## Scope
+
+Two requests, one model, one prompt shape, one account. Establishes that raw CoT is absent on this
+path; does not establish what a different auth tier (e.g. a platform API key rather than ChatGPT
+backend) would return. Auth tokens were read from `~/.codex/auth.json` and never logged.


### PR DESCRIPTION
claudex ran a **66.6%** prompt-cache hit rate against grok's 98.0% and kimi's 96.3% — same daemon, same cache infrastructure. This is why.

## Measurement

From 15,797 real telemetry lines, over 7,056 consecutive continuation pairs. For a prefix cache, turn N+1 contains turn N's input as a strict prefix, so a healthy turn reports `cached >= previous input`. The shortfall is provably re-sent tokens.

| prefix still cached | turns | wasted tokens | share |
|---|---|---|---|
| 0% (total miss) | 211 | 23,906,436 | 6.8% |
| **1-25%** | **1,378** | **249,782,104** | **71.2%** |
| 25-75% | 714 | 48,964,780 | 13.9% |
| 75-99% | 2,729 | 26,961,485 | 7.7% |
| ~100% healthy | 2,024 | 1,306,127 | 0.4% |

**350,920,932 tokens** of known-identical prefix re-sent. Only **7.4%** of continuation turns reused the full prefix they had already paid for.

The shape is the diagnosis: the 1-25% band has half as many turns as the 75-99% band and costs **nine times** as much, because an early divergence invalidates everything after it.

## Cause

The builder injects each round's reasoning immediately before that round's first `function_call` (`appendToolUse`, the RC-3 path). `ReasoningCache` expired entries on a 30-minute **insertion** TTL and evicted **oldest-round-first**.

Both drop the OLDEST round first — precisely the item sitting EARLIEST in the input array. Dropping it deletes an element from the middle and shifts everything after it, so turn N+1 stops being a prefix-extension of turn N and the remainder is re-billed. Sessions run for hours against a 30-minute TTL.

**Why it survived review:** the file's own header says losing an entry "degrades to today's no-injection behavior, never to an error." That is true — and it is a *per-turn* statement. It is the *cross-turn* view that bills: no single request is malformed, but two consecutive requests disagree about the middle of the array. Every existing test asserted one request at a time.

## Fix

A conversation's entries now live and die together:

- `lookup()` refreshes the whole conversation → the TTL becomes an **idle** timer, so an active conversation never partially expires.
- `sweepLocked()` expires a conversation **wholesale** → an idle one makes one clean transition to no-injection instead of churning round by round.
- bound eviction drops the oldest **conversation**, never the one being written — a single dominant conversation would otherwise wipe itself on every put, which is worse than status quo. That guard exists because the first attempt did exactly that and four existing tests caught it.

## Proof

`PrefixStabilityDiagnostic` drives the **real** cache through a 12-round conversation outliving its TTL and asserts every turn extends the previous turn's prefix exactly. Red on the parent commit:

```
turn 2 rewrote the prefix at index 2 of 5 (40.0% reused)
  was: {"type":"reasoning","encrypted_content":"envelope-for-call_1"}
  now: {"type":"function_call","call_id":"call_1",...}
```

Plus `ReasoningCacheTest` pins for the active-conversation and wholesale-expiry contracts, and the unchanged idle-expiry behaviour. Full `./gradlew build` green including detekt; `ast-grep scan` clean.

## Deliberately not fixed

- **The 75-99% band (7.7%)** is upstream, not ours: a structural rewrite would hold a constant *fraction* of context, but the deficit shrinks (7.2% → 3.5% as context grows) with only 3% under one cache block. That is the newest slice of the previous request not yet committed upstream.
- **`previous_response_id`** is real but lives entirely on codex's v2 **WebSocket** transport (`prepare_websocket_request`, `ResponseCreateWsRequest`), needs a reused connection with a `generate=false` prewarm, and gates reuse on `responses_request_properties_match`. splice speaks HTTP SSE. Adopting it is a transport project and an operator call. Note `store` stays **false** against the ChatGPT backend, so it carries no upstream-retention implication.

Both are written up in `gateway/spikes/results/prompt-cache-drain.md`, along with `raw-reasoning-availability.md` — a decisive negative result showing the backend never streams raw CoT to this client, and that dropping the `summary` key yields *no reasoning at all* rather than raw thinking.

## Honesty note

Token counts are exact and from real turns. The attribution of the 1-25% band is **proven for the mechanism** (offline, deterministic) and **inferred for the live turns** — the daemon logs no cache key or request bytes, so no single live turn was traced end to end. No post-fix hit rate is claimed; it should be measured from telemetry after a comparable deployment period.

🤖 Generated with [Claude Code](https://claude.com/claude-code)