### PR TITLE
feat(ws): Responses WebSocket transport with previous_response_id chaining, default off

### DIFF
--- a/config/splice.example.toml
+++ b/config/splice.example.toml
@@ -41,6 +41,15 @@ quirks = { store = false, account_id_header = true, cache_key = "first-message-h
 # stay false. Lite-only — ignored on non-lite turns (grok's value comes from the client's
 # tool_choice). UNTESTED against the live backend: leaving the field out entirely once let the
 # backend default to parallel and gpt-5.6 sprayed 30-50 parallel Task calls. Opt in to measure.
+# websocket (default false): serve rounds over the Responses WebSocket with previous_response_id
+# chaining, so a continuation turn sends ONLY the new items instead of the whole history. Measured
+# on a 12-round tool loop: wire bytes go FLAT (~2.4KB) while the full send grows linearly — 92.5%
+# less at round 12. Add `websocket = true` INSIDE the inline quirks table above (a separate
+# [providers.codex.quirks] section would clash with it and fail to parse).
+# It is an OVERLAY: any failure — handshake, busy socket, send, first-event timeout, or a round that
+# fails before the client sees content — falls back to the normal SSE path, which keeps sole
+# ownership of retry, the 401 refresh and the 429 cooldown. With the key absent no WebSocket is ever
+# constructed and the request path is byte-identical to a build without the feature.
 [[providers.codex.models]]
 id = "gpt-5.6-sol"
 label = "Codex 5.6 Sol"

--- a/dev/campaigns/ws-transport.toml
+++ b/dev/campaigns/ws-transport.toml
@@ -49,6 +49,7 @@ verify = "cd gateway && ./gradlew :provider-spi:test --tests 'WsUpstream*'"
 # [2026-07-31] ATTEST-START: tree=5d85c5310c5e8577b97b3e19191b0a070fa4e8b6 at=2026-07-31T23:11:58Z
 # [2026-07-31] landed: WsUpstream.kt — JDK java.net.http.WebSocket, injectable connector, bounded LRU(32) registry, busy-flag single-round-per-connection, 15s first-event commit point, kill-on-anomaly (binary frame/unparseable JSON/inbox overflow/tear/cancel). Walls forced runCatchingCancellable + non-collapsed Results throughout (5 findings, all fixed, none suppressed). Compiles clean. Tests are WS-4.
 # [2026-07-31] ATTEST: scoped diffstat: .../src/main/kotlin/splice/spi/WsUpstream.kt       | 309 +++++++++++++++++++++ | 1 file changed, 309 insertions(+); sidecar: .claude/ledger-diffs/WS-1.diff; off-scope: gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesWsSession.kt, gateway/dialect-openai-responses/src/test/kotlin/ResponsesWsSessionTest.kt
+# [2026-07-31] [2026-07-31] ADVERSARIAL LOOP (wf_151e0f40-0b2, item WS-A) found 3 REAL defects in the as-shipped WsUpstream, all orchestrator-confirmed before fixing: (1) ClosedReceiveChannelException extends NoSuchElementException -> outside runCatchingCancellable's catch list, so it ESCAPED round() past withTimeoutOrNull and the caller never got the null the SSE fallback depends on — a direct NEVER-BELOW-STATUS-QUO violation; (2) sendText returns CompletableFuture (javap) so the async failure was discarded, costing the full 15s budget before fallback; (3) sendFrame's catch was inert — sendText's sync throw is IllegalStateException and runCatchingCancellable cannot catch ISE because CancellationException extends it. Fixed in 8fd4065 with receiveCatching()/await()/explicit catch. 33 lifecycle tests landed; RED-GREEN proven 7-of-33 red against cb9ee4c. Full build green, walls clean.
 
 [[items]]
 id = "WS-2"
@@ -65,7 +66,7 @@ verify = "cd gateway && ./gradlew :dialect-openai-responses:test --tests 'Respon
 [[items]]
 id = "WS-3"
 phase = "wire"
-status = "todo"
+status = "done"
 title = "Wiring: quirks.websocket (Boolean, default false) + withWebSocketToml nullable overlay + QuirksConfig websocket key; ResponsesProvider owns WsUpstream+ResponsesWsSession when enabled and exposes a wsRound hook through the Provider SPI; TurnDriver.postRound tries the WS round first (watchdog touch per frame, EVENTS_IN perf, zero-event classify parity) and falls back to upstream.post SSE on null; example TOML documents the key inside the inline quirks table."
 files = [
   "gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesRequestBuilder.kt",
@@ -77,17 +78,22 @@ files = [
   "config/splice.example.toml",
 ]
 verify = "cd gateway && ./gradlew build"
+# [2026-07-31] [2026-07-31] ESCALATED by the adversarial loop (wf_151e0f40-0b2, item WS-B). Premise auditor returned OVER_PINNED; implementer LAND_WIDENED; round-1 panel: 1 CANNOT_FAIL + 3 MISFIRES, all IN_SCOPE_DEFECT; planner+repair ran; round-2 panel STILL routed FIX_FORWARD (MISFIRES, UNVERIFIED_CLAIM, MISFIRES). Artifact preserved at scratchpad/artifact-WS-B-LAND.kt (163K). NOT APPLIED — surviving objections need orchestrator adjudication, and the session hit its quota limit mid-loop (advocate-r1:WS-A and plan:WS-A died). Next: adjudicate the round-2 objections with commands before any apply.
+# [2026-08-01] [2026-08-01] LANDED. Implemented by the orchestrator after adjudicating all 7 round-2 objections from wf_151e0f40-0b2 item WS-B; the 163K artifact was NOT applied. Design: WsRoundRunner SPI in :provider-spi (module law forbids :gateway naming a dialect type), ResponsesWsRunner in the dialect, WsRoundDriver extracted in :gateway (TurnDriver was at its LargeClass/TooManyFunctions ceiling). Objections closed: (1) CANNOT_FAIL switch -> WsQuirkWiringTest, mutation-proven 3-red on inverting the condition; (2) stale-frame leak -> pool only when inbox.isEmpty, else kill; (3) key collision -> chain key is sessionId+firstMessageHash, never the hash alone (TurnMeta gained sessionId); (4) per-turn headers dropped -> headers fold into the connection key so a changed set opens a new socket; (5) failure terminal served raw -> WsRoundNeedsSse falls back to SSE while no client frame has been emitted; (6) log hygiene -> logKey digest; (7) non-injective key encoding -> length-prefixed. Full ./gradlew build green, walls clean.
+# [2026-08-01] Attribution unavailable: missing in_flight tree snapshot
 
 [[items]]
 id = "WS-4"
 phase = "tests"
-status = "todo"
+status = "in_flight"
 title = "Tests: delta classifier driven by the REAL ResponsesRequestBuilder over a growing conversation (pure tool round -> chains with exactly the function_call_output suffix; text+tool round -> assistant message dropped in drop-phase; user continuation -> chains with the user message; deferred-tool declaration in suffix -> bail; image/unknown item -> bail; effort flip -> props mismatch full send; retry same input -> full send not double-chain); WsUpstream frame assembly + lifecycle against a scripted fake (fragmented frames, first-event timeout -> null, busy connection -> null, mid-round tear -> flow error, LRU eviction closes); TurnDriver fallback (ws null -> SSE path serves, zero behavior change with quirk off — the DEFAULT-OFF pin)."
 files = [
   "gateway/dialect-openai-responses/src/test/kotlin/ResponsesWsSessionTest.kt",
   "gateway/provider-spi/src/test/kotlin/WsUpstreamTest.kt",
 ]
 verify = "cd gateway && ./gradlew :provider-spi:test :dialect-openai-responses:test :gateway:test"
+# [2026-07-31] ATTEST-START: tree=0252f2701682c3c9362d22d53da6ae2550a1f53d at=2026-08-01T03:31:39Z
+# [2026-07-31] [2026-07-31] WsUpstream third LANDED via loop item WS-A (33 tests, 8fd4065). Remaining: the TurnDriver-fallback third, which depends on WS-3 wiring. WS-B (the wiring) ESCALATED — see WS-3 note.
 
 [[items]]
 id = "WS-5"
@@ -100,10 +106,12 @@ verify = "daemon.log shows chained rounds and no regression vs SSE baseline; ope
 [[items]]
 id = "WS-6"
 phase = "docs"
-status = "todo"
+status = "done"
 title = "Docs: spike receipt (landed with WS-0); prompt-cache-drain.md 'previous_response_id — WebSocket-only' section updated from 'separate project, not portable' to 'landed behind quirks.websocket, default off' with the chaining rules and per-connection caveat; SECURITY.md note if needed (store stays false — chaining is connection state, no upstream retention change)."
 files = [
   "gateway/spikes/results/prompt-cache-drain.md",
   "gateway/spikes/results/responses-websocket.md",
 ]
 verify = "docs state the shipped behavior, not the plan"
+# [2026-08-01] [2026-08-01] prompt-cache-drain.md updated: the previous_response_id section now records the landing (default-off quirk, measured 86% wire reduction) instead of 'a separate project'. splice.example.toml documents the websocket key.
+# [2026-08-01] Attribution unavailable: missing in_flight tree snapshot

--- a/dev/campaigns/ws-transport.toml
+++ b/dev/campaigns/ws-transport.toml
@@ -1,0 +1,109 @@
+# LAW: concept #945 — this manifest IS the memory; access ONLY via dev/campaigns/manifest.py
+# LAW [2026-07-31]: PROVENANCE — born from the live WS spike (scratchpad ws_probe.py, receipt
+#   gateway/spikes/results/responses-websocket.md): the ChatGPT codex backend accepts splice's own
+#   OAuth on wss://chatgpt.com/backend-api/codex/responses with OpenAI-Beta
+#   responses_websockets=2026-02-06, streams the SAME event vocabulary the SSE translator already
+#   consumes, and honors previous_response_id chaining with store:false (turn 2 = new items only).
+# LAW [2026-07-31]: NEVER-BELOW-STATUS-QUO — the WS path is an OVERLAY. Any failure at any stage
+#   (handshake, first-event timeout, mid-round tear, delta-classifier bail) degrades to the
+#   existing SSE full-send path, never to a client-visible error the SSE path would not have
+#   produced. A chained round that fails BEFORE the first client frame falls back to SSE in the
+#   same postRound; after the first frame it follows the existing torn-stream rules.
+# LAW [2026-07-31]: BAIL-CLOSED DELTA — the incremental send fires ONLY when the suffix beyond the
+#   last built input classifies cleanly (drop-phase: rebuilt assistant/reasoning/function_call
+#   items the server already holds; send-phase: function_call_output + user messages only).
+#   ANY unrecognized item shape ANYWHERE in the suffix -> full send. Wrong-drop risks silent
+#   context loss; wrong-send risks duplicate items; bailing costs only bytes.
+# LAW [2026-07-31]: DEFAULT OFF — ships behind [providers.*.quirks] websocket = true (nullable
+#   overlay, absent keeps false). Flipping it live is the OPERATOR's one-line TOML act, never a
+#   code default change. Chaining is additionally per-connection: reconnect => full send.
+# LAW [2026-07-31]: NO NEW DEPENDENCIES — java.net.http.WebSocket (JDK 21) only, matching the
+#   UpstreamClient Java-engine lineage. No ktor-client-websockets, no verification-metadata churn.
+# LAW [2026-07-31]: MIRROR THE PROVEN NEIGHBOR — WsUpstream mirrors UpstreamClient idioms
+#   (MonoClock, runCatchingCancellable, injectable clock/log, bounded LRU like ReasoningCache).
+
+[campaign]
+name = "ws-transport"
+goal = "Responses WebSocket transport with previous_response_id chaining for the codex head — end the full-history re-send on 95.6%-tool-round-trip traffic"
+next = "WS-1"
+
+[[items]]
+id = "WS-0"
+phase = "spike"
+status = "done"
+title = "GO/NO-GO live spike: splice OAuth opens wss://chatgpt.com/backend-api/codex/responses (101), a full response.create streams (same event vocabulary + codex.* extras the reducer ignores), and previous_response_id chaining works with store:false — turn 2 sent ONLY the new user message and answered in context. Receipt: gateway/spikes/results/responses-websocket.md. Caveats recorded: billed input still counts the full logical context (the win is structural cache stability + ~480KB->~1KB wire upload); chaining presumed per-connection; tiny-context probe proves protocol, not cache economics."
+files = ["gateway/spikes/results/responses-websocket.md"]
+verify = "receipt exists and states the three facts with caveats"
+# 2026-07-31 probe facts: turn1 resp_id resp_0c9480…, turn2 chained resp_id resp_0c9480…, both
+# response.completed; events seen: codex.rate_limits, codex.response.metadata,
+# responsesapi.websocket_timing + the standard response.* set.
+
+[[items]]
+id = "WS-1"
+phase = "transport"
+status = "done"
+title = "WsUpstream (provider-spi): java.net.http.WebSocket client — connect with per-round auth headers + OpenAI-Beta responses_websockets=2026-02-06; text-frame assembly across fragmented frames (Listener last=false accumulation); round(requestJson) sends ONE response.create frame and yields Flow<JsonObject> that completes at response.completed/failed/incomplete or errors on tear; first-event timeout (15s) returns null -> caller falls back to SSE; per-key connection map bounded LRU (32, close on evict); one in-flight round per connection (busy -> null -> SSE); dead-marking on close/error/unsolicited-frame anomalies."
+files = ["gateway/provider-spi/src/main/kotlin/splice/spi/WsUpstream.kt"]
+verify = "cd gateway && ./gradlew :provider-spi:test --tests 'WsUpstream*'"
+# [2026-07-31] CLAIM: owner=opus-main at=2026-07-31T23:11:58Z
+# [2026-07-31] ATTEST-START: tree=5d85c5310c5e8577b97b3e19191b0a070fa4e8b6 at=2026-07-31T23:11:58Z
+# [2026-07-31] landed: WsUpstream.kt — JDK java.net.http.WebSocket, injectable connector, bounded LRU(32) registry, busy-flag single-round-per-connection, 15s first-event commit point, kill-on-anomaly (binary frame/unparseable JSON/inbox overflow/tear/cancel). Walls forced runCatchingCancellable + non-collapsed Results throughout (5 findings, all fixed, none suppressed). Compiles clean. Tests are WS-4.
+# [2026-07-31] ATTEST: scoped diffstat: .../src/main/kotlin/splice/spi/WsUpstream.kt       | 309 +++++++++++++++++++++ | 1 file changed, 309 insertions(+); sidecar: .claude/ledger-diffs/WS-1.diff; off-scope: gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesWsSession.kt, gateway/dialect-openai-responses/src/test/kotlin/ResponsesWsSessionTest.kt
+
+[[items]]
+id = "WS-2"
+phase = "chaining"
+status = "done"
+title = "ResponsesWsSession (dialect-openai-responses): per-conversation chaining state {lastBuiltInput canonical item strings, lastResponseId, propsFingerprint = request JSON minus input/type/previous_response_id, connection generation} + the BAIL-CLOSED delta classifier: prefix check (lastBuiltInput elementwise == new input head) -> suffix walk: drop-phase accepts reasoning/function_call/assistant-message rebuilds of the last response, boundary at first function_call_output-or-user-message, send-phase accepts ONLY those two shapes; tool_search_*/additional_tools/developer/unknown anywhere in suffix -> bail; props mismatch -> full send; state cleared on anything but response.completed and on fallback. lastBuiltInput updates to the FULL built input after every WS round (chained or full)."
+files = ["gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesWsSession.kt"]
+verify = "cd gateway && ./gradlew :dialect-openai-responses:test --tests 'ResponsesWsSession*'"
+# [2026-07-31] CLAIM: owner=opus-main at=2026-07-31T23:17:08Z
+# [2026-07-31] ATTEST-START: tree=2646d3eef7dbc51c088d416a1e752b172ee677db at=2026-07-31T23:17:08Z
+# [2026-07-31] landed: ResponsesWsSession.kt — chaining state + BAIL-CLOSED delta classifier. 12 walls in ResponsesWsSessionTest, all driven by the REAL builder (a fixture would pin my assumptions about item shapes, which is the actual risk). Chains: pure tool round -> delta is EXACTLY [function_call_output]; assistant-text round -> assistant message dropped (server-held); user follow-up -> the user message. Bails: reconnect generation, effort flip (props), rewritten prefix, identical retry (empty delta), unknown item type, other conversation key, null response id. Measured magnitude on a 12-round loop with 2KB tool results: wire bytes FLAT at ~2385 while full send grows linearly (round 12: 31882 -> 2387, 92.5% saved; total 208674 -> 29250, 86%). Constant-vs-linear: the saving grows with conversation length.
+# [2026-07-31] ATTEST: scoped diffstat: .../splice/dialect/responses/ResponsesWsSession.kt | 140 +++++++++++++++++++++ | 1 file changed, 140 insertions(+); sidecar: .claude/ledger-diffs/WS-2.diff; off-scope: gateway/dialect-openai-responses/src/test/kotlin/ResponsesWsSessionTest.kt
+
+[[items]]
+id = "WS-3"
+phase = "wire"
+status = "todo"
+title = "Wiring: quirks.websocket (Boolean, default false) + withWebSocketToml nullable overlay + QuirksConfig websocket key; ResponsesProvider owns WsUpstream+ResponsesWsSession when enabled and exposes a wsRound hook through the Provider SPI; TurnDriver.postRound tries the WS round first (watchdog touch per frame, EVENTS_IN perf, zero-event classify parity) and falls back to upstream.post SSE on null; example TOML documents the key inside the inline quirks table."
+files = [
+  "gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesRequestBuilder.kt",
+  "gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesProvider.kt",
+  "gateway/core/src/main/kotlin/splice/core/topology/Topology.kt",
+  "gateway/app/src/main/kotlin/splice/app/Daemon.kt",
+  "gateway/gateway/src/main/kotlin/splice/gateway/head/TurnDriver.kt",
+  "gateway/provider-spi/src/main/kotlin/splice/spi/Provider.kt",
+  "config/splice.example.toml",
+]
+verify = "cd gateway && ./gradlew build"
+
+[[items]]
+id = "WS-4"
+phase = "tests"
+status = "todo"
+title = "Tests: delta classifier driven by the REAL ResponsesRequestBuilder over a growing conversation (pure tool round -> chains with exactly the function_call_output suffix; text+tool round -> assistant message dropped in drop-phase; user continuation -> chains with the user message; deferred-tool declaration in suffix -> bail; image/unknown item -> bail; effort flip -> props mismatch full send; retry same input -> full send not double-chain); WsUpstream frame assembly + lifecycle against a scripted fake (fragmented frames, first-event timeout -> null, busy connection -> null, mid-round tear -> flow error, LRU eviction closes); TurnDriver fallback (ws null -> SSE path serves, zero behavior change with quirk off — the DEFAULT-OFF pin)."
+files = [
+  "gateway/dialect-openai-responses/src/test/kotlin/ResponsesWsSessionTest.kt",
+  "gateway/provider-spi/src/test/kotlin/WsUpstreamTest.kt",
+]
+verify = "cd gateway && ./gradlew :provider-spi:test :dialect-openai-responses:test :gateway:test"
+
+[[items]]
+id = "WS-5"
+phase = "live"
+status = "todo"
+title = "Live verification (operator-gated): deploy default-off; operator flips websocket = true on the codex head; verify from daemon.log — chaining engages (ws log lines), no error-class regressions, cache hit vs the Jul-31 90% baseline, wire req_bytes collapse on chained rounds; capture the codex.rate_limits event shape and wire it into usageStore (SSE-path rate-limit headers do not exist on WS — statusline soft-warn goes stale on a WS-only head until this lands); then decide the default with the operator."
+files = []
+verify = "daemon.log shows chained rounds and no regression vs SSE baseline; operator sign-off"
+
+[[items]]
+id = "WS-6"
+phase = "docs"
+status = "todo"
+title = "Docs: spike receipt (landed with WS-0); prompt-cache-drain.md 'previous_response_id — WebSocket-only' section updated from 'separate project, not portable' to 'landed behind quirks.websocket, default off' with the chaining rules and per-connection caveat; SECURITY.md note if needed (store stays false — chaining is connection state, no upstream retention change)."
+files = [
+  "gateway/spikes/results/prompt-cache-drain.md",
+  "gateway/spikes/results/responses-websocket.md",
+]
+verify = "docs state the shipped behavior, not the plan"

--- a/gateway/app/src/main/kotlin/splice/app/Daemon.kt
+++ b/gateway/app/src/main/kotlin/splice/app/Daemon.kt
@@ -54,6 +54,7 @@ import splice.dialect.responses.withParallelToolCallsToml
 import splice.dialect.responses.withReasoningCacheToml
 import splice.dialect.responses.withToml
 import splice.dialect.responses.withToolSurfaceToml
+import splice.dialect.responses.withWebSocketToml
 import splice.gateway.compact.CompactStats
 import splice.gateway.compact.ShadowClassifier
 import splice.gateway.head.HeadDeps
@@ -510,6 +511,7 @@ public class Daemon(
         toolChoice = quirks.toolChoice,
     ).withReasoningCacheToml(quirks.reasoningCache)
         .withParallelToolCallsToml(quirks.parallelToolCalls)
+        .withWebSocketToml(quirks.webSocket)
         .withToolSurfaceToml(toolDeferralPolicy(quirks.toolSurface, cfg.toolSurfaceOff))
 
     private fun responsesProvider(ctx: ProviderBuild, label: String): Wired {

--- a/gateway/core/src/main/kotlin/splice/core/topology/Topology.kt
+++ b/gateway/core/src/main/kotlin/splice/core/topology/Topology.kt
@@ -117,6 +117,10 @@ public data class QuirksConfig(
      *  way the non-nullable summary_field above does. true lets the model batch tool calls into one
      *  turn instead of one per turn; UNTESTED against the live backend, see ResponsesQuirks. */
     @SerialName("parallel_tool_calls") val parallelToolCalls: Boolean? = null,
+    /** openai-responses only: serve rounds over the Responses WebSocket with previous_response_id
+     *  chaining (ws-transport). NULLABLE overlay — absent keeps the provider default (false), so
+     *  the feature is invisible until an operator opts in. Any failure degrades to the SSE path. */
+    @SerialName("websocket") val webSocket: Boolean? = null,
     /** openai-chat only: emit reasoning_effort/reasoning fields (DeepSeek/xAI/OpenRouter-style
      *  backends read them). null keeps the provider's own default (true); set false for strict
      *  OpenAI-compatible vendors (Fireworks — issue #21) that 400 on unrecognized fields. */

--- a/gateway/core/src/main/kotlin/splice/core/turn/Turn.kt
+++ b/gateway/core/src/main/kotlin/splice/core/turn/Turn.kt
@@ -126,6 +126,12 @@ public data class TurnMeta(
      *  gateway reasoning cache so concurrent conversations on one head can never cross-inject
      *  (review 2026-07-24, RC-2's eli-risk-8 keying). Null (chat/passthrough) = one shared scope. */
     val conversationKey: String? = null,
+    /** The client's session id when it sent one (ws-transport WS-3). [conversationKey] alone is a
+     *  hash of the first user message's TEXT, so two conversations that open with identical words
+     *  share it BY DESIGN — harmless for a cache miss, but fatal as a previous_response_id chain
+     *  anchor, where it would hand one conversation's server-side context to another. Null when
+     *  the client sends no session id; consumers must mix BOTH, never either alone. */
+    val sessionId: String? = null,
     /** Tool-surface partition sizes for THIS turn's request; null when deferral was not in play.
      *  Non-null stamps the perf counters even at zero — a deploy where tools_deferred stays 0 is a
      *  false landing, and it must be visible in one grep of the perf JSONL. */

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ReasoningCache.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ReasoningCache.kt
@@ -237,7 +237,11 @@ internal class ReasoningCache(
 
     private fun removeNullLocked(roundKey: String) {
         val round = nullRounds.remove(roundKey) ?: return
-        round.toolIds.forEach { nullByToolId.remove(it) }
+        // Remove an id ONLY while it still points at THIS round: the null-key class shares one id
+        // namespace, so a newer round re-using a tool id has already overwritten the index, and an
+        // unconditional remove would delete the LIVE mapping and lose the newer round's reasoning
+        // (review of #72).
+        round.toolIds.forEach { toolId -> if (nullByToolId[toolId] == roundKey) nullByToolId.remove(toolId) }
         totalBytes -= round.bytes
         roundCount--
     }

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesProvider.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesProvider.kt
@@ -22,6 +22,8 @@ import splice.spi.ReanchorController
 import splice.spi.StreamTranslator
 import splice.spi.TurnSignals
 import splice.spi.UpstreamClient
+import splice.spi.WsRoundRunner
+import splice.spi.WsUpstream
 
 public abstract class ResponsesProvider(
     tuning: ProviderTuning,
@@ -152,6 +154,22 @@ public abstract class ResponsesProvider(
         return ResponsesFoldController(cfg, decodeReasoningEnvelope = { decodeReasoningEnvelope(it) })
     }
 
+    /** ws-transport WS-3: non-null ONLY when the operator opted in. With the quirk off this is
+     *  null, no WsUpstream is constructed, and the request path is byte-identical to before —
+     *  the property that makes the overlay safe to ship. */
+    final override val wsRunner: WsRoundRunner? = if (!quirks.webSocket) {
+        null
+    } else {
+        ResponsesWsRunner(
+            transport = WsUpstream(log = log),
+            session = ResponsesWsSession(),
+            // Same path as upstreamUrl, on the WebSocket scheme (live spike receipt).
+            wssUrl = upstreamUrl.replaceFirst("https://", "wss://").replaceFirst("http://", "ws://"),
+            handshakeHeaders = { creds -> extraHeaders(creds) + mapOf("OpenAI-Beta" to WS_BETA_HEADER) },
+            log = log,
+        )
+    }
+
     // RC-2/RC-4: gateway-held reasoning continuity for tool round-trips (codex parity). One
     // cache per provider instance; capture and lookup wire in via buildTurn/streamTranslator.
     // The log sink surfaces the cache's two one-way transitions (freeze, bound eviction) in
@@ -209,4 +227,10 @@ public abstract class ResponsesProvider(
         if (meta.compact) null else reanchorPolicy
 
     private fun showOn(): Boolean = !showReasoning.isOff
+
+    private companion object {
+        /** The v2 Responses-WebSocket beta value codex-rs sends (codex-rs/core/src/client.rs:155),
+         *  confirmed accepted by the live backend in the WS-0 spike. */
+        const val WS_BETA_HEADER = "responses_websockets=2026-02-06"
+    }
 }

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesProvider.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesProvider.kt
@@ -7,6 +7,7 @@
 // on the stream — lives here ONCE.
 package splice.dialect.responses
 
+import splice.core.auth.Credentials
 import splice.core.parse.AnthropicTurnBody
 import splice.core.reasoning.decodeReasoningEnvelope
 import splice.core.reasoning.encodeReasoningEnvelope
@@ -154,20 +155,44 @@ public abstract class ResponsesProvider(
         return ResponsesFoldController(cfg, decodeReasoningEnvelope = { decodeReasoningEnvelope(it) })
     }
 
-    /** ws-transport WS-3: non-null ONLY when the operator opted in. With the quirk off this is
-     *  null, no WsUpstream is constructed, and the request path is byte-identical to before —
-     *  the property that makes the overlay safe to ship. */
-    final override val wsRunner: WsRoundRunner? = if (!quirks.webSocket) {
-        null
-    } else {
-        ResponsesWsRunner(
-            transport = WsUpstream(log = log),
-            session = ResponsesWsSession(),
-            // Same path as upstreamUrl, on the WebSocket scheme (live spike receipt).
-            wssUrl = upstreamUrl.replaceFirst("https://", "wss://").replaceFirst("http://", "ws://"),
-            handshakeHeaders = { creds -> extraHeaders(creds) + mapOf("OpenAI-Beta" to WS_BETA_HEADER) },
-            log = log,
-        )
+    /** Whether THIS provider's upstream actually speaks the Responses WebSocket. False by default:
+     *  the quirk table is shared by every openai-responses provider (codex, grok, openai-platform),
+     *  so an operator setting websocket = true under [providers.xai.quirks] would otherwise make
+     *  grok open a WebSocket to api.x.ai and fail every round into SSE (review of #72). Only a
+     *  provider that has PROVEN the protocol against its own upstream overrides this. */
+    protected open val supportsWebSocket: Boolean = false
+
+    /** ws-transport WS-3: non-null ONLY when the operator opted in AND this provider's upstream
+     *  was actually probed. With the quirk off no WsUpstream is constructed and the request path is
+     *  byte-identical to before the overlay landed — the property that makes it safe to ship.
+     *
+     *  LAZY, not an eager val: [supportsWebSocket] is overridden by subclasses, whose own
+     *  properties are assigned AFTER this base constructor runs. Computing it eagerly read the
+     *  override before it existed, so EVERY provider got null and the overlay could never arm —
+     *  caught by WsQuirkWiringTest, and it would have silently disabled the feature in production. */
+    final override val wsRunner: WsRoundRunner? by lazy {
+        if (!quirks.webSocket || !supportsWebSocket) {
+            null
+        } else {
+            ResponsesWsRunner(
+                transport = WsUpstream(log = log),
+                session = ResponsesWsSession(),
+                // Same path as upstreamUrl, on the WebSocket scheme (live spike receipt).
+                wssUrl = upstreamUrl.replaceFirst("https://", "wss://").replaceFirst("http://", "ws://"),
+                // Authorization is added HERE because the SSE path gets it from
+                // UpstreamClient.applyAuth, which the WS path never goes through — without it every
+                // handshake 401s and the overlay falls back to SSE forever, i.e. the feature simply
+                // cannot work (found while adjudicating the review of #72).
+                handshakeHeaders = { creds ->
+                    val auth = when (creds) {
+                        is Credentials.Bearer -> mapOf("Authorization" to "Bearer ${creds.token}")
+                        is Credentials.ApiKey -> mapOf(creds.header to "${creds.prefix}${creds.key}")
+                    }
+                    auth + extraHeaders(creds) + mapOf("OpenAI-Beta" to WS_BETA_HEADER)
+                },
+                log = log,
+            )
+        }
     }
 
     // RC-2/RC-4: gateway-held reasoning continuity for tool round-trips (codex parity). One

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesProvider.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesProvider.kt
@@ -24,7 +24,6 @@ import splice.spi.StreamTranslator
 import splice.spi.TurnSignals
 import splice.spi.UpstreamClient
 import splice.spi.WsRoundRunner
-import splice.spi.WsUpstream
 
 public abstract class ResponsesProvider(
     tuning: ProviderTuning,

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesRequestBuilder.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesRequestBuilder.kt
@@ -86,6 +86,10 @@ public data class ResponsesQuirks(
      *  the whole context. UNTESTED against the live backend — see the 30-50 parallel Task spray in
      *  this class's header, which came from omitting the field entirely. */
     val liteParallelToolCalls: Boolean = false,
+    /** ws-transport WS-3: serve rounds over the Responses WebSocket, with previous_response_id
+     *  chaining, falling back to SSE on ANY failure. DEFAULT FALSE — the overlay must be invisible
+     *  until an operator opts in, and with it off no WebSocket is ever constructed. */
+    val webSocket: Boolean = false,
     val emitToolChoice: Boolean = false,
     /** Passes through a tool's own `strict == true` as `"strict": true`; false (the default,
      *  and the only value that has ever mattered — Claude Code's ToolDefinition.strict is always
@@ -272,6 +276,7 @@ public class ResponsesRequestBuilder(private val quirks: ResponsesQuirks) {
             // The reasoning cache's conversation scope — the SAME derivation the provider's
             // lookup closure uses, so capture (which only sees TurnMeta) and injection agree.
             conversationKey = stablePromptCacheKey(body),
+            sessionId = opts.sessionId,
             // summaryParts is NOT passed: TurnMeta's default constructs the turn's one instance.
             // Every continuation round reuses this meta object (continuationRequest bypasses
             // build()), so the dedup state it carries is genuinely turn-scoped.

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesWsRunner.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesWsRunner.kt
@@ -32,7 +32,6 @@ import splice.core.turn.TurnMeta
 import splice.core.util.runCatchingCancellable
 import splice.core.util.str
 import splice.spi.WsRoundRunner
-import splice.spi.WsUpstream
 import java.security.MessageDigest
 
 /** ws-transport WS-3 overlay, NULLABLE like its siblings — absent TOML keeps the provider default
@@ -84,16 +83,17 @@ internal class ResponsesWsRunner(
             isTerminal = { it[FIELD_TYPE].str() in ResponsesRoundEnd.ALL },
         ) { conn ->
             val frame = session.frameFor(chain, request, conn.generation)
-            pending = PendingCommit(request, conn.generation)
+            // Capture the epoch the frame was built under: if anything invalidates this conversation
+            // before the terminal lands, the commit is discarded rather than resurrecting it.
+            pending = PendingCommit(request, conn.generation, session.epochOf(chain))
             if (frame.chained) log("[ws] ${logKey(key)} chained onto the previous response\n")
             frame.json
         }
-        if (flow == null) {
-            // The round never reached the wire; the chain state must not survive as an anchor for
-            // a turn that will now be served over SSE with the full history.
-            session.cleared(chain)
-            return null
-        }
+        // No clear here: the transport declining (busy / connect failure) is a BYPASS, and the head
+        // calls roundBypassed for exactly that. Clearing in both places bumped the epoch twice for
+        // one logical event and, on the busy path, threw away a concurrent round's valid state
+        // before its terminal could even be observed (review of #72).
+        if (flow == null) return null
         // Terminal observation lives HERE, not in the caller: the runner is the only party that
         // knows which events are terminal AND owns the chaining state they commit.
         return flow.onEach { event -> observeTerminal(chain, pending, event) }
@@ -107,7 +107,13 @@ internal class ResponsesWsRunner(
             session.cleared(chain)
             return
         }
-        session.completed(chain, commit.request, (event["response"] as? JsonObject)?.get("id").str(), commit.generation)
+        session.completed(
+            chain,
+            commit.request,
+            (event["response"] as? JsonObject)?.get("id").str(),
+            commit.generation,
+            commit.epoch,
+        )
     }
 
     override fun isFailureTerminal(event: JsonObject): Boolean =
@@ -125,7 +131,7 @@ internal class ResponsesWsRunner(
         chainKey(meta)?.let { session.cleared(it) }
     }
 
-    private data class PendingCommit(val request: JsonObject, val generation: Long)
+    private data class PendingCommit(val request: JsonObject, val generation: Long, val epoch: Long)
 
     /** Session id + first-message hash, or NULL when either is missing.
      *

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesWsRunner.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesWsRunner.kt
@@ -33,6 +33,7 @@ import splice.core.util.runCatchingCancellable
 import splice.core.util.str
 import splice.spi.WsRoundRunner
 import splice.spi.WsUpstream
+import java.security.MessageDigest
 
 /** ws-transport WS-3 overlay, NULLABLE like its siblings — absent TOML keeps the provider default
  *  (false). A non-nullable field would stomp the provider default; that is exactly how
@@ -66,10 +67,13 @@ internal class ResponsesWsRunner(
         turnHeaders: Map<String, String>,
         creds: Credentials,
     ): Flow<JsonObject>? {
-        val request = parseRequest(bodyJson) ?: return null
-        val headers = handshakeHeaders(creds) + turnHeaders
-        val key = connectionKey(meta, headers)
+        // No parseable body, or no isolation identity => ride SSE. The second is not a weaker key
+        // but NO key: without it, conversations sharing a first message would share a chain.
+        val request = parseRequest(bodyJson)
         val chain = chainKey(meta)
+        if (request == null || chain == null) return null
+        val headers = handshakeHeaders(creds) + turnHeaders
+        val key = connectionKey(chain, meta, headers)
         // Committed at SEND time, read at TERMINAL time: the frame the chaining layer just built
         // determines what the next turn's prefix must be, and only a clean terminal may commit it.
         var pending: PendingCommit? = null
@@ -110,24 +114,45 @@ internal class ResponsesWsRunner(
         event[FIELD_TYPE].str() in ResponsesRoundEnd.FAILED
 
     override fun roundEnded(meta: TurnMeta, ok: Boolean) {
-        if (!ok) session.cleared(chainKey(meta))
+        if (!ok) chainKey(meta)?.let { session.cleared(it) }
+    }
+
+    /** A round this overlay did NOT serve still advances the conversation, so the chain must be
+     *  dropped (review of #72): the server's chained context stops at the last WS round, and the
+     *  delta classifier would then drop the SSE turn's assistant message as "server-held" when it
+     *  is nothing of the sort — a silent context loss, not a miss. */
+    override fun roundBypassed(meta: TurnMeta) {
+        chainKey(meta)?.let { session.cleared(it) }
     }
 
     private data class PendingCommit(val request: JsonObject, val generation: Long)
 
-    /** Session id + first-message hash. NEITHER alone is sufficient: the hash alone fuses two
-     *  conversations that open with identical text (finding 1 above), and the session id alone is
-     *  absent on clients that do not send one. */
-    private fun chainKey(meta: TurnMeta): String =
-        lengthPrefixed(listOf(meta.sessionId.orEmpty(), meta.conversationKey.orEmpty()))
+    /** Session id + first-message hash, or NULL when either is missing.
+     *
+     *  Null means "do not chain, and do not reuse a socket" — enforced by the callers. Substituting
+     *  empty strings (the first cut, caught in review of #72) silently re-opened the exact collision
+     *  the two-part key exists to close: with no session id, every conversation whose first message
+     *  hashes the same shares one chain, and one conversation's server-side context answers another.
+     *  A missing isolation value is not a weaker key, it is NO key. */
+    private fun chainKey(meta: TurnMeta): String? {
+        val session = meta.sessionId?.takeIf { it.isNotEmpty() } ?: return null
+        val conversation = meta.conversationKey?.takeIf { it.isNotEmpty() } ?: return null
+        return lengthPrefixed(listOf(session, conversation))
+    }
 
-    /** The chain key plus the handshake-relevant header set (finding 2): a turn whose headers
-     *  differ must not ride a socket opened without them. */
-    private fun connectionKey(meta: TurnMeta, headers: Map<String, String>): String =
-        lengthPrefixed(
-            listOf(chainKey(meta), meta.upstreamModel) +
-                headers.toSortedMap().flatMap { (k, v) -> listOf(k, v) },
-        )
+    /** The chain key plus a DIGEST of the handshake header set. Headers must participate in
+     *  identity (a turn needing a different set must not ride a socket opened without it), but they
+     *  carry the Authorization bearer token, and this key reaches daemon.log on the busy/connect
+     *  paths. Hashing keeps identity exact while making it structurally impossible for a credential
+     *  to be logged — safer than remembering to redact at every call site (review of #72). */
+    private fun connectionKey(chain: String, meta: TurnMeta, headers: Map<String, String>): String =
+        lengthPrefixed(listOf(chain, meta.upstreamModel, headerDigest(headers)))
+
+    private fun headerDigest(headers: Map<String, String>): String {
+        val canonical = lengthPrefixed(headers.toSortedMap().flatMap { (k, v) -> listOf(k, v) })
+        val bytes = MessageDigest.getInstance("SHA-256").digest(canonical.toByteArray(Charsets.UTF_8))
+        return bytes.take(DIGEST_BYTES).joinToString("") { "%02x".format(it) }
+    }
 
     /** Injective for every String, with no reserved character (finding 3). */
     private fun lengthPrefixed(parts: List<String>): String =
@@ -146,5 +171,9 @@ internal class ResponsesWsRunner(
 
     private companion object {
         const val FIELD_TYPE = "type"
+
+        /** 8 bytes of SHA-256: collision-free enough to key a per-head connection pool, and short
+         *  enough that the key stays readable. */
+        const val DIGEST_BYTES = 8
     }
 }

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesWsRunner.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesWsRunner.kt
@@ -1,0 +1,150 @@
+// NEW: (ws-transport WS-3, 2026-08-01) the Responses side of the WS seam — everything
+// :gateway is forbidden to know (module law: :gateway may name only :core and :provider-spi).
+// It owns the round-terminal vocabulary, the chaining frame, the connection identity, and the
+// commit/clear of chaining state.
+//
+// THREE THINGS HERE EXIST BECAUSE ADVERSARIAL REVIEW FOUND THEM, each closing a silent-corruption
+// class rather than an error:
+//
+//  1. CONNECTION IDENTITY IS NOT stablePromptCacheKey. That key is a hash of the FIRST USER
+//     MESSAGE'S TEXT ONLY (ResponsesRequestBuilder.kt:752), so two conversations that open with
+//     the same words are ONE key — by design, not by collision. Used as the chain key it would
+//     hand conversation X's previous_response_id to conversation Y as its anchor, and the delta
+//     classifier cannot catch it: the very thing that makes them share a key (identical first
+//     item) is what makes Y's input look like a legitimate prefix-extension of X's. The session
+//     id is mixed in, so distinct sessions can never share a chain.
+//  2. PER-TURN HEADERS PARTICIPATE IN IDENTITY. A WebSocket's handshake headers are fixed for the
+//     socket's life, but the head's per-turn set is not — the responses-lite marker keys off
+//     `!meta.compact`, so a compact turn on the same conversation wants it OFF on a socket opened
+//     with it ON. Reusing that socket silently sends a lite-SHAPED body without its lite marker.
+//     Folding the header set into the key means a changed set opens a new connection instead.
+//  3. THE KEY ENCODING IS LENGTH-PREFIXED, not separator-joined. Any separator can appear inside a
+//     header value, and a joined key would then alias two different header sets onto one
+//     connection. Length prefixes are injective for every possible String with no reserved
+//     character at all.
+package splice.dialect.responses
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onEach
+import kotlinx.serialization.json.JsonObject
+import splice.core.auth.Credentials
+import splice.core.turn.TurnMeta
+import splice.core.util.runCatchingCancellable
+import splice.core.util.str
+import splice.spi.WsRoundRunner
+import splice.spi.WsUpstream
+
+/** ws-transport WS-3 overlay, NULLABLE like its siblings — absent TOML keeps the provider default
+ *  (false). A non-nullable field would stomp the provider default; that is exactly how
+ *  supportsSummary became an unreachable dead lever. Lives HERE, not beside its sibling overlays,
+ *  because ResponsesRequestBuilder.kt is at detekt's TooManyFunctions ceiling and this knob is
+ *  WS-specific anyway. */
+public fun ResponsesQuirks.withWebSocketToml(webSocket: Boolean?): ResponsesQuirks =
+    copy(webSocket = webSocket ?: this.webSocket)
+
+/** Round-terminal vocabulary, mirrored from ResponsesStreamTranslator.kt:352-353. Both sets end a
+ *  round: the flow must complete on EITHER, or the connection never returns to the pool and the
+ *  round hangs — strictly worse than an error. Failure terminals additionally let the head bail to
+ *  SSE while the client has still seen nothing. */
+internal object ResponsesRoundEnd {
+    val SUCCESS = setOf("response.completed", "response.done", "response.incomplete")
+    val FAILED = setOf("response.failed", "response.error", "error")
+    val ALL = SUCCESS + FAILED
+}
+
+internal class ResponsesWsRunner(
+    private val transport: WsUpstream,
+    private val session: ResponsesWsSession,
+    private val wssUrl: String,
+    private val handshakeHeaders: (Credentials) -> Map<String, String>,
+    private val log: (String) -> Unit = {},
+) : WsRoundRunner {
+
+    override suspend fun attempt(
+        bodyJson: String,
+        meta: TurnMeta,
+        turnHeaders: Map<String, String>,
+        creds: Credentials,
+    ): Flow<JsonObject>? {
+        val request = parseRequest(bodyJson) ?: return null
+        val headers = handshakeHeaders(creds) + turnHeaders
+        val key = connectionKey(meta, headers)
+        val chain = chainKey(meta)
+        // Committed at SEND time, read at TERMINAL time: the frame the chaining layer just built
+        // determines what the next turn's prefix must be, and only a clean terminal may commit it.
+        var pending: PendingCommit? = null
+        val flow = transport.round(
+            key = key,
+            headers = headers,
+            wssUrl = wssUrl,
+            isTerminal = { it[FIELD_TYPE].str() in ResponsesRoundEnd.ALL },
+        ) { conn ->
+            val frame = session.frameFor(chain, request, conn.generation)
+            pending = PendingCommit(request, conn.generation)
+            if (frame.chained) log("[ws] ${logKey(key)} chained onto the previous response\n")
+            frame.json
+        }
+        if (flow == null) {
+            // The round never reached the wire; the chain state must not survive as an anchor for
+            // a turn that will now be served over SSE with the full history.
+            session.cleared(chain)
+            return null
+        }
+        // Terminal observation lives HERE, not in the caller: the runner is the only party that
+        // knows which events are terminal AND owns the chaining state they commit.
+        return flow.onEach { event -> observeTerminal(chain, pending, event) }
+    }
+
+    private fun observeTerminal(chain: String, pending: PendingCommit?, event: JsonObject) {
+        val type = event[FIELD_TYPE].str()
+        if (type !in ResponsesRoundEnd.ALL) return
+        val commit = pending
+        if (type !in ResponsesRoundEnd.SUCCESS || commit == null) {
+            session.cleared(chain)
+            return
+        }
+        session.completed(chain, commit.request, (event["response"] as? JsonObject)?.get("id").str(), commit.generation)
+    }
+
+    override fun isFailureTerminal(event: JsonObject): Boolean =
+        event[FIELD_TYPE].str() in ResponsesRoundEnd.FAILED
+
+    override fun roundEnded(meta: TurnMeta, ok: Boolean) {
+        if (!ok) session.cleared(chainKey(meta))
+    }
+
+    private data class PendingCommit(val request: JsonObject, val generation: Long)
+
+    /** Session id + first-message hash. NEITHER alone is sufficient: the hash alone fuses two
+     *  conversations that open with identical text (finding 1 above), and the session id alone is
+     *  absent on clients that do not send one. */
+    private fun chainKey(meta: TurnMeta): String =
+        lengthPrefixed(listOf(meta.sessionId.orEmpty(), meta.conversationKey.orEmpty()))
+
+    /** The chain key plus the handshake-relevant header set (finding 2): a turn whose headers
+     *  differ must not ride a socket opened without them. */
+    private fun connectionKey(meta: TurnMeta, headers: Map<String, String>): String =
+        lengthPrefixed(
+            listOf(chainKey(meta), meta.upstreamModel) +
+                headers.toSortedMap().flatMap { (k, v) -> listOf(k, v) },
+        )
+
+    /** Injective for every String, with no reserved character (finding 3). */
+    private fun lengthPrefixed(parts: List<String>): String =
+        parts.joinToString("") { "${it.length}:$it" }
+
+    /** The operator-facing form: keys are long and carry raw client text, so daemon.log gets a
+     *  short stable digest instead of the key itself. */
+    private fun logKey(key: String): String = "ws-" + Integer.toHexString(key.hashCode())
+
+    /** A body we cannot parse is a body we must not chain: fall back to SSE, which sends the
+     *  original bytes untouched. */
+    private fun parseRequest(bodyJson: String): JsonObject? =
+        runCatchingCancellable { responsesRequestJson.parseToJsonElement(bodyJson) as? JsonObject }
+            .onFailure { log("[ws] unparseable request body — round rides SSE: ${it::class.simpleName}\n") }
+            .getOrNull()
+
+    private companion object {
+        const val FIELD_TYPE = "type"
+    }
+}

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesWsSession.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesWsSession.kt
@@ -1,0 +1,162 @@
+// NEW: (ws-transport WS-2, 2026-07-31) previous_response_id chaining state + the delta classifier.
+//
+// THE POINT: 95.6% of claudex turns are tool round-trips, and each one re-sends the entire input
+// array (~177k tokens, ~480KB) to collect a ~175-token tool call. Over a reused WebSocket the
+// server keeps the previous response's context, so a continuation turn can send ONLY the items
+// that are genuinely new (`previous_response_id` + the delta). What the server already holds, it
+// must not be handed again — a re-sent item would DUPLICATE in its context, not dedupe.
+//
+// THE LAW (campaign ws-transport, BAIL-CLOSED DELTA): the incremental frame is emitted only when
+// the new input is provably [everything the server already has] + [a suffix of exactly the shapes
+// we understand]. Anything else — a rewritten prefix, an unrecognized item type anywhere in the
+// suffix, a changed request property, a different connection generation — falls back to the FULL
+// input in the same frame. A wrong drop silently loses context; a wrong send silently duplicates
+// it; bailing costs only bytes we were already paying today. So every unknown bails.
+package splice.dialect.responses
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import splice.core.util.str
+
+/** What to send on the wire for one WS round. [chained] is diagnostics + the WS-5 instrument: the
+ *  count that must move when chaining engages, and must NOT when it bails. */
+internal data class WsFrame(val json: String, val chained: Boolean)
+
+/**
+ * Per-conversation chaining state for ONE provider. Not thread-safe by itself; the WS transport
+ * serializes rounds per conversation (one in-flight round per connection), and every method here
+ * runs inside that serialized window.
+ *
+ * State is committed ONLY on a clean terminal ([completed]); any other ending clears it, so the
+ * next round full-sends. That asymmetry is deliberate: an uncommitted response id is worthless,
+ * while a stale one would chain onto context the server never finished building.
+ */
+internal class ResponsesWsSession {
+
+    private data class Chain(
+        /** The input array we last sent LOGICALLY (full history, not the delta) — the prefix any
+         *  next turn must extend. Canonical strings, compared elementwise. */
+        val input: List<String>,
+        val responseId: String,
+        /** Everything in the request except input (and the WS-only keys, which are never in the
+         *  builder's output). The server pins these per response; a change (effort flip, tool
+         *  surface change, instruction edit) must not ride a chained turn — codex gates connection
+         *  reuse on the same set (responses_request_properties_match, client.rs:307). */
+        val props: String,
+        val generation: Long,
+    )
+
+    private val chains = HashMap<String, Chain>()
+
+    /**
+     * Build the frame for this round. [request] is the full request the builder produced.
+     * Returns the incremental frame when every chaining precondition holds, else the full frame.
+     */
+    fun frameFor(key: String, request: JsonObject, generation: Long): WsFrame {
+        val chain = chains[key]
+        val delta = if (chain == null) null else chainableDelta(chain, request, generation)
+        return if (chain == null || delta == null) {
+            WsFrame(frame(request, previousResponseId = null, input = null), chained = false)
+        } else {
+            WsFrame(frame(request, previousResponseId = chain.responseId, input = JsonArray(delta)), chained = true)
+        }
+    }
+
+    /** The items to send incrementally, or null when ANY precondition fails (bail closed). */
+    private fun chainableDelta(chain: Chain, request: JsonObject, generation: Long): List<JsonObject>? {
+        // Reconnect (server context died with the socket) or a changed pinned property.
+        val reusable = chain.generation == generation && chain.props == propsOf(request)
+        val array = (request[FIELD_INPUT] as? JsonArray)?.takeIf { reusable } ?: return null
+        val items = array.filterIsInstance<JsonObject>()
+        // A non-object item is a shape this classifier does not model, so bail: filterIsInstance
+        // would otherwise silently drop it from the comparison and produce a WRONG delta.
+        // An empty delta means the same input was re-sent (a client retry), not a continuation:
+        // chaining it would ask the server to continue from a response with nothing to react to.
+        return items.takeIf { it.size == array.size }
+            ?.let { deltaOf(chain.input, it) }
+            ?.takeIf { it.isNotEmpty() }
+    }
+
+    /** Commit after a clean terminal: the round's FULL logical input becomes the next turn's
+     *  prefix (never the delta — the server now holds the chained context PLUS what we sent). */
+    fun completed(key: String, request: JsonObject, responseId: String?, generation: Long) {
+        val input = request[FIELD_INPUT] as? JsonArray
+        if (responseId == null || input == null) {
+            chains.remove(key)
+            return
+        }
+        chains[key] = Chain(input.map { it.toString() }, responseId, propsOf(request), generation)
+    }
+
+    /** Any non-clean ending (tear, cancel, failure, SSE fallback): the next round full-sends. */
+    fun cleared(key: String) {
+        chains.remove(key)
+    }
+
+    /** [input] null = keep the request's own input array (the full send). */
+    private fun frame(request: JsonObject, previousResponseId: String?, input: JsonArray?): String =
+        buildJsonObject {
+            put("type", "response.create")
+            request.forEach { (k, v) -> if (!(k == FIELD_INPUT && input != null)) put(k, v) }
+            if (input != null) put(FIELD_INPUT, input)
+            if (previousResponseId != null) put("previous_response_id", previousResponseId)
+        }.toString()
+
+    private fun propsOf(request: JsonObject): String =
+        JsonObject(request.filterKeys { it != FIELD_INPUT }).toString()
+
+    internal companion object {
+        /** Item kinds the server ALREADY holds after the previous response: it produced them, so
+         *  the builder's rebuild of them is a duplicate that must be dropped from the delta. */
+        private val SERVER_HELD = setOf("reasoning", "function_call", "tool_search_call", "tool_search_output")
+
+        /** Item kinds that are genuinely NEW client-side input and must be sent. */
+        private val CLIENT_NEW = setOf("function_call_output", "message")
+
+        /**
+         * The suffix beyond [previous] that must be sent, or null to bail.
+         *
+         * Bails when the new input does not EXTEND the previous one elementwise (a rewritten
+         * prefix means the builder changed history — cache-key drift, a compaction, an amended
+         * body), or when the suffix holds any item that is neither a known server-held rebuild nor
+         * a known client-new item. An assistant `message` in the suffix is server-held (it produced
+         * that text) — distinguished from a user message by role.
+         */
+        fun deltaOf(previous: List<String>, current: List<JsonObject>): List<JsonObject>? {
+            if (!extendsPrefix(previous, current)) return null
+            val send = mutableListOf<JsonObject>()
+            for (item in current.drop(previous.size)) {
+                when (dispositionOf(item)) {
+                    Disposition.SERVER_HAS_IT -> Unit // it produced this; re-sending would duplicate
+                    Disposition.SEND -> send += item
+                    Disposition.BAIL -> return null
+                }
+            }
+            return send
+        }
+
+        private fun extendsPrefix(previous: List<String>, current: List<JsonObject>): Boolean =
+            current.size >= previous.size &&
+                previous.indices.all { previous[it] == current[it].toString() }
+
+        private enum class Disposition { SERVER_HAS_IT, SEND, BAIL }
+
+        private fun dispositionOf(item: JsonObject): Disposition {
+            // The builder emits plain role/content messages with no explicit `type`.
+            val type = item[FIELD_TYPE].str() ?: item[FIELD_ROLE]?.let { MESSAGE } ?: return Disposition.BAIL
+            val assistantMessage = type == MESSAGE && item[FIELD_ROLE].str() == "assistant"
+            return when {
+                type in SERVER_HELD || assistantMessage -> Disposition.SERVER_HAS_IT
+                type in CLIENT_NEW -> Disposition.SEND
+                else -> Disposition.BAIL // unknown shape
+            }
+        }
+
+        private const val FIELD_INPUT = "input"
+        private const val FIELD_TYPE = "type"
+        private const val FIELD_ROLE = "role"
+        private const val MESSAGE = "message"
+    }
+}

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesWsSession.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesWsSession.kt
@@ -48,18 +48,26 @@ internal class ResponsesWsSession {
         val generation: Long,
     )
 
-    private val chains = HashMap<String, Chain>()
+    // BOUNDED, insertion-ordered, oldest dropped at the cap (review of #72's flow map: these had
+    // no TTL or bound at all, so one daemon lifetime accumulated a record per conversation
+    // forever). Dropping a record costs that conversation one full send — today's behaviour —
+    // never a wrong chain: see epochOf for why eviction cannot resurrect stale state.
+    private val chains = LinkedHashMap<String, Chain>()
+    private val epochs = LinkedHashMap<String, Long>()
 
-    /** Per-conversation invalidation counter. A commit carries the epoch it was BUILT under and is
-     *  discarded if the epoch has moved since (review of #72): a concurrent round declined as busy,
-     *  or any bypass, rides SSE and advances the conversation, but an in-flight WS round's terminal
-     *  lands AFTER that clear and would otherwise resurrect a chain the server can no longer honour
-     *  — the next delta would then drop the SSE turn's assistant message as "server-held" when the
-     *  server never saw it. Clearing alone cannot fix an ordering problem; the epoch can. */
-    private val epochs = HashMap<String, Long>()
+    /** A MONOTONIC counter, never per-key. Each [cleared] stamps a fresh value strictly greater
+     *  than anything previously handed out, so a captured epoch can only still match when nothing
+     *  invalidated the conversation in between. */
+    private var seq = 0L
 
-    /** The current epoch for [key] — captured at send time, checked at commit time. */
-    fun epochOf(key: String): Long = epochs[key] ?: 0L
+    /** The epoch for [key] — captured at send time, checked at commit time.
+     *
+     *  An ABSENT key falls back to the current [seq], not to zero, and that is what makes eviction
+     *  safe: after a record is dropped under the cap, every previously captured epoch is strictly
+     *  LESS than [seq] (a clear always stamps ++seq), so a late commit can never match and can
+     *  never resurrect a chain the server no longer honours. Falling back to 0 would have
+     *  re-opened exactly the ordering hole the epoch exists to close. */
+    fun epochOf(key: String): Long = epochs[key] ?: seq
 
     /**
      * Build the frame for this round. [request] is the full request the builder produced.
@@ -101,14 +109,25 @@ internal class ResponsesWsSession {
             chains.remove(key)
             return
         }
+        chains.remove(key)
         chains[key] = Chain(input!!.map { it.toString() }, responseId!!, propsOf(request), generation)
+        trimLocked()
     }
 
     /** Any non-clean ending (tear, cancel, failure, SSE fallback): the next round full-sends, AND
      *  any round still in flight is barred from committing (the epoch bump). */
     fun cleared(key: String) {
         chains.remove(key)
-        epochs[key] = epochOf(key) + 1
+        epochs.remove(key)
+        epochs[key] = ++seq
+        trimLocked()
+    }
+
+    /** Drop the oldest records past the cap. Order is by last WRITE, which for a live conversation
+     *  is every completed round, so an active one is never the eviction victim. */
+    private fun trimLocked() {
+        while (chains.size > MAX_CONVERSATIONS) chains.remove(chains.keys.first())
+        while (epochs.size > MAX_CONVERSATIONS) epochs.remove(epochs.keys.first())
     }
 
     /** [input] null = keep the request's own input array (the full send). */
@@ -124,6 +143,10 @@ internal class ResponsesWsSession {
         JsonObject(request.filterKeys { it != FIELD_INPUT }).toString()
 
     internal companion object {
+        /** Same order as the reasoning cache's bound: far more than any real concurrent-session
+         *  count on one head, and an evicted record costs only a full send. */
+        const val MAX_CONVERSATIONS = 256
+
         /** Item kinds the server ALREADY holds after the previous response: it produced them, so
          *  the builder's rebuild of them is a duplicate that must be dropped from the delta. */
         private val SERVER_HELD = setOf("reasoning", "function_call", "tool_search_call", "tool_search_output")

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesWsSession.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesWsSession.kt
@@ -50,6 +50,17 @@ internal class ResponsesWsSession {
 
     private val chains = HashMap<String, Chain>()
 
+    /** Per-conversation invalidation counter. A commit carries the epoch it was BUILT under and is
+     *  discarded if the epoch has moved since (review of #72): a concurrent round declined as busy,
+     *  or any bypass, rides SSE and advances the conversation, but an in-flight WS round's terminal
+     *  lands AFTER that clear and would otherwise resurrect a chain the server can no longer honour
+     *  — the next delta would then drop the SSE turn's assistant message as "server-held" when the
+     *  server never saw it. Clearing alone cannot fix an ordering problem; the epoch can. */
+    private val epochs = HashMap<String, Long>()
+
+    /** The current epoch for [key] — captured at send time, checked at commit time. */
+    fun epochOf(key: String): Long = epochs[key] ?: 0L
+
     /**
      * Build the frame for this round. [request] is the full request the builder produced.
      * Returns the incremental frame when every chaining precondition holds, else the full frame.
@@ -81,18 +92,23 @@ internal class ResponsesWsSession {
 
     /** Commit after a clean terminal: the round's FULL logical input becomes the next turn's
      *  prefix (never the delta — the server now holds the chained context PLUS what we sent). */
-    fun completed(key: String, request: JsonObject, responseId: String?, generation: Long) {
+    fun completed(key: String, request: JsonObject, responseId: String?, generation: Long, epoch: Long) {
         val input = request[FIELD_INPUT] as? JsonArray
-        if (responseId == null || input == null) {
+        // A stale epoch means something invalidated this conversation while the round was in flight.
+        val committable = responseId != null && input != null && epoch == epochOf(key)
+        if (!committable) {
+            // Committing now would anchor the next turn onto context the server lacks.
             chains.remove(key)
             return
         }
-        chains[key] = Chain(input.map { it.toString() }, responseId, propsOf(request), generation)
+        chains[key] = Chain(input!!.map { it.toString() }, responseId!!, propsOf(request), generation)
     }
 
-    /** Any non-clean ending (tear, cancel, failure, SSE fallback): the next round full-sends. */
+    /** Any non-clean ending (tear, cancel, failure, SSE fallback): the next round full-sends, AND
+     *  any round still in flight is barred from committing (the epoch bump). */
     fun cleared(key: String) {
         chains.remove(key)
+        epochs[key] = epochOf(key) + 1
     }
 
     /** [input] null = keep the request's own input array (the full send). */

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/WsUpstream.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/WsUpstream.kt
@@ -1,4 +1,9 @@
-// NEW: (ws-transport WS-1, 2026-07-31) the Responses WebSocket transport. The ChatGPT codex
+// NEW: (ws-transport WS-1, 2026-07-31; moved out of :provider-spi 2026-08-01) the Responses
+// WebSocket transport. It lives in the DIALECT because the Responses runner is its only caller:
+// keeping it in the shared SPI exposed connection-lifecycle details no other module needs
+// (review of #72). :gateway still sees only the WsRoundRunner seam, which is all the module
+// law lets it see.
+// The Responses WebSocket transport. The ChatGPT codex
 // backend serves the Responses API over a v2 WebSocket (OpenAI-Beta: responses_websockets=…) whose
 // payload frames are the SAME JSON events the SSE body carries — one event per text message — so a
 // WS round yields the exact Flow<JsonObject> the stream translators already consume. What the WS
@@ -14,7 +19,7 @@
 //   NO NEW DEPENDENCIES — java.net.http.WebSocket (JDK 21), same lineage as UpstreamClient's Java
 //   engine. The dialect stays out of this file: the round-terminal predicate is INJECTED, so
 //   provider-spi never learns Responses event names.
-package splice.spi
+package splice.dialect.responses
 
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
@@ -27,8 +32,6 @@ import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
-import splice.core.auth.Credentials
-import splice.core.turn.TurnMeta
 import splice.core.util.runCatchingCancellable
 import java.io.IOException
 import java.net.URI
@@ -181,8 +184,19 @@ public class WsUpstream(
         }
         val conn = WsConnection(socket, inbox, generation, log)
         holder[0] = conn
+        // RACE (review of #72): two callers can both miss the lookup in acquire() and both connect.
+        // Replacing unconditionally meant the SECOND registration killed the first caller's socket —
+        // which may already have won `busy` and started streaming — aborting a live response. Under
+        // the lock we now re-check: a LIVE predecessor wins and our socket is discarded; only a dead
+        // one is replaced.
+        var winner = conn
         val evicted = synchronized(lock) {
-            connections.remove(key)?.also { it.kill() } // a dead predecessor never lingers
+            val existing = connections[key]
+            if (existing != null && !existing.dead.get()) {
+                winner = existing
+                return@synchronized null
+            }
+            connections.remove(key)?.also { it.kill() } // only ever a DEAD predecessor
             connections[key] = conn
             if (connections.size > maxConnections) {
                 // Only an IDLE connection may be evicted: an entry stays registered for the whole
@@ -194,6 +208,11 @@ public class WsUpstream(
             } else {
                 null
             }
+        }
+        if (winner !== conn) {
+            // Lost the connect race: close our redundant socket and use the live one.
+            conn.kill()
+            return winner
         }
         evicted?.kill()
         log("[ws] $key connected (generation=$generation)\n")
@@ -402,49 +421,3 @@ private val wsJson = Json {
     ignoreUnknownKeys = true
     isLenient = true
 }
-
-/**
- * The WS seam the generic head drives (ws-transport WS-3). It lives in :provider-spi because the
- * module law forbids :gateway from naming a dialect type (splice.module-law.gradle.kts:15-31), so
- * every Responses-specific decision — the round-terminal vocabulary, the chaining frame, the
- * pre-content failure test — is supplied by the provider behind this interface.
- *
- * Contract: [attempt] returns null for "serve this round over SSE", which is the answer to every
- * failure (NEVER-BELOW-STATUS-QUO). The head then runs its normal upstream POST, and SSE keeps
- * sole ownership of retry, the single-flight 401 refresh and the shared 429 cooldown (L5).
- */
-public interface WsRoundRunner {
-
-    /** Attempt one round; null = ride SSE. [turnHeaders] are the PER-TURN headers the SSE path
-     *  would send — they participate in connection identity, because a WebSocket's handshake
-     *  headers are fixed for the socket's life and a turn needing a different set must not reuse
-     *  a socket opened without it (adversarial review of WS-3: a lite marker was silently dropped). */
-    public suspend fun attempt(
-        bodyJson: String,
-        meta: TurnMeta,
-        turnHeaders: Map<String, String>,
-        creds: Credentials,
-    ): Flow<JsonObject>?
-
-    /** True when [event] ends the round in FAILURE. The head uses this to bail to SSE while the
-     *  client has still seen nothing, so an upstream error keeps SSE's retry/refresh/cooldown
-     *  rather than being served raw over the WebSocket. */
-    public fun isFailureTerminal(event: JsonObject): Boolean
-
-    /** Called once the round is over: [ok] true only for a clean, fully-consumed terminal.
-     *  Anything else must clear the chaining state — a response id that was never completed would
-     *  anchor the next turn onto context the server never finished building. */
-    public fun roundEnded(meta: TurnMeta, ok: Boolean)
-
-    /** The head served this round WITHOUT the overlay (no credentials, transport declined, or a
-     *  pre-content failure fell back). The conversation still advanced, so any chaining state must
-     *  be dropped — a chain anchored before a turn the server never saw would make the next delta
-     *  omit that turn entirely. */
-    public fun roundBypassed(meta: TurnMeta)
-}
-
-/** Thrown by the head when a WS round failed BEFORE the client saw any content, so the round is
- *  re-served over SSE. A plain RuntimeException on purpose: the stream translators' catch lists
- *  (IOException / SerializationException / IllegalArgumentException) must not swallow it, the same
- *  reason [StreamTornBeforeClient] is one. */
-public class WsRoundNeedsSse : RuntimeException("websocket round failed before any client frame")

--- a/gateway/dialect-openai-responses/src/test/kotlin/ResponsesWsRunnerTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ResponsesWsRunnerTest.kt
@@ -1,0 +1,181 @@
+// WALLS for the Responses side of the WS seam (review of #72). Three classes of finding are
+// pinned here, each one a silent-corruption path rather than an error:
+//
+//  * THE TERMINAL VOCABULARY. Six event names decide whether a round completes, hangs, or falls
+//    back. A typo in any of them is invisible to every other test, so all six are parameterized.
+//  * THE CHAIN CLEARS ON FAILURE. A chain committed from a round that did not cleanly finish
+//    would anchor the next turn onto context the server never built.
+//  * THE ISOLATION KEY. Without a session id there is no safe chain identity, and substituting an
+//    empty string re-opens the cross-conversation collision the two-part key exists to close.
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import splice.core.auth.Credentials
+import splice.core.turn.ReasoningDisplay
+import splice.core.turn.TurnMeta
+import splice.dialect.responses.ResponsesRoundEnd
+import splice.dialect.responses.ResponsesWsRunner
+import splice.dialect.responses.ResponsesWsSession
+import splice.dialect.responses.responsesRequestJson
+import splice.spi.WsUpstream
+import java.net.URI
+import java.net.http.WebSocket
+import java.util.concurrent.CompletableFuture
+
+private const val BODY = """{"model":"gpt-5.6-sol","input":[{"role":"user","content":"hi"}]}"""
+
+private fun meta(session: String? = "sess-1", conversation: String? = "splice-abc") = TurnMeta(
+    compact = false,
+    showReasoning = ReasoningDisplay.from("text"),
+    stream = true,
+    originalModel = "claude-codex--gpt-5.6-sol",
+    upstreamModel = "gpt-5.6-sol",
+    clientMaxTokens = null,
+    effort = "high",
+    summary = "detailed",
+    budgetTokens = null,
+    conversationKey = conversation,
+    sessionId = session,
+)
+
+/** A scripted socket: every send replies with the frames the script returns for that round. */
+private class Rig(private val script: (Int) -> List<String>) {
+    var rounds = 0
+    val sent = mutableListOf<String>()
+    private val transport = WsUpstream(connector = ::connect)
+    val session = ResponsesWsSession()
+    val runner = ResponsesWsRunner(
+        transport = transport,
+        session = session,
+        wssUrl = "wss://example.invalid/responses",
+        handshakeHeaders = { emptyMap() },
+    )
+
+    private var listener: WebSocket.Listener? = null
+
+    @Suppress("UNUSED_PARAMETER")
+    private fun connect(unusedUri: URI, unusedHeaders: Map<String, String>, l: WebSocket.Listener): WebSocket {
+        listener = l
+        val socket = object : WebSocket {
+            override fun sendText(data: CharSequence, last: Boolean): CompletableFuture<WebSocket> {
+                sent += data.toString()
+                val frames = script(rounds++)
+                frames.forEach { listener?.onText(this, it, true) }
+                return CompletableFuture.completedFuture(this)
+            }
+            override fun sendBinary(
+                d: java.nio.ByteBuffer,
+                l2: Boolean,
+            ) = CompletableFuture.completedFuture<WebSocket>(this)
+            override fun sendPing(m: java.nio.ByteBuffer) = CompletableFuture.completedFuture<WebSocket>(this)
+            override fun sendPong(m: java.nio.ByteBuffer) = CompletableFuture.completedFuture<WebSocket>(this)
+            override fun sendClose(c: Int, r: String) = CompletableFuture.completedFuture<WebSocket>(this)
+            override fun request(n: Long) = Unit
+            override fun getSubprotocol() = ""
+            override fun isOutputClosed() = false
+            override fun isInputClosed() = false
+            override fun abort() = Unit
+        }
+        l.onOpen(socket)
+        return socket
+    }
+
+    suspend fun round(m: TurnMeta = meta(), body: String = BODY): List<JsonObject>? =
+        runner.attempt(body, m, emptyMap(), Credentials.Bearer("tok", "acct"))
+            ?.let { flow -> mutableListOf<JsonObject>().also { out -> flow.collect { out += it } } }
+
+    fun lastSentChained(): Boolean =
+        (responsesRequestJson.parseToJsonElement(sent.last()) as JsonObject)["previous_response_id"] != null
+}
+
+private fun completed(id: String) = """{"type":"response.completed","response":{"id":"$id"}}"""
+
+class ResponsesWsRunnerTest {
+
+    /** Every SUCCESS variant must END the round — otherwise the flow never completes, the
+     *  connection never returns to the pool, and the turn HANGS (worse than any error). */
+    @ParameterizedTest
+    @ValueSource(strings = ["response.completed", "response.done", "response.incomplete"])
+    fun `each success terminal completes the round`(type: String) = runTest {
+        val rig = Rig { listOf("""{"type":"response.created"}""", """{"type":"$type","response":{"id":"r1"}}""") }
+        val seen = rig.round()
+        assertNotNull(seen, "$type must be recognised as a terminal")
+        assertEquals(listOf("response.created", type), seen!!.map { it["type"]!!.toString().trim('"') })
+    }
+
+    /** Every FAILED variant must be recognised as a failure terminal — that predicate is what lets
+     *  the head bail to SSE while the client has seen nothing, keeping retry/refresh/cooldown. */
+    @ParameterizedTest
+    @ValueSource(strings = ["response.failed", "response.error", "error"])
+    fun `each failure terminal is recognised as a failure`(type: String) = runTest {
+        val rig = Rig { listOf("""{"type":"$type"}""") }
+        val event = responsesRequestJson.parseToJsonElement("""{"type":"$type"}""") as JsonObject
+        assertTrue(rig.runner.isFailureTerminal(event), "$type must be a FAILURE terminal, not a success")
+    }
+
+    /** The vocabulary itself: six names, disjoint, and every one of them ends a round. */
+    @Test
+    fun `the terminal sets are disjoint and jointly end every round`() {
+        assertTrue(ResponsesRoundEnd.SUCCESS.intersect(ResponsesRoundEnd.FAILED).isEmpty())
+        assertEquals(ResponsesRoundEnd.SUCCESS + ResponsesRoundEnd.FAILED, ResponsesRoundEnd.ALL)
+        assertEquals(6, ResponsesRoundEnd.ALL.size)
+    }
+
+    /** A clean terminal commits the chain, so the NEXT round is a delta. */
+    @Test
+    fun `a clean terminal commits the chain and the next round chains`() = runTest {
+        val rig = Rig { i -> listOf(completed("resp_$i")) }
+        rig.round()
+        assertFalse(rig.lastSentChained(), "the first round has nothing to chain onto")
+        val grown =
+            """{"model":"gpt-5.6-sol","input":[{"role":"user","content":"hi"},{"role":"user","content":"more"}]}"""
+        rig.round(body = grown)
+        assertTrue(rig.lastSentChained(), "a committed chain must produce a previous_response_id delta")
+    }
+
+    /** THE REVIEW'S CONCERN: a FAILURE terminal must clear the chain, so the next attempt sends a
+     *  FULL request. Without this a future terminal-handling change could leave an incomplete chain
+     *  committed while the success-oriented tests above stayed green. */
+    @ParameterizedTest
+    @ValueSource(strings = ["response.failed", "response.error", "error"])
+    fun `a failure terminal clears the chain and the next round full-sends`(type: String) = runTest {
+        val rig = Rig { i -> if (i == 0) listOf(completed("resp_0")) else listOf("""{"type":"$type"}""") }
+        rig.round() // commits resp_0
+        val grown = """{"model":"gpt-5.6-sol","input":[{"role":"user","content":"hi"},{"role":"user","content":"b"}]}"""
+        rig.round(body = grown) // ends in $type -> must CLEAR
+        val grownMore =
+            """{"model":"gpt-5.6-sol","input":[{"role":"user","content":"hi"},{"role":"user","content":"b"},""" +
+                """{"role":"user","content":"c"}]}"""
+        rig.round(body = grownMore)
+        assertFalse(rig.lastSentChained(), "after a $type terminal the next round must FULL-send")
+    }
+
+    /** A round the overlay did not serve still advanced the conversation. */
+    @Test
+    fun `roundBypassed clears the chain`() = runTest {
+        val rig = Rig { i -> listOf(completed("resp_$i")) }
+        rig.round()
+        rig.runner.roundBypassed(meta())
+        val grown = """{"model":"gpt-5.6-sol","input":[{"role":"user","content":"hi"},{"role":"user","content":"b"}]}"""
+        rig.round(body = grown)
+        assertFalse(rig.lastSentChained(), "an SSE-served turn is invisible to the server chain; do not chain over it")
+    }
+
+    /** THE ISOLATION BLOCKER: no session id means NO safe chain identity. Substituting an empty
+     *  string would fuse every conversation whose first message hashes the same. */
+    @Test
+    fun `a missing session id refuses the ws path entirely`() = runTest {
+        val rig = Rig { i -> listOf(completed("resp_$i")) }
+        assertNull(rig.round(meta(session = null)), "no session id => ride SSE, never chain on a fusable key")
+        assertNull(rig.round(meta(session = "")), "an empty session id is absent, not a value")
+        assertNull(rig.round(meta(conversation = null)), "no conversation key => same refusal")
+        assertEquals(0, rig.rounds, "not one frame may reach the wire without an isolation identity")
+    }
+}

--- a/gateway/dialect-openai-responses/src/test/kotlin/ResponsesWsRunnerTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ResponsesWsRunnerTest.kt
@@ -23,8 +23,8 @@ import splice.core.turn.TurnMeta
 import splice.dialect.responses.ResponsesRoundEnd
 import splice.dialect.responses.ResponsesWsRunner
 import splice.dialect.responses.ResponsesWsSession
+import splice.dialect.responses.WsUpstream
 import splice.dialect.responses.responsesRequestJson
-import splice.spi.WsUpstream
 import java.net.URI
 import java.net.http.WebSocket
 import java.util.concurrent.CompletableFuture

--- a/gateway/dialect-openai-responses/src/test/kotlin/ResponsesWsSessionTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ResponsesWsSessionTest.kt
@@ -99,7 +99,7 @@ class ResponsesWsSessionTest {
     fun `a tool round chains and sends only the function_call_output`() {
         val s = ResponsesWsSession()
         val r1 = build(convo(1))
-        s.completed(KEY, r1, "resp_1", GEN)
+        s.completed(KEY, r1, "resp_1", GEN, s.epochOf(KEY))
         val r2 = build(convo(2))
         val f = s.frameFor(KEY, r2, GEN)
 
@@ -120,7 +120,7 @@ class ResponsesWsSessionTest {
     @Test
     fun `a round whose assistant also spoke still chains, dropping the assistant message`() {
         val s = ResponsesWsSession()
-        s.completed(KEY, build(convo(1)), "resp_1", GEN)
+        s.completed(KEY, build(convo(1)), "resp_1", GEN, s.epochOf(KEY))
         val f = s.frameFor(KEY, build(convo(2, assistantText = "thinking out loud")), GEN)
         assertTrue(f.chained)
         assertEquals(listOf("function_call_output"), typesOf(f.frameItems()))
@@ -130,7 +130,7 @@ class ResponsesWsSessionTest {
     @Test
     fun `a user follow-up chains and sends the user message`() {
         val s = ResponsesWsSession()
-        s.completed(KEY, build(convo(1)), "resp_1", GEN)
+        s.completed(KEY, build(convo(1)), "resp_1", GEN, s.epochOf(KEY))
         val f = s.frameFor(KEY, build(convo(1, trailingUserText = "and now this")), GEN)
         assertTrue(f.chained)
         val types = typesOf(f.frameItems())
@@ -142,7 +142,7 @@ class ResponsesWsSessionTest {
     @Test
     fun `a new connection generation full-sends`() {
         val s = ResponsesWsSession()
-        s.completed(KEY, build(convo(1)), "resp_1", GEN)
+        s.completed(KEY, build(convo(1)), "resp_1", GEN, s.epochOf(KEY))
         assertFalse(s.frameFor(KEY, build(convo(2)), GEN + 1).chained)
     }
 
@@ -150,7 +150,7 @@ class ResponsesWsSessionTest {
     @Test
     fun `an effort flip full-sends`() {
         val s = ResponsesWsSession()
-        s.completed(KEY, build(convo(1), effort = "high"), "resp_1", GEN)
+        s.completed(KEY, build(convo(1), effort = "high"), "resp_1", GEN, s.epochOf(KEY))
         val f = s.frameFor(KEY, build(convo(2), effort = "low"), GEN)
         assertFalse(f.chained, "reasoning.effort is pinned per response; a change must not ride a chain")
     }
@@ -159,7 +159,7 @@ class ResponsesWsSessionTest {
     @Test
     fun `a rewritten prefix full-sends`() {
         val s = ResponsesWsSession()
-        s.completed(KEY, build(convo(2)), "resp_1", GEN)
+        s.completed(KEY, build(convo(2)), "resp_1", GEN, s.epochOf(KEY))
         // A different opening message rewrites input[0] — everything after it is untrustworthy.
         val rewritten = build(
             """{"model":"m","messages":[{"role":"user","content":"DIFFERENT start"},""" +
@@ -175,7 +175,7 @@ class ResponsesWsSessionTest {
     fun `an identical retry full-sends rather than chaining an empty delta`() {
         val s = ResponsesWsSession()
         val r = build(convo(2))
-        s.completed(KEY, r, "resp_1", GEN)
+        s.completed(KEY, r, "resp_1", GEN, s.epochOf(KEY))
         assertFalse(s.frameFor(KEY, r, GEN).chained)
     }
 
@@ -185,7 +185,7 @@ class ResponsesWsSessionTest {
     fun `an unknown item type in the suffix full-sends`() {
         val s = ResponsesWsSession()
         val base = build(convo(1))
-        s.completed(KEY, base, "resp_1", GEN)
+        s.completed(KEY, base, "resp_1", GEN, s.epochOf(KEY))
         val withAlien = JsonObject(
             base.toMutableMap().apply {
                 put(
@@ -197,15 +197,41 @@ class ResponsesWsSessionTest {
         assertFalse(s.frameFor(KEY, withAlien, GEN).chained)
     }
 
+    /** THE EPOCH FENCE (review of #72). Clearing alone cannot fix an ORDERING problem: a bypass
+     *  clears while a WS round is still in flight, and that round's terminal lands afterwards. Its
+     *  commit must be discarded, or the next turn chains onto context the server never got. */
+    @Test
+    fun `a commit built before an invalidation is discarded, not resurrected`() {
+        val s = ResponsesWsSession()
+        val r1 = build(convo(1))
+        val epochAtSend = s.epochOf(KEY) // the in-flight round captures this...
+        s.cleared(KEY) // ...then something bypasses (busy round rides SSE)
+        s.completed(KEY, r1, "resp_1", GEN, epochAtSend) // ...and the terminal lands LATE
+        assertFalse(
+            s.frameFor(KEY, build(convo(2)), GEN).chained,
+            "a stale-epoch commit must NOT resurrect the chain — the next round full-sends",
+        )
+    }
+
+    /** The fence must not block the normal path: a commit under the CURRENT epoch still applies. */
+    @Test
+    fun `a commit under the current epoch still chains`() {
+        val s = ResponsesWsSession()
+        s.cleared(KEY) // epoch moves; a round STARTED AFTER it captures the new value
+        val r1 = build(convo(1))
+        s.completed(KEY, r1, "resp_1", GEN, s.epochOf(KEY))
+        assertTrue(s.frameFor(KEY, build(convo(2)), GEN).chained)
+    }
+
     /** State is committed only on a clean terminal; a tear/cancel must not leave a chain behind. */
     @Test
     fun `a cleared conversation full-sends, and a null response id never commits`() {
         val s = ResponsesWsSession()
-        s.completed(KEY, build(convo(1)), "resp_1", GEN)
+        s.completed(KEY, build(convo(1)), "resp_1", GEN, s.epochOf(KEY))
         s.cleared(KEY)
         assertFalse(s.frameFor(KEY, build(convo(2)), GEN).chained)
 
-        s.completed(KEY, build(convo(1)), null, GEN)
+        s.completed(KEY, build(convo(1)), null, GEN, s.epochOf(KEY))
         assertFalse(s.frameFor(KEY, build(convo(2)), GEN).chained, "a terminal without an id is not chainable")
     }
 
@@ -213,7 +239,7 @@ class ResponsesWsSessionTest {
     @Test
     fun `chains are scoped per conversation key`() {
         val s = ResponsesWsSession()
-        s.completed(KEY, build(convo(1)), "resp_1", GEN)
+        s.completed(KEY, build(convo(1)), "resp_1", GEN, s.epochOf(KEY))
         assertFalse(s.frameFor("other-conv", build(convo(2)), GEN).chained)
     }
 

--- a/gateway/dialect-openai-responses/src/test/kotlin/ResponsesWsSessionTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ResponsesWsSessionTest.kt
@@ -1,0 +1,230 @@
+// WALLS for the WS delta classifier (ws-transport WS-2/WS-4). Driven by the REAL
+// ResponsesRequestBuilder over a growing conversation — a hand-written fixture would pin my
+// ASSUMPTIONS about item shapes, and the whole risk here is that the real shapes differ.
+//
+// The failure modes these guard, in the order they would hurt:
+//   wrong DROP  -> the server never sees an item; the model answers without context, silently
+//   wrong SEND  -> the server sees an item twice; duplicated tool results, silently
+//   wrong BAIL  -> a full send; costs bytes we already pay today (the acceptable failure)
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import splice.core.parse.parseAnthropicBody
+import splice.core.turn.ReasoningDisplay
+import splice.dialect.responses.BuildOptions
+import splice.dialect.responses.InjectPriorReasoning
+import splice.dialect.responses.RequestEncryptedReasoning
+import splice.dialect.responses.ResponsesQuirks
+import splice.dialect.responses.ResponsesRequestBuilder
+import splice.dialect.responses.ResponsesWsSession
+
+private val CODEX = ResponsesQuirks(providerTag = "claudex")
+private const val KEY = "conv-1"
+private const val GEN = 7L
+
+private fun opts(effort: String? = null) = BuildOptions(
+    compact = false,
+    originalModel = "claude-codex--gpt-5.6-sol",
+    upstreamModel = "gpt-5.6-sol",
+    configEffort = effort,
+    configSummary = null,
+    showReasoning = ReasoningDisplay.from("text"),
+    replayReasoning = InjectPriorReasoning(false),
+    includeEncryptedReasoning = RequestEncryptedReasoning(true),
+    decodeReasoningEnvelope = { data ->
+        buildJsonObject {
+            put("type", JsonPrimitive("reasoning"))
+            put("id", JsonPrimitive("rs_$data"))
+            put("encrypted_content", JsonPrimitive(data))
+        }
+    },
+    reasoningLookup = { id -> listOf("env-$id") },
+)
+
+private fun build(json: String, effort: String? = null): JsonObject =
+    parseAnthropicBody(json).let { ResponsesRequestBuilder(CODEX).build(it.typed, it.raw, opts(effort)).req }
+
+/** A conversation after [rounds] completed tool round-trips, optionally with a trailing text turn. */
+private fun convo(rounds: Int, trailingUserText: String? = null, assistantText: String? = null): String {
+    val msgs = mutableListOf("""{"role":"user","content":"start"}""")
+    for (i in 1..rounds) {
+        val text = if (i == rounds && assistantText != null) {
+            """{"type":"text","text":"$assistantText"},"""
+        } else {
+            ""
+        }
+        msgs += """{"role":"assistant","content":[$text{"type":"tool_use","id":"call_$i","name":"read","input":{"p":"$i"}}]}"""
+        msgs += """{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_$i","content":"out$i"}]}"""
+    }
+    if (trailingUserText != null) msgs += """{"role":"user","content":"$trailingUserText"}"""
+    return """{"model":"m","messages":[${msgs.joinToString(",")}]}"""
+}
+
+private fun JsonObject.items(): List<JsonObject> = this["input"]!!.jsonArray.map { it.jsonObject }
+
+private fun splice.dialect.responses.WsFrame.frameObj(): JsonObject =
+    splice.dialect.responses.responsesRequestJson.parseToJsonElement(json) as JsonObject
+
+private fun splice.dialect.responses.WsFrame.frameItems(): List<JsonObject> =
+    frameObj()["input"]!!.jsonArray.map { it.jsonObject }
+
+private fun typesOf(items: List<JsonObject>): List<String> =
+    items.map { it["type"]?.jsonPrimitive?.content ?: "message:${it["role"]?.jsonPrimitive?.content}" }
+
+class ResponsesWsSessionTest {
+
+    /** Turn 1 always full-sends (no prior response to chain from) and carries the WS frame type. */
+    @Test
+    fun `first round is a full send and carries type response_create`() {
+        val s = ResponsesWsSession()
+        val req = build(convo(0, trailingUserText = null))
+        val f = s.frameFor(KEY, req, GEN)
+        assertFalse(f.chained)
+        assertEquals("response.create", f.frameObj()["type"]?.jsonPrimitive?.content)
+        assertEquals(req.items().size, f.frameItems().size, "full send carries the whole input")
+        assertTrue(f.frameObj()["previous_response_id"] == null)
+    }
+
+    /** THE LEVERAGE: a tool round-trip chains, and the delta is EXACTLY the tool output — the
+     *  rebuilt reasoning + function_call are dropped because the server produced them. */
+    @Test
+    fun `a tool round chains and sends only the function_call_output`() {
+        val s = ResponsesWsSession()
+        val r1 = build(convo(1))
+        s.completed(KEY, r1, "resp_1", GEN)
+        val r2 = build(convo(2))
+        val f = s.frameFor(KEY, r2, GEN)
+
+        assertTrue(f.chained, "a pure tool continuation must chain")
+        assertEquals("resp_1", f.frameObj()["previous_response_id"]?.jsonPrimitive?.content)
+        assertEquals(
+            listOf("function_call_output"),
+            typesOf(f.frameItems()),
+            "the server already holds the reasoning and the function_call it produced; re-sending duplicates",
+        )
+        assertTrue(
+            f.frameItems().size < r2.items().size,
+            "the whole point: ${f.frameItems().size} items on the wire instead of ${r2.items().size}",
+        )
+    }
+
+    /** An assistant TEXT block in the suffix is server-held too (the model produced it). */
+    @Test
+    fun `a round whose assistant also spoke still chains, dropping the assistant message`() {
+        val s = ResponsesWsSession()
+        s.completed(KEY, build(convo(1)), "resp_1", GEN)
+        val f = s.frameFor(KEY, build(convo(2, assistantText = "thinking out loud")), GEN)
+        assertTrue(f.chained)
+        assertEquals(listOf("function_call_output"), typesOf(f.frameItems()))
+    }
+
+    /** A user continuation sends the user message (client-new), not the history. */
+    @Test
+    fun `a user follow-up chains and sends the user message`() {
+        val s = ResponsesWsSession()
+        s.completed(KEY, build(convo(1)), "resp_1", GEN)
+        val f = s.frameFor(KEY, build(convo(1, trailingUserText = "and now this")), GEN)
+        assertTrue(f.chained)
+        val types = typesOf(f.frameItems())
+        assertEquals(1, types.size, "only the new user message rides: $types")
+        assertTrue(types.single().startsWith("message"), "expected a user message, got $types")
+    }
+
+    /** BAIL: a reconnect means the server's per-connection context died — full send. */
+    @Test
+    fun `a new connection generation full-sends`() {
+        val s = ResponsesWsSession()
+        s.completed(KEY, build(convo(1)), "resp_1", GEN)
+        assertFalse(s.frameFor(KEY, build(convo(2)), GEN + 1).chained)
+    }
+
+    /** BAIL: a pinned request property changed (codex gates connection reuse on exactly this). */
+    @Test
+    fun `an effort flip full-sends`() {
+        val s = ResponsesWsSession()
+        s.completed(KEY, build(convo(1), effort = "high"), "resp_1", GEN)
+        val f = s.frameFor(KEY, build(convo(2), effort = "low"), GEN)
+        assertFalse(f.chained, "reasoning.effort is pinned per response; a change must not ride a chain")
+    }
+
+    /** BAIL: the prefix was rewritten (compaction, cache-key drift, an amended body). */
+    @Test
+    fun `a rewritten prefix full-sends`() {
+        val s = ResponsesWsSession()
+        s.completed(KEY, build(convo(2)), "resp_1", GEN)
+        // A different opening message rewrites input[0] — everything after it is untrustworthy.
+        val rewritten = build(
+            """{"model":"m","messages":[{"role":"user","content":"DIFFERENT start"},""" +
+                """{"role":"assistant","content":[{"type":"tool_use","id":"call_1","name":"read","input":{"p":"1"}}]},""" +
+                """{"role":"user","content":[{"type":"tool_result","tool_use_id":"call_1","content":"out1"}]}]}""",
+        )
+        assertFalse(s.frameFor(KEY, rewritten, GEN).chained)
+    }
+
+    /** BAIL: an identical re-send is a client retry, not a continuation — chaining it would ask
+     *  the server to continue from a response with nothing new to react to. */
+    @Test
+    fun `an identical retry full-sends rather than chaining an empty delta`() {
+        val s = ResponsesWsSession()
+        val r = build(convo(2))
+        s.completed(KEY, r, "resp_1", GEN)
+        assertFalse(s.frameFor(KEY, r, GEN).chained)
+    }
+
+    /** BAIL: an unmodelled item shape anywhere in the suffix. Wrong-drop and wrong-send are both
+     *  silent corruption; a full send is merely the status quo. */
+    @Test
+    fun `an unknown item type in the suffix full-sends`() {
+        val s = ResponsesWsSession()
+        val base = build(convo(1))
+        s.completed(KEY, base, "resp_1", GEN)
+        val withAlien = JsonObject(
+            base.toMutableMap().apply {
+                put(
+                    "input",
+                    JsonArray(base.items() + buildJsonObject { put("type", JsonPrimitive("image_generation_call")) }),
+                )
+            },
+        )
+        assertFalse(s.frameFor(KEY, withAlien, GEN).chained)
+    }
+
+    /** State is committed only on a clean terminal; a tear/cancel must not leave a chain behind. */
+    @Test
+    fun `a cleared conversation full-sends, and a null response id never commits`() {
+        val s = ResponsesWsSession()
+        s.completed(KEY, build(convo(1)), "resp_1", GEN)
+        s.cleared(KEY)
+        assertFalse(s.frameFor(KEY, build(convo(2)), GEN).chained)
+
+        s.completed(KEY, build(convo(1)), null, GEN)
+        assertFalse(s.frameFor(KEY, build(convo(2)), GEN).chained, "a terminal without an id is not chainable")
+    }
+
+    /** Chaining is per-conversation: one conversation's state never serves another. */
+    @Test
+    fun `chains are scoped per conversation key`() {
+        val s = ResponsesWsSession()
+        s.completed(KEY, build(convo(1)), "resp_1", GEN)
+        assertFalse(s.frameFor("other-conv", build(convo(2)), GEN).chained)
+    }
+
+    /** The full-send frame must be byte-identical to the request plus the WS envelope keys —
+     *  no field invented, none lost (the closed-DTO law this repo already holds elsewhere). */
+    @Test
+    fun `a full send preserves every request field exactly`() {
+        val s = ResponsesWsSession()
+        val req = build(convo(2))
+        val frame = s.frameFor(KEY, req, GEN).frameObj()
+        assertEquals(req.keys + "type", frame.keys)
+        req.forEach { (k, v) -> assertEquals(v, frame[k], "field $k must ride unchanged") }
+    }
+}

--- a/gateway/dialect-openai-responses/src/test/kotlin/WsQuirkWiringTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/WsQuirkWiringTest.kt
@@ -1,0 +1,98 @@
+// WALLS for the WS overlay's enable switch (ws-transport WS-3/WS-4).
+//
+// WHY THESE EXIST: an adversarial reviewer inverted the feature's entire production on/off
+// condition (`webSocket == true` -> `webSocket == false`) and the WHOLE GATE STAYED GREEN — 828
+// tests, 0 failures. A switch nothing can falsify is worse than no switch: it reads as coverage
+// forever while the feature is either permanently inert or permanently on. These tests fail on
+// that mutation in both directions.
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import splice.core.auth.AuthDescription
+import splice.core.auth.Credentials
+import splice.core.auth.RefreshableAuthProvider
+import splice.core.model.ModelCatalog
+import splice.core.model.ModelEntry
+import splice.core.turn.ReasoningDisplay
+import splice.core.turn.WatchdogBudget
+import splice.dialect.responses.ResponsesProvider
+import splice.dialect.responses.ResponsesQuirks
+import splice.dialect.responses.withWebSocketToml
+import splice.spi.ProviderTuning
+import kotlin.time.Duration.Companion.seconds
+
+private class ProbeProvider(quirks: ResponsesQuirks) : ResponsesProvider(
+    tuning = ProviderTuning(
+        key = "probe",
+        label = "probe",
+        catalog = ModelCatalog(
+            discoveryPrefix = "claude-codex",
+            models = listOf(ModelEntry(id = "gpt-5.6-sol", label = "sol", contextWindow = 400_000)),
+            defaultContextWindow = 400_000,
+        ),
+        pinnedModel = "gpt-5.6-sol",
+        auth = StubAuth,
+        baseUrl = "https://chatgpt.com/backend-api/codex",
+        watchdog = WatchdogBudget(5.seconds, 3.seconds, 30.seconds),
+    ),
+    showReasoning = ReasoningDisplay.from("text"),
+    replayReasoning = false,
+    configEffort = null,
+    configSummary = null,
+    quirks = quirks,
+) {
+    override fun extraHeaders(creds: Credentials): Map<String, String> = emptyMap()
+}
+
+private object StubAuth : RefreshableAuthProvider {
+    override suspend fun credentials(): Credentials = Credentials.Bearer("tok", "acct")
+    override suspend fun refresh(): Credentials = credentials()
+    override suspend fun describe(): AuthDescription = AuthDescription(true, "stub")
+}
+
+class WsQuirkWiringTest {
+
+    /** THE DEFAULT-OFF PIN. With the quirk absent no runner exists, so not one line of the overlay
+     *  can execute and the request path is byte-identical to before it landed. */
+    @Test
+    fun `absent quirk means NO ws runner is constructed`() {
+        assertNull(ProbeProvider(ResponsesQuirks(providerTag = "claudex")).wsRunner)
+    }
+
+    /** THE MUTATION WALL, direction 1: with the quirk ON a runner MUST exist. Inverting the
+     *  production condition makes this fail — previously nothing did. */
+    @Test
+    fun `quirk on constructs a ws runner`() {
+        val on = ResponsesQuirks(providerTag = "claudex").withWebSocketToml(true)
+        assertNotNull(
+            ProbeProvider(on).wsRunner,
+            "websocket = true must produce a runner; inverting the production condition leaves the " +
+                "feature permanently INERT with every gate green",
+        )
+    }
+
+    /** THE MUTATION WALL, direction 2: explicit false must NOT construct one. Without this, a
+     *  condition inverted the other way turns the overlay permanently ON for operators who
+     *  deliberately disabled it. */
+    @Test
+    fun `quirk explicitly false constructs no runner`() {
+        val off = ResponsesQuirks(providerTag = "claudex").withWebSocketToml(false)
+        assertNull(ProbeProvider(off).wsRunner)
+    }
+
+    /** The nullable-overlay contract: ABSENT keeps the provider default, it does not stomp it.
+     *  A non-nullable TOML field is how supportsSummary became an unreachable dead lever. */
+    @Test
+    fun `absent TOML keeps the provider default, and never stomps an on default`() {
+        val base = ResponsesQuirks(providerTag = "claudex")
+        assertEquals(false, base.withWebSocketToml(null).webSocket, "absent keeps the shipped default")
+        val providerDefaultOn = base.copy(webSocket = true)
+        assertEquals(
+            true,
+            providerDefaultOn.withWebSocketToml(null).webSocket,
+            "an absent key must not stomp a provider that defaults ON",
+        )
+        assertEquals(false, providerDefaultOn.withWebSocketToml(false).webSocket, "explicit false still wins")
+    }
+}

--- a/gateway/dialect-openai-responses/src/test/kotlin/WsQuirkWiringTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/WsQuirkWiringTest.kt
@@ -22,7 +22,7 @@ import splice.dialect.responses.withWebSocketToml
 import splice.spi.ProviderTuning
 import kotlin.time.Duration.Companion.seconds
 
-private class ProbeProvider(quirks: ResponsesQuirks) : ResponsesProvider(
+private class ProbeProvider(quirks: ResponsesQuirks, private val supports: Boolean = true) : ResponsesProvider(
     tuning = ProviderTuning(
         key = "probe",
         label = "probe",
@@ -42,6 +42,9 @@ private class ProbeProvider(quirks: ResponsesQuirks) : ResponsesProvider(
     configSummary = null,
     quirks = quirks,
 ) {
+    /** Stands in for a provider that has PROVEN the protocol against its own upstream (codex). */
+    override val supportsWebSocket: Boolean get() = supports
+
     override fun extraHeaders(creds: Credentials): Map<String, String> = emptyMap()
 }
 
@@ -79,6 +82,19 @@ class WsQuirkWiringTest {
     fun `quirk explicitly false constructs no runner`() {
         val off = ResponsesQuirks(providerTag = "claudex").withWebSocketToml(false)
         assertNull(ProbeProvider(off).wsRunner)
+    }
+
+    /** THE PROVIDER-GATING WALL (review of #72). The quirk table is SHARED by every
+     *  openai-responses provider, so `websocket = true` under [providers.xai.quirks] would
+     *  otherwise make grok open a WebSocket to api.x.ai and fail every round into SSE. A provider
+     *  that has not proven the protocol against its own upstream gets no runner, quirk or not. */
+    @Test
+    fun `a provider that does not support the protocol gets no runner even with the quirk on`() {
+        val on = ResponsesQuirks(providerTag = "claude-grok").withWebSocketToml(true)
+        assertNull(
+            ProbeProvider(on, supports = false).wsRunner,
+            "the shared quirk must not arm the overlay on a provider whose upstream was never probed",
+        )
     }
 
     /** The nullable-overlay contract: ABSENT keeps the provider default, it does not stomp it.

--- a/gateway/dialect-openai-responses/src/test/kotlin/WsUpstreamTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/WsUpstreamTest.kt
@@ -33,9 +33,9 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import splice.spi.InboxListener
-import splice.spi.WsConnection
-import splice.spi.WsUpstream
+import splice.dialect.responses.InboxListener
+import splice.dialect.responses.WsConnection
+import splice.dialect.responses.WsUpstream
 import java.io.IOException
 import java.net.URI
 import java.net.http.WebSocket
@@ -296,23 +296,34 @@ class WsUpstreamTest {
     }
 
     @Test
-    fun `KNOWN GAP - concurrent COLD rounds on one key both connect, the second tears the first`() = runTest {
+    fun `concurrent COLD rounds on one key share ONE connection - the loser never tears the winner`() = runTest {
+        // WAS "KNOWN GAP": both callers missed the acquire() lookup, both connected, and the second
+        // registration killed the first — aborting a LIVE round mid-stream. The implementer pinned
+        // that gap as a test; the review of #72 independently filed it as a blocker. connect() now
+        // re-checks under the lock, so a live predecessor wins and the redundant socket is discarded.
         val fx = Fixture().apply {
             connectGate = CompletableDeferred()
-            reply = replyWith(CREATED)
+            reply = replyWith(CREATED, DONE)
         }.start()
         val first = async { fx.go() }
         val second = async { fx.go() }
         runCurrent()
         assertTrue(fx.connectGate?.complete(Unit) == true, "both rounds are parked in the handshake")
         val flowA = first.await()
-        assertNotNull(second.await(), "the second round also commits")
-        assertNotNull(flowA, "both took the existing==null branch — the busy CAS never saw them")
-        assertEquals(2, fx.connects, "the busy flag only guards an EXISTING connection")
-        assertEquals(1, fx.opened[0].aborts, "the second connect kills the first mid-round")
+        val flowB = second.await()
+
+        assertNotNull(flowA, "the winner commits")
+        assertNull(flowB, "the loser finds the winner BUSY and rides SSE — it must not open a second round")
+        assertEquals(2, fx.connects, "both raced into connect()...")
+        assertEquals(
+            1,
+            fx.opened.count { it.aborts == 0 },
+            "...but exactly ONE socket survives: the loser's is closed, the winner's is untouched",
+        )
+
         val (seen, torn) = collectTorn(flowA ?: error("no flow"))
-        assertEquals(listOf("response.created"), seen)
-        assertNotNull(torn, "the victim round tears rather than truncating silently")
+        assertEquals(listOf("response.created", "response.completed"), seen, "the winner streams to its terminal")
+        assertNull(torn, "the winner must NOT be torn by the loser's arrival")
     }
 
     // ================================================================================ sendFrame ===

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnDriver.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnDriver.kt
@@ -128,6 +128,7 @@ internal class TurnDriver(
     private val clock get() = deps.clock
 
     private val telemetry = TurnTelemetry(provider.key, deps.perfStats, deps.log, deps.clock)
+    private val wsDriver = WsRoundDriver(provider, deps.log, ::classifyZeroEventFailure)
     private val health = HeadHealthCounters()
 
     /** G20: passive health snapshot for HeadServer.healthSnapshot() — the control-plane's
@@ -435,6 +436,14 @@ internal class TurnDriver(
         val framesBase = drive.perfCounter(PerfKeys.CONTENT_FRAMES_OUT)
         val eventsBase = drive.perfCounter(PerfKeys.EVENTS_IN)
         val frameEmittedThisRound = { drive.perfCounter(PerfKeys.CONTENT_FRAMES_OUT) > framesBase }
+        // ws-transport WS-3: try the WebSocket overlay first. It returns null for "ride SSE" on
+        // EVERY failure, and WsRoundNeedsSse when a round failed before the client saw content —
+        // both land on the unchanged post() below, so SSE keeps sole ownership of retry, the
+        // single-flight 401 refresh and the shared 429 cooldown (L5). With the quirk off,
+        // provider.wsRunner is null and not one line of this executes.
+        wsDriver.run(
+            WsRoundInputs(drive, bodyJson, sink, self, turnJob, frameEmittedThisRound, eventsBase),
+        )?.let { return it }
         return upstream.post(
             url = provider.upstreamUrl,
             bodyJson = bodyJson,

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/WsRoundDriver.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/WsRoundDriver.kt
@@ -1,0 +1,100 @@
+// NEW: (ws-transport WS-3, 2026-08-01) one round over the WebSocket overlay, extracted from
+// TurnDriver for the same reason TurnDriver was itself split out of HeadServer: the class was at
+// its LargeClass/TooManyFunctions ceiling and this is a self-contained drive, not more turn logic.
+//
+// THE CONTRACT, and it is the whole safety argument for the overlay: [run] returns null for
+// "serve this round over SSE", and every failure produces exactly that — the quirk is off, no
+// runner exists, credentials are unavailable, the transport declined, or the round failed before
+// the client saw content. Nothing here can produce a client-visible failure the SSE path would not
+// have produced (NEVER-BELOW-STATUS-QUO), and SSE keeps sole ownership of retry, the single-flight
+// 401 refresh and the shared 429 cooldown, which live in UpstreamClient and are deliberately NOT
+// reimplemented here.
+package splice.gateway.head
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.onEach
+import splice.core.perf.PerfKeys
+import splice.core.turn.TurnOutcome
+import splice.spi.Provider
+import splice.spi.TurnSignals
+import splice.spi.WireSink
+import splice.spi.WsRoundNeedsSse
+
+/** The per-round collaborators the WS drive needs, grouped so the entry point stays one cohesive
+ *  argument (the same shape [TurnDrive] uses for the SSE path). */
+internal data class WsRoundInputs(
+    val drive: TurnDrive,
+    val bodyJson: String,
+    val sink: WireSink,
+    val scope: CoroutineScope,
+    val turnJob: Job,
+    val frameEmittedThisRound: () -> Boolean,
+    val eventsBase: Long,
+)
+
+internal class WsRoundDriver(
+    private val provider: Provider,
+    private val log: (String) -> Unit,
+    private val classifyZeroEvent: (TurnDrive, TurnOutcome, String, Long) -> TurnOutcome,
+) {
+
+    /** Run the round, or null to fall through to the SSE path. */
+    suspend fun run(inputs: WsRoundInputs): TurnOutcome? {
+        val runner = provider.wsRunner ?: return null
+        val drive = inputs.drive
+        // Credentials come from the provider's auth surface, NOT from a WS-side refresh: L5 keeps
+        // the single-flight 401 refresh in UpstreamClient, so a missing/expired credential here
+        // simply rides SSE and gets refreshed there.
+        val events = provider.auth.credentials()
+            ?.let { creds -> runner.attempt(inputs.bodyJson, drive.meta, drive.turnHeaders, creds) }
+            ?: return null
+        drive.slot.touch()
+        drive.emitter.ensureStarted()
+        drive.watchdog.resetFirstByte()
+        val poller = drive.watchdog.launchIn(inputs.scope, drive.slot, inputs.turnJob)
+        return try {
+            drive(inputs, runner, events)
+        } catch (ignored: WsRoundNeedsSse) {
+            // The round failed while the client had seen nothing, so it can still be re-served with
+            // the full recovery machinery. Serving the failure raw over the WebSocket instead would
+            // bypass retry/refresh/cooldown entirely — the one way this overlay could land BELOW
+            // the status quo.
+            log("[${provider.key}] websocket round failed before any client frame — serving over SSE\n")
+            runner.roundEnded(drive.meta, ok = false)
+            null
+        } finally {
+            poller.cancel()
+        }
+    }
+
+    /** The per-round bookkeeping mirrors the SSE path exactly — slot touch, watchdog byte mark,
+     *  first-byte/events perf, zero-event classification — because the client must not be able to
+     *  tell which transport served its turn. */
+    private suspend fun drive(
+        inputs: WsRoundInputs,
+        runner: splice.spi.WsRoundRunner,
+        events: kotlinx.coroutines.flow.Flow<kotlinx.serialization.json.JsonObject>,
+    ): TurnOutcome {
+        val drive = inputs.drive
+        // No raw-text capture on this path: ZeroEventCapture's snippet exists to classify a
+        // non-SSE dead-head BODY (an HTML login page arriving where SSE was expected), and a
+        // WebSocket round has no body to misread. An empty snippet makes the classifier keep the
+        // translator's own verdict, which is the honest answer here.
+        val instrumented = events.onEach { evt ->
+            if (runner.isFailureTerminal(evt) && !inputs.frameEmittedThisRound()) throw WsRoundNeedsSse()
+            drive.slot.touch()
+            drive.watchdog.markByte()
+            drive.perf.markOnce(PerfKeys.FIRST_BYTE)
+            drive.perf.add(PerfKeys.EVENTS_IN, 1)
+        }
+        val signals = TurnSignals(
+            watchdogFired = { drive.watchdog.fired },
+            clientGone = { drive.channel.clientGone.get() },
+        )
+        val raw = provider.streamTranslator(drive.meta, signals).driveTurn(instrumented, inputs.sink)
+        drive.perf.mark(PerfKeys.STREAM_END)
+        runner.roundEnded(drive.meta, ok = true)
+        return classifyZeroEvent(drive, raw, "", inputs.eventsBase)
+    }
+}

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/WsRoundDriver.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/WsRoundDriver.kt
@@ -48,7 +48,11 @@ internal class WsRoundDriver(
         // simply rides SSE and gets refreshed there.
         val events = provider.auth.credentials()
             ?.let { creds -> runner.attempt(inputs.bodyJson, drive.meta, drive.turnHeaders, creds) }
-            ?: return null
+        if (events == null) {
+            // SSE is about to serve this round, so the conversation advances outside any chain.
+            runner.roundBypassed(drive.meta)
+            return null
+        }
         drive.slot.touch()
         drive.emitter.ensureStarted()
         drive.watchdog.resetFirstByte()
@@ -61,7 +65,7 @@ internal class WsRoundDriver(
             // bypass retry/refresh/cooldown entirely — the one way this overlay could land BELOW
             // the status quo.
             log("[${provider.key}] websocket round failed before any client frame — serving over SSE\n")
-            runner.roundEnded(drive.meta, ok = false)
+            runner.roundBypassed(drive.meta)
             null
         } finally {
             poller.cancel()

--- a/gateway/gateway/src/test/kotlin/head/WsRoundDriverTest.kt
+++ b/gateway/gateway/src/test/kotlin/head/WsRoundDriverTest.kt
@@ -1,0 +1,233 @@
+// NEW (review of #72, WsRoundDriver.kt:85): the pre-content fallback decision is ONE boolean, and
+// flipping it changes the user-visible failure mode — a WS round answered with a failure terminal
+// would be served raw over the WebSocket, bypassing UpstreamClient's retry, its single-flight 401
+// refresh and the shared 429 cooldown. Nothing tested it. These are HTTP-level, through a real
+// HeadServer, because "the SSE path is reached" is only observable at the upstream.
+//
+// The two cases are opposites and both matter:
+//   failure BEFORE any client frame -> abandon the WS round, SSE serves the turn (retry intact)
+//   failure AFTER a frame           -> stay on the WS path; re-serving would duplicate output
+package head
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonObject
+import mock.MockChatGptUpstream
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import splice.core.auth.AuthDescription
+import splice.core.auth.Credentials
+import splice.core.auth.RefreshableAuthProvider
+import splice.core.model.ModelCatalog
+import splice.core.model.ModelEntry
+import splice.core.turn.ReasoningDisplay
+import splice.core.turn.TurnMeta
+import splice.core.turn.WatchdogBudget
+import splice.gateway.compact.CompactStats
+import splice.gateway.compact.ShadowClassifier
+import splice.gateway.head.HeadDeps
+import splice.gateway.head.HeadServer
+import splice.gateway.head.RequestMaterializationGate
+import splice.gateway.perf.PerfStats
+import splice.gateway.usage.UsageStore
+import splice.provider.codex.CodexProvider
+import splice.spi.InflightGate
+import splice.spi.Provider
+import splice.spi.ProviderTuning
+import splice.spi.UpstreamClient
+import splice.spi.WsRoundRunner
+import java.net.ServerSocket
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.time.Duration.Companion.seconds
+
+private class WsFakeAuth : RefreshableAuthProvider {
+    override suspend fun credentials(): Credentials = Credentials.Bearer("tok-ws", "acct-ws")
+    override suspend fun refresh(): Credentials = credentials()
+    override suspend fun describe(): AuthDescription = AuthDescription(true, "fake")
+}
+
+private fun ev(json: String): JsonObject =
+    kotlinx.serialization.json.Json.parseToJsonElement(json) as JsonObject
+
+/** A runner that replays a scripted round, so the driver's decision is the only variable. */
+private class ScriptedRunner(private val events: List<String>) : WsRoundRunner {
+    var attempts = 0
+    var bypassed = 0
+    var endedOk = 0
+
+    override suspend fun attempt(
+        bodyJson: String,
+        meta: TurnMeta,
+        turnHeaders: Map<String, String>,
+        creds: Credentials,
+    ): Flow<JsonObject>? {
+        attempts += 1
+        return flowOf(*events.map(::ev).toTypedArray())
+    }
+
+    override fun isFailureTerminal(event: JsonObject): Boolean =
+        event["type"].toString().trim('"') in setOf("response.failed", "response.error", "error")
+
+    override fun roundEnded(meta: TurnMeta, ok: Boolean) {
+        if (ok) endedOk += 1
+    }
+
+    override fun roundBypassed(meta: TurnMeta) {
+        bypassed += 1
+    }
+}
+
+/** A real codex provider with ONE member swapped. Interface delegation, not subclassing:
+ *  CodexProvider is final and wsRunner is a final override, and delegating keeps every other
+ *  behaviour (buildTurn, the stream translator, the SSE path) genuinely real. */
+private class ScriptedWsProvider(
+    private val inner: CodexProvider,
+    private val runner: ScriptedRunner,
+) : Provider by inner {
+    override val wsRunner: WsRoundRunner get() = runner
+}
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class WsRoundDriverTest {
+
+    private val mock = MockChatGptUpstream()
+    private val client = HttpClient(CIO) { defaultRequest { bearerAuth("test-inference-token") } }
+    private lateinit var tmp: Path
+
+    @BeforeAll
+    fun setUp() {
+        tmp = Files.createTempDirectory("ws-driver")
+    }
+
+    @AfterAll
+    fun tearDown() {
+        client.close()
+        mock.stop()
+    }
+
+    private fun freshPort(): Int = ServerSocket(0).use { it.localPort }
+
+    private fun head(port: Int, runner: ScriptedRunner): HeadServer {
+        val provider = ScriptedWsProvider(
+            CodexProvider(
+                tuning = ProviderTuning(
+                    key = "codex",
+                    label = "claudex",
+                    catalog = ModelCatalog(
+                        discoveryPrefix = "claude-codex--",
+                        models = listOf(ModelEntry("gpt-5.6-sol", "Sol", contextWindow = 272_000)),
+                        defaultContextWindow = 272_000,
+                    ),
+                    pinnedModel = "gpt-5.6-sol",
+                    auth = WsFakeAuth(),
+                    baseUrl = mock.baseUrl,
+                    watchdog = WatchdogBudget(10.seconds, 10.seconds, 30.seconds),
+                    loginCommand = "claudex login",
+                ),
+                showReasoning = ReasoningDisplay.TEXT,
+                replayReasoning = false,
+                configEffort = "high",
+                configSummary = "detailed",
+            ),
+            runner,
+        )
+        return HeadServer(
+            provider = provider,
+            listenPort = port,
+            deps = HeadDeps(
+                upstream = UpstreamClient(firstByteTimeoutMs = 5_000, totalTimeoutMs = 30_000, maxRetries = 2),
+                inferenceToken = "test-inference-token",
+                gate = InflightGate({ 0 }),
+                shadow = ShadowClassifier(log = {}),
+                compactStats = CompactStats(tmp.resolve("compact-$port.jsonl")),
+                usageStore = UsageStore(tmp.resolve("usage-$port.json"), tmp.resolve("rl-$port.json")),
+                perfStats = PerfStats(tmp.resolve("perf-$port.jsonl")),
+                log = {},
+                requestMaterializationGate = RequestMaterializationGate(2),
+            ),
+        )
+    }
+
+    private fun turn(port: Int): String = runBlocking {
+        client.post("http://127.0.0.1:$port/v1/messages") {
+            setBody(
+                """{"model":"claude-codex--gpt-5.6-sol","stream":true,"max_tokens":100,
+                    "messages":[{"role":"user","content":"hi"}]}""",
+            )
+        }.bodyAsText()
+    }
+
+    /** FAILURE BEFORE ANY CLIENT FRAME -> the round is abandoned and SSE serves the turn, so the
+     *  upstream POST happens and the client sees the normal answer. Without this the failure is
+     *  delivered raw over the WebSocket, skipping retry / 401 refresh / 429 cooldown entirely. */
+    @Test
+    fun `a failure terminal before any client frame falls back to the SSE path`() {
+        val runner = ScriptedRunner(listOf("""{"type":"response.failed","response":{"id":"r1"}}"""))
+        val port = freshPort()
+        val h = head(port, runner)
+        runBlocking { h.start() }
+        try {
+            val before = mock.upstreamBodies.size
+            val sse = turn(port)
+            assertEquals(1, runner.attempts, "the overlay was tried")
+            assertEquals(1, runner.bypassed, "and it reported the bypass so the chain is cleared")
+            assertEquals(0, runner.endedOk, "a failure terminal is NOT a clean round")
+            assertTrue(mock.upstreamBodies.size > before, "the SSE upstream must have served the turn")
+            assertTrue(sse.contains("event: message_stop"), "the client sees a normal completed turn")
+        } finally {
+            runBlocking { h.stop() }
+        }
+    }
+
+    /** FAILURE AFTER A FRAME -> the client has already seen output, so re-serving over SSE would
+     *  duplicate it. The round stays on the WS path and no upstream POST is made. */
+    @Test
+    fun `a failure terminal AFTER a client frame stays on the websocket path`() {
+        val runner = ScriptedRunner(
+            listOf(
+                """{"type":"response.created","response":{"id":"r1"}}""",
+                """{"type":"response.output_item.added","output_index":0,""" +
+                    """"item":{"type":"message","role":"assistant"}}""",
+                """{"type":"response.content_part.added","output_index":0,"content_index":0,""" +
+                    """"part":{"type":"output_text","text":""}}""",
+                """{"type":"response.output_text.delta","output_index":0,"content_index":0,"delta":"hello"}""",
+                """{"type":"response.failed","response":{"id":"r1"}}""",
+            ),
+        )
+        val port = freshPort()
+        val h = head(port, runner)
+        runBlocking { h.start() }
+        try {
+            val before = mock.upstreamBodies.size
+            val sse = turn(port)
+            // Rounds > 1 are the head's own re-anchor retries, which a post-content failure gets on
+            // EITHER transport — pre-existing behaviour and not what this test is about.
+            assertTrue(runner.attempts >= 1, "the overlay served the round")
+            assertEquals(
+                0,
+                runner.bypassed,
+                "content was already emitted, so the pre-content fallback must NOT fire — re-serving " +
+                    "over SSE would duplicate output the client already has",
+            )
+            assertEquals(before, mock.upstreamBodies.size, "no SSE upstream request may be made")
+            assertTrue(sse.contains("hello"), "the content the client already saw is preserved")
+            assertFalse(sse.isEmpty())
+        } finally {
+            runBlocking { h.stop() }
+        }
+    }
+}

--- a/gateway/provider-codex/src/main/kotlin/splice/provider/codex/CodexProvider.kt
+++ b/gateway/provider-codex/src/main/kotlin/splice/provider/codex/CodexProvider.kt
@@ -27,6 +27,11 @@ public class CodexProvider(
     log: (String) -> Unit = DaemonLog::write,
 ) : ResponsesProvider(tuning, showReasoning, replayReasoning, configEffort, configSummary, quirks, foldConfig, log) {
 
+    /** Proven against the live ChatGPT backend by the WS-0 spike
+     *  (gateway/spikes/results/responses-websocket.md): handshake, event vocabulary and
+     *  previous_response_id chaining all confirmed. No other Responses upstream has been probed. */
+    override val supportsWebSocket: Boolean = true
+
     override fun extraHeaders(creds: Credentials): Map<String, String> = buildMap {
         put("Accept", "text/event-stream")
         val accountId = (creds as? Credentials.Bearer)?.accountId

--- a/gateway/provider-spi/src/main/kotlin/splice/spi/Provider.kt
+++ b/gateway/provider-spi/src/main/kotlin/splice/spi/Provider.kt
@@ -95,4 +95,10 @@ public interface Provider : ProviderIdentity {
      *  deterministic upstream rejection — (status, responseText, bodyJson) -> amended
      *  body or null. Default null keeps every provider on the plain retry plan. */
     public fun amendBodyOnFailure(status: Int, responseText: String, bodyJson: String): String? = null
+
+    /** ws-transport WS-3: the WebSocket overlay for this provider, or null (the default, and every
+     *  provider that has not opted in). Non-null lets the head attempt a WS round before its normal
+     *  SSE post; the runner returns null for "ride SSE", so the overlay can only ever remove work,
+     *  never add a failure mode the SSE path did not already have. */
+    public val wsRunner: WsRoundRunner? get() = null
 }

--- a/gateway/provider-spi/src/main/kotlin/splice/spi/WsRoundRunner.kt
+++ b/gateway/provider-spi/src/main/kotlin/splice/spi/WsRoundRunner.kt
@@ -1,0 +1,57 @@
+// NEW: (ws-transport WS-3, 2026-08-01) the WS seam the generic head drives — and ONLY the seam.
+// The concrete transport (WsUpstream/WsConnection) deliberately does NOT live here: it is used by
+// exactly one caller, the Responses dialect, and keeping an implementation type in :provider-spi
+// widened the shared surface for no consumer (review of #72). :gateway needs the interface and the
+// sentinel, nothing more, and the module law gives it nothing more.
+package splice.spi
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.serialization.json.JsonObject
+import splice.core.auth.Credentials
+import splice.core.turn.TurnMeta
+
+/**
+ * The WS seam the generic head drives (ws-transport WS-3). It lives in :provider-spi because the
+ * module law forbids :gateway from naming a dialect type (splice.module-law.gradle.kts:15-31), so
+ * every Responses-specific decision — the round-terminal vocabulary, the chaining frame, the
+ * pre-content failure test — is supplied by the provider behind this interface.
+ *
+ * Contract: [attempt] returns null for "serve this round over SSE", which is the answer to every
+ * failure (NEVER-BELOW-STATUS-QUO). The head then runs its normal upstream POST, and SSE keeps
+ * sole ownership of retry, the single-flight 401 refresh and the shared 429 cooldown (L5).
+ */
+public interface WsRoundRunner {
+
+    /** Attempt one round; null = ride SSE. [turnHeaders] are the PER-TURN headers the SSE path
+     *  would send — they participate in connection identity, because a WebSocket's handshake
+     *  headers are fixed for the socket's life and a turn needing a different set must not reuse
+     *  a socket opened without it (adversarial review of WS-3: a lite marker was silently dropped). */
+    public suspend fun attempt(
+        bodyJson: String,
+        meta: TurnMeta,
+        turnHeaders: Map<String, String>,
+        creds: Credentials,
+    ): Flow<JsonObject>?
+
+    /** True when [event] ends the round in FAILURE. The head uses this to bail to SSE while the
+     *  client has still seen nothing, so an upstream error keeps SSE's retry/refresh/cooldown
+     *  rather than being served raw over the WebSocket. */
+    public fun isFailureTerminal(event: JsonObject): Boolean
+
+    /** Called once the round is over: [ok] true only for a clean, fully-consumed terminal.
+     *  Anything else must clear the chaining state — a response id that was never completed would
+     *  anchor the next turn onto context the server never finished building. */
+    public fun roundEnded(meta: TurnMeta, ok: Boolean)
+
+    /** The head served this round WITHOUT the overlay (no credentials, transport declined, or a
+     *  pre-content failure fell back). The conversation still advanced, so any chaining state must
+     *  be dropped — a chain anchored before a turn the server never saw would make the next delta
+     *  omit that turn entirely. */
+    public fun roundBypassed(meta: TurnMeta)
+}
+
+/** Thrown by the head when a WS round failed BEFORE the client saw any content, so the round is
+ *  re-served over SSE. A plain RuntimeException on purpose: the stream translators' catch lists
+ *  (IOException / SerializationException / IllegalArgumentException) must not swallow it, the same
+ *  reason [StreamTornBeforeClient] is one. */
+public class WsRoundNeedsSse : RuntimeException("websocket round failed before any client frame")

--- a/gateway/provider-spi/src/main/kotlin/splice/spi/WsUpstream.kt
+++ b/gateway/provider-spi/src/main/kotlin/splice/spi/WsUpstream.kt
@@ -51,6 +51,13 @@ public class WsConnection internal constructor(
     internal val busy = AtomicBoolean(false)
     internal val dead = AtomicBoolean(false)
 
+    /** Set by the consumer when the round's terminal event has been taken. From that moment ANY
+     *  further frame is a late tail belonging to a finished round, and the listener (the producer)
+     *  poisons the connection on arrival. The consumer-side `inbox.isEmpty` check is only a
+     *  sample and cannot fence a frame that lands just after it (review of #72); this can, because
+     *  it runs on the producer itself. */
+    internal val terminalSeen = AtomicBoolean(false)
+
     /** Poison this connection: no further rounds will reuse it; the socket is torn down hard.
      *  abort(), not sendClose() — the one caller path that lands here is an ABNORMAL end (tear,
      *  timeout, cancelled round, eviction), where a graceful close handshake could block behind
@@ -112,8 +119,18 @@ public class WsUpstream(
         frameFor: (WsConnection) -> String,
     ): Flow<JsonObject>? {
         val conn = acquire(key, headers, wssUrl) ?: return null
-        val first = if (sendFrame(conn, key, frameFor(conn))) awaitFirstEvent(conn, key) else null
-        return first?.let { roundFlow(conn, key, it, isTerminal) }
+        // Between winning the busy flag and handing back a flow there are two suspension points,
+        // and a cancellation at either one used to propagate BEFORE any flow existed — so
+        // onCompletion never ran, the busy flag stayed set, and every later round for this key lost
+        // the CAS and rode SSE forever (review of #72). Any non-flow exit now poisons the
+        // connection, which costs one reconnect instead of stranding the conversation.
+        var handedOff = false
+        return try {
+            val first = if (sendFrame(conn, key, frameFor(conn))) awaitFirstEvent(conn, key) else null
+            first?.let { roundFlow(conn, key, it, isTerminal) }?.also { handedOff = true }
+        } finally {
+            if (!handedOff) failRound(conn, key)
+        }
     }
 
     /** Receive one event, or null when the inbox is CLOSED.
@@ -141,6 +158,9 @@ public class WsUpstream(
         }
         // Lost the race with a tear between the registry read and the busy win.
         if (conn.dead.get()) conn.busy.set(false)
+        // A NEW round begins: the previous round's terminal must not make this round's first frame
+        // look like a late tail. The fence is per-round, and this is the one place a round starts.
+        conn.terminalSeen.set(false)
         return conn.takeIf { !it.dead.get() }
     }
 
@@ -148,7 +168,11 @@ public class WsUpstream(
         val generation = generations.incrementAndGet()
         val inbox = Channel<JsonObject>(INBOX_CAPACITY)
         val holder = arrayOfNulls<WsConnection>(1)
-        val listener = InboxListener(inbox, log) { holder[0]?.kill() }
+        val listener = InboxListener(
+            inbox,
+            log,
+            terminalSeen = { holder[0]?.terminalSeen?.get() == true },
+        ) { holder[0]?.kill() }
         val socket = runCatchingCancellable {
             connector(URI.create(wssUrl), headers, listener)
         }.getOrElse { e ->
@@ -161,8 +185,12 @@ public class WsUpstream(
             connections.remove(key)?.also { it.kill() } // a dead predecessor never lingers
             connections[key] = conn
             if (connections.size > maxConnections) {
-                val oldest = connections.keys.first()
-                connections.remove(oldest)
+                // Only an IDLE connection may be evicted: an entry stays registered for the whole
+                // of its round, so evicting by pure age could abort an in-flight response
+                // (review of #72). With every connection busy nothing is evicted — the cap is a
+                // soft bound under burst, and each round poisons its own connection on completion.
+                val idle = connections.entries.firstOrNull { !it.value.busy.get() }?.key
+                idle?.let { connections.remove(it) }
             } else {
                 null
             }
@@ -233,6 +261,7 @@ public class WsUpstream(
         isTerminal: (JsonObject) -> Boolean,
     ): Flow<JsonObject> {
         var completed = isTerminal(first)
+        if (completed) conn.terminalSeen.set(true)
         return flow {
             emit(first)
             while (!completed) {
@@ -244,29 +273,34 @@ public class WsUpstream(
                 val evt = received.getOrNull()
                     ?: throw IOException("websocket stream ended mid-round", received.exceptionOrNull())
                 completed = isTerminal(evt)
+                if (completed) conn.terminalSeen.set(true)
                 emit(evt)
             }
-        }.onCompletion { cause ->
-            // The inbox MUST be empty to pool the connection (adversarial review of WS-3): a frame
-            // the server emits AFTER the round-ending one would otherwise sit in the inbox and be
-            // handed to the NEXT round as its first event — a silent cross-round frame leak, and
-            // the reason this class kills rather than drains. Killing costs one reconnect (a full
-            // send, i.e. today's behaviour); serving a stale frame corrupts the next turn.
-            val drained = conn.inbox.isEmpty
-            val poolable = cause == null && completed
-            if (poolable && drained) {
-                conn.busy.set(false)
-                synchronized(lock) { // touch: completed rounds move their connection to MRU
-                    connections.remove(key)?.let { connections[key] = it }
-                }
-            } else {
-                if (poolable) {
-                    log("[ws] $key frames arrived after the round terminal — killing rather than pooling\n")
-                }
-                // Cancelled (watchdog/client-gone) or torn: leftover frames of a half-consumed
-                // round poison reuse — kill, next round reconnects (full send, status quo).
-                failRound(conn, key)
+        }.onCompletion { cause -> finishRound(conn, key, cause, completed) }
+    }
+
+    /** Pool the connection only when the round ended CLEANLY and left nothing behind; otherwise
+     *  poison it. Split out of [roundFlow] to stay under the complexity ceiling. */
+    private fun finishRound(conn: WsConnection, key: String, cause: Throwable?, completed: Boolean) {
+        // The inbox MUST be empty to pool the connection (adversarial review of WS-3): a frame
+        // the server emits AFTER the round-ending one would otherwise sit in the inbox and be
+        // handed to the NEXT round as its first event — a silent cross-round frame leak, and
+        // the reason this class kills rather than drains. Killing costs one reconnect (a full
+        // send, i.e. today's behaviour); serving a stale frame corrupts the next turn.
+        val drained = conn.inbox.isEmpty
+        val poolable = cause == null && completed
+        if (poolable && drained) {
+            conn.busy.set(false)
+            synchronized(lock) { // touch: completed rounds move their connection to MRU
+                connections.remove(key)?.let { connections[key] = it }
             }
+        } else {
+            if (poolable) {
+                log("[ws] $key frames arrived after the round terminal — killing rather than pooling\n")
+            }
+            // Cancelled (watchdog/client-gone) or torn: leftover frames of a half-consumed
+            // round poison reuse — kill, next round reconnects (full send, status quo).
+            failRound(conn, key)
         }
     }
 
@@ -312,6 +346,7 @@ public class WsUpstream(
 internal class InboxListener(
     private val inbox: Channel<JsonObject>,
     private val log: (String) -> Unit,
+    private val terminalSeen: () -> Boolean,
     private val onAnomaly: () -> Unit,
 ) : WebSocket.Listener {
     private val assembly = StringBuilder()
@@ -321,6 +356,14 @@ internal class InboxListener(
     }
 
     override fun onText(webSocket: WebSocket, data: CharSequence, last: Boolean): CompletionStage<*>? {
+        if (terminalSeen()) {
+            // A frame after the round's terminal: the round it belongs to is over, so this can only
+            // ever be served as some LATER round's first event. Poison instead.
+            log("[ws] frame arrived after the round terminal — poisoning rather than serving it later\n")
+            onAnomaly()
+            webSocket.request(1)
+            return null
+        }
         assembly.append(data)
         if (last) {
             val payload = assembly.toString()
@@ -392,6 +435,12 @@ public interface WsRoundRunner {
      *  Anything else must clear the chaining state — a response id that was never completed would
      *  anchor the next turn onto context the server never finished building. */
     public fun roundEnded(meta: TurnMeta, ok: Boolean)
+
+    /** The head served this round WITHOUT the overlay (no credentials, transport declined, or a
+     *  pre-content failure fell back). The conversation still advanced, so any chaining state must
+     *  be dropped — a chain anchored before a turn the server never saw would make the next delta
+     *  omit that turn entirely. */
+    public fun roundBypassed(meta: TurnMeta)
 }
 
 /** Thrown by the head when a WS round failed BEFORE the client saw any content, so the round is

--- a/gateway/provider-spi/src/main/kotlin/splice/spi/WsUpstream.kt
+++ b/gateway/provider-spi/src/main/kotlin/splice/spi/WsUpstream.kt
@@ -1,0 +1,305 @@
+// NEW: (ws-transport WS-1, 2026-07-31) the Responses WebSocket transport. The ChatGPT codex
+// backend serves the Responses API over a v2 WebSocket (OpenAI-Beta: responses_websockets=…) whose
+// payload frames are the SAME JSON events the SSE body carries — one event per text message — so a
+// WS round yields the exact Flow<JsonObject> the stream translators already consume. What the WS
+// adds over SSE is a REUSABLE connection: the server keeps the previous response's context per
+// connection, which is what makes previous_response_id incremental turns possible (live spike
+// receipt: gateway/spikes/results/responses-websocket.md).
+//
+// Laws (campaign ws-transport):
+//   NEVER-BELOW-STATUS-QUO — every failure here (connect, busy, send, first-event timeout) surfaces
+//   as `null`, and the caller falls back to the SSE full-send path. Only a tear AFTER the first
+//   event follows the existing torn-stream rules (the flow throws; the translator's honest
+//   terminal owns it), exactly like an SSE body tear today.
+//   NO NEW DEPENDENCIES — java.net.http.WebSocket (JDK 21), same lineage as UpstreamClient's Java
+//   engine. The dialect stays out of this file: the round-terminal predicate is INJECTED, so
+//   provider-spi never learns Responses event names.
+package splice.spi
+
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import splice.core.util.runCatchingCancellable
+import java.io.IOException
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.WebSocket
+import java.time.Duration
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+
+/** One live upstream WebSocket + its inbox. [generation] is the chaining layer's reconnect
+ *  detector: a new socket for the same key gets a new generation, and chaining state pinned to an
+ *  older generation must full-send (the server's per-connection context died with the socket). */
+public class WsConnection internal constructor(
+    internal val socket: WebSocket,
+    internal val inbox: Channel<JsonObject>,
+    public val generation: Long,
+    private val log: (String) -> Unit,
+) {
+    internal val busy = AtomicBoolean(false)
+    internal val dead = AtomicBoolean(false)
+
+    /** Poison this connection: no further rounds will reuse it; the socket is torn down hard.
+     *  abort(), not sendClose() — the one caller path that lands here is an ABNORMAL end (tear,
+     *  timeout, cancelled round, eviction), where a graceful close handshake could block behind
+     *  the very stall being escaped. */
+    internal fun kill() {
+        if (dead.compareAndSet(false, true)) {
+            runCatchingCancellable { socket.abort() }
+                .onFailure { log("[ws] abort of a torn socket failed (already dead): ${it::class.simpleName}\n") }
+            inbox.close()
+        }
+    }
+}
+
+/**
+ * The WebSocket upstream: a bounded per-key connection registry plus the one operation the head
+ * needs — [round]: send ONE request frame, get the round's events as a Flow, or `null` meaning
+ * "use the SSE path for this round" (connect failed / connection busy / first event never came).
+ *
+ * Reuse contract: a connection is returned to the pool ONLY after a round ends at the injected
+ * terminal predicate. A round that ends ANY other way (flow cancelled by the watchdog/client,
+ * upstream tear, collector threw) kills the connection — leftover frames from a half-consumed
+ * round must never bleed into the next one.
+ */
+public class WsUpstream(
+    private val firstEventTimeoutMs: Long = FIRST_EVENT_TIMEOUT_MS,
+    private val maxConnections: Int = MAX_CONNECTIONS,
+    private val log: (String) -> Unit = {},
+    /** Injectable socket factory — tests script a fake WebSocket without a live server. Receives
+     *  the wss URI, the handshake headers, and the listener the socket must feed. */
+    private val connector: suspend (URI, Map<String, String>, WebSocket.Listener) -> WebSocket =
+        { uri, headers, listener -> jdkConnect(uri, headers, listener, CONNECT_TIMEOUT_MS) },
+) {
+
+    // LRU by round-completion (touched on successful reuse); oldest evicted at the cap. Same
+    // bounded-registry shape as ReasoningCache — one instance per provider, keys are conversation
+    // keys, and an evicted entry costs a reconnect (status quo full-send), never an error.
+    private val connections = LinkedHashMap<String, WsConnection>()
+    private val lock = Any()
+    private val generations = AtomicLong(0)
+
+    /**
+     * Run one request/response round over the key's WebSocket.
+     *
+     * Returns `null` — meaning "this round rides SSE instead" — when the connection could not be
+     * established, is mid-round (busy), the frame could not be sent, or the first event did not
+     * arrive within [firstEventTimeoutMs]. Once the first event HAS arrived, the returned flow is
+     * committed: it replays that event and then relays the connection's inbox until [isTerminal]
+     * matches (connection returns to the pool) or the stream tears (IOException out of the flow,
+     * connection killed — the translator's honest-terminal path owns it from there).
+     *
+     * [frameFor] runs AFTER the connection is acquired so the chaining layer can pick
+     * full-vs-incremental against the live connection's generation and return the frame to send.
+     */
+    public suspend fun round(
+        key: String,
+        headers: Map<String, String>,
+        wssUrl: String,
+        isTerminal: (JsonObject) -> Boolean,
+        frameFor: (WsConnection) -> String,
+    ): Flow<JsonObject>? {
+        val conn = acquire(key, headers, wssUrl) ?: return null
+        val first = if (sendFrame(conn, key, frameFor(conn))) awaitFirstEvent(conn, key) else null
+        return first?.let { roundFlow(conn, key, it, isTerminal) }
+    }
+
+    /** Get-or-connect, and win the busy flag — or null (SSE round). */
+    private suspend fun acquire(key: String, headers: Map<String, String>, wssUrl: String): WsConnection? {
+        val existing = synchronized(lock) { connections[key]?.takeIf { !it.dead.get() } }
+        val conn = existing ?: connect(key, headers, wssUrl) ?: return null
+        if (!conn.busy.compareAndSet(false, true)) {
+            // A concurrent round of the SAME conversation is already on the socket — never
+            // interleave two response.create frames on one connection; the second rides SSE.
+            log("[ws] $key busy — concurrent round rides SSE\n")
+            return null
+        }
+        // Lost the race with a tear between the registry read and the busy win.
+        if (conn.dead.get()) conn.busy.set(false)
+        return conn.takeIf { !it.dead.get() }
+    }
+
+    private suspend fun connect(key: String, headers: Map<String, String>, wssUrl: String): WsConnection? {
+        val generation = generations.incrementAndGet()
+        val inbox = Channel<JsonObject>(INBOX_CAPACITY)
+        val holder = arrayOfNulls<WsConnection>(1)
+        val listener = InboxListener(inbox, log) { holder[0]?.kill() }
+        val socket = runCatchingCancellable {
+            connector(URI.create(wssUrl), headers, listener)
+        }.getOrElse { e ->
+            log("[ws] $key connect failed (${e::class.simpleName}: ${e.message?.take(ERR_SNIPPET)}) — SSE\n")
+            return null
+        }
+        val conn = WsConnection(socket, inbox, generation, log)
+        holder[0] = conn
+        val evicted = synchronized(lock) {
+            connections.remove(key)?.also { it.kill() } // a dead predecessor never lingers
+            connections[key] = conn
+            if (connections.size > maxConnections) {
+                val oldest = connections.keys.first()
+                connections.remove(oldest)
+            } else {
+                null
+            }
+        }
+        evicted?.kill()
+        log("[ws] $key connected (generation=$generation)\n")
+        return conn
+    }
+
+    private fun sendFrame(conn: WsConnection, key: String, frame: String): Boolean {
+        // sendText's async completion is observed by the first-event wait; what is caught here is
+        // the SYNCHRONOUS failure class (IllegalStateException: output closed / pending send).
+        val sent = runCatchingCancellable { conn.socket.sendText(frame, true) }
+            .onFailure { e ->
+                log(
+                    "[ws] $key send failed (${e::class.simpleName}: ${e.message?.take(ERR_SNIPPET)}) " +
+                        "— killing connection, round rides SSE\n",
+                )
+            }
+        if (sent.isFailure) failRound(conn, key)
+        return sent.isSuccess
+    }
+
+    /** The commit point: no event within the budget → the round (and the connection, whose state
+     *  is now indeterminate — the server may or may not have started the response) goes to SSE. */
+    private suspend fun awaitFirstEvent(conn: WsConnection, key: String): JsonObject? {
+        val first = withTimeoutOrNull(firstEventTimeoutMs) {
+            runCatchingCancellable { conn.inbox.receive() }
+                .onFailure { log("[ws] $key inbox closed before first event: ${it::class.simpleName}\n") }
+                .getOrNull()
+        }
+        if (first == null) {
+            log("[ws] $key no first event in ${firstEventTimeoutMs}ms — killing connection, round rides SSE\n")
+            failRound(conn, key)
+        }
+        return first
+    }
+
+    private fun roundFlow(
+        conn: WsConnection,
+        key: String,
+        first: JsonObject,
+        isTerminal: (JsonObject) -> Boolean,
+    ): Flow<JsonObject> {
+        var completed = isTerminal(first)
+        return flow {
+            emit(first)
+            while (!completed) {
+                val evt = runCatchingCancellable { conn.inbox.receive() }.getOrElse {
+                    throw IOException("websocket stream ended mid-round", it)
+                }
+                completed = isTerminal(evt)
+                emit(evt)
+            }
+        }.onCompletion { cause ->
+            if (cause == null && completed) {
+                conn.busy.set(false)
+                synchronized(lock) { // touch: completed rounds move their connection to MRU
+                    connections.remove(key)?.let { connections[key] = it }
+                }
+            } else {
+                // Cancelled (watchdog/client-gone) or torn: leftover frames of a half-consumed
+                // round poison reuse — kill, next round reconnects (full send, status quo).
+                failRound(conn, key)
+            }
+        }
+    }
+
+    private fun failRound(conn: WsConnection, key: String) {
+        conn.kill()
+        synchronized(lock) { if (connections[key] === conn) connections.remove(key) }
+    }
+
+    public companion object {
+        private const val CONNECT_TIMEOUT_MS = 10_000L // same budget as UpstreamClient's TCP connect
+
+        // response.created is an immediate ack (probed live: arrives instantly even ahead of a
+        // long prefill), so a missing first event is a broken round, not a slow model.
+        private const val FIRST_EVENT_TIMEOUT_MS = 15_000L
+        private const val MAX_CONNECTIONS = 32
+        private const val ERR_SNIPPET = 160
+
+        // Bounded so a stalled consumer cannot buffer unboundedly; the turn watchdog fires long
+        // before a healthy translator falls 1024 events behind. Overflow = kill (InboxListener).
+        private const val INBOX_CAPACITY = 1024
+
+        private suspend fun jdkConnect(
+            uri: URI,
+            headers: Map<String, String>,
+            listener: WebSocket.Listener,
+            connectTimeoutMs: Long,
+        ): WebSocket {
+            val builder = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofMillis(connectTimeoutMs))
+                .build()
+                .newWebSocketBuilder()
+            headers.forEach { (k, v) -> builder.header(k, v) }
+            return builder.buildAsync(uri, listener).await()
+        }
+    }
+}
+
+/** Assembles (possibly fragmented) text frames into JSON events and feeds the inbox. Every
+ *  overridden callback must re-arm request(1) itself — overriding a Listener method REPLACES the
+ *  default that did it (a missed request() deadlocks the stream silently). Binary frames, JSON
+ *  that fails to parse, and an overflowing inbox are all protocol anomalies: [onAnomaly] kills the
+ *  owning connection (the caller falls back to SSE; NEVER-BELOW-STATUS-QUO). */
+internal class InboxListener(
+    private val inbox: Channel<JsonObject>,
+    private val log: (String) -> Unit,
+    private val onAnomaly: () -> Unit,
+) : WebSocket.Listener {
+    private val assembly = StringBuilder()
+
+    override fun onOpen(webSocket: WebSocket) {
+        webSocket.request(1)
+    }
+
+    override fun onText(webSocket: WebSocket, data: CharSequence, last: Boolean): CompletionStage<*>? {
+        assembly.append(data)
+        if (last) {
+            val payload = assembly.toString()
+            assembly.setLength(0)
+            val event = runCatchingCancellable { wsJson.parseToJsonElement(payload).jsonObject }
+                .onFailure { log("[ws] unparseable frame (${payload.length} chars) — anomaly\n") }
+                .getOrNull()
+            if (event == null) {
+                onAnomaly()
+            } else if (!inbox.trySend(event).isSuccess) {
+                log("[ws] inbox overflow/closed — anomaly\n")
+                onAnomaly()
+            }
+        }
+        webSocket.request(1)
+        return null
+    }
+
+    override fun onBinary(webSocket: WebSocket, data: java.nio.ByteBuffer, last: Boolean): CompletionStage<*>? {
+        log("[ws] unexpected binary frame — anomaly\n")
+        onAnomaly() // the protocol is text-JSON; a binary frame means we misunderstand the stream
+        return null
+    }
+
+    override fun onClose(webSocket: WebSocket, statusCode: Int, reason: String): CompletionStage<*>? {
+        inbox.close()
+        return null
+    }
+
+    override fun onError(webSocket: WebSocket, error: Throwable) {
+        inbox.close(IOException("websocket error", error))
+    }
+}
+
+private val wsJson = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+}

--- a/gateway/provider-spi/src/main/kotlin/splice/spi/WsUpstream.kt
+++ b/gateway/provider-spi/src/main/kotlin/splice/spi/WsUpstream.kt
@@ -16,7 +16,9 @@
 //   provider-spi never learns Responses event names.
 package splice.spi
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ChannelResult
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onCompletion
@@ -112,6 +114,19 @@ public class WsUpstream(
         return first?.let { roundFlow(conn, key, it, isTerminal) }
     }
 
+    /** Receive one event, or null when the inbox is CLOSED.
+     *
+     *  Why this exists (adversarial review of WS-1, 2026-07-31): `receive()` signals closure by
+     *  THROWING ClosedReceiveChannelException, which extends NoSuchElementException -> RuntimeException
+     *  and is therefore outside runCatchingCancellable's {IOException, SerializationException,
+     *  IllegalArgumentException} (core/util/Cancellation.kt:20-25). A server closing cleanly before
+     *  answering threw straight out of round(), past withTimeoutOrNull, so the caller never received
+     *  the `null` the whole SSE-fallback design depends on — a NEVER-BELOW-STATUS-QUO violation that
+     *  surfaced as a client-visible error where SSE would have served the turn.
+     *  receiveCatching() returns the closure as a VALUE, so it cannot escape. */
+    private suspend fun receiveCatching(conn: WsConnection): ChannelResult<JsonObject> =
+        conn.inbox.receiveCatching()
+
     /** Get-or-connect, and win the busy flag — or null (SSE round). */
     private suspend fun acquire(key: String, headers: Map<String, String>, wssUrl: String): WsConnection? {
         val existing = synchronized(lock) { connections[key]?.takeIf { !it.dead.get() } }
@@ -155,30 +170,55 @@ public class WsUpstream(
         return conn
     }
 
-    private fun sendFrame(conn: WsConnection, key: String, frame: String): Boolean {
-        // sendText's async completion is observed by the first-event wait; what is caught here is
-        // the SYNCHRONOUS failure class (IllegalStateException: output closed / pending send).
-        val sent = runCatchingCancellable { conn.socket.sendText(frame, true) }
-            .onFailure { e ->
-                log(
-                    "[ws] $key send failed (${e::class.simpleName}: ${e.message?.take(ERR_SNIPPET)}) " +
-                        "— killing connection, round rides SSE\n",
-                )
-            }
-        if (sent.isFailure) failRound(conn, key)
-        return sent.isSuccess
+    /** Send the round's one frame and AWAIT delivery.
+     *
+     *  Both failure modes are real and neither was caught before the adversarial review of WS-1:
+     *  sendText returns a CompletableFuture (javap: `CompletableFuture<WebSocket> sendText(...)`),
+     *  so a delivery failure is ASYNCHRONOUS and was previously discarded with the future; and its
+     *  SYNCHRONOUS throw is IllegalStateException ("Send pending"/output closed), which
+     *  runCatchingCancellable deliberately cannot catch because CancellationException extends
+     *  IllegalStateException — catching ISE there would swallow cancellation repo-wide.
+     *  Hence the explicit catch with the cancellation rethrow, and the await. */
+    private suspend fun sendFrame(conn: WsConnection, key: String, frame: String): Boolean {
+        // "sync" vs "async" stays in the log line on purpose: they are different upstream faults
+        // (a socket we already broke vs a delivery the peer refused) and only the log distinguishes
+        // them after the fact.
+        val failure: Pair<String, Throwable>? = try {
+            conn.socket.sendText(frame, true).await()
+            null
+        } catch (e: CancellationException) {
+            throw e // a cancelled turn must stop, never look like a send failure
+        } catch (e: IllegalStateException) {
+            "sync" to e // output closed, or a send already pending on this socket
+        } catch (e: IOException) {
+            "async" to e // the delivery future completed exceptionally
+        }
+        if (failure != null) {
+            val (kind, error) = failure
+            log(
+                "[ws] $key send failed $kind (${error::class.simpleName}: " +
+                    "${error.message?.take(ERR_SNIPPET)}) — killing connection, round rides SSE\n",
+            )
+            failRound(conn, key)
+        }
+        return failure == null
     }
 
     /** The commit point: no event within the budget → the round (and the connection, whose state
-     *  is now indeterminate — the server may or may not have started the response) goes to SSE. */
+     *  is now indeterminate — the server may or may not have started the response) goes to SSE.
+     *  A CLOSED inbox ends the wait IMMEDIATELY instead of burning the whole budget, and says so
+     *  distinguishably: "inbox closed before first event" and "no first event in Nms" are different
+     *  upstream faults, and daemon.log is the only place that difference survives. */
     private suspend fun awaitFirstEvent(conn: WsConnection, key: String): JsonObject? {
-        val first = withTimeoutOrNull(firstEventTimeoutMs) {
-            runCatchingCancellable { conn.inbox.receive() }
-                .onFailure { log("[ws] $key inbox closed before first event: ${it::class.simpleName}\n") }
-                .getOrNull()
-        }
+        val received = withTimeoutOrNull(firstEventTimeoutMs) { receiveCatching(conn) }
+        val first = received?.getOrNull()
         if (first == null) {
-            log("[ws] $key no first event in ${firstEventTimeoutMs}ms — killing connection, round rides SSE\n")
+            val why = if (received == null) {
+                "no first event in ${firstEventTimeoutMs}ms"
+            } else {
+                "inbox closed before first event (${received.exceptionOrNull()?.message?.take(ERR_SNIPPET) ?: "clean"})"
+            }
+            log("[ws] $key $why — killing connection, round rides SSE\n")
             failRound(conn, key)
         }
         return first
@@ -194,9 +234,13 @@ public class WsUpstream(
         return flow {
             emit(first)
             while (!completed) {
-                val evt = runCatchingCancellable { conn.inbox.receive() }.getOrElse {
-                    throw IOException("websocket stream ended mid-round", it)
-                }
+                // A closed inbox mid-round is a TEAR. It must surface as IOException specifically:
+                // TurnDriver's pre-frame reissue keys on `e is IOException` (tearAwareEvents), and
+                // the raw ClosedReceiveChannelException this used to throw matched neither that
+                // check nor the translators' catch lists (adversarial review of WS-1).
+                val received = receiveCatching(conn)
+                val evt = received.getOrNull()
+                    ?: throw IOException("websocket stream ended mid-round", received.exceptionOrNull())
                 completed = isTerminal(evt)
                 emit(evt)
             }

--- a/gateway/provider-spi/src/main/kotlin/splice/spi/WsUpstream.kt
+++ b/gateway/provider-spi/src/main/kotlin/splice/spi/WsUpstream.kt
@@ -27,6 +27,8 @@ import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
+import splice.core.auth.Credentials
+import splice.core.turn.TurnMeta
 import splice.core.util.runCatchingCancellable
 import java.io.IOException
 import java.net.URI
@@ -245,12 +247,22 @@ public class WsUpstream(
                 emit(evt)
             }
         }.onCompletion { cause ->
-            if (cause == null && completed) {
+            // The inbox MUST be empty to pool the connection (adversarial review of WS-3): a frame
+            // the server emits AFTER the round-ending one would otherwise sit in the inbox and be
+            // handed to the NEXT round as its first event — a silent cross-round frame leak, and
+            // the reason this class kills rather than drains. Killing costs one reconnect (a full
+            // send, i.e. today's behaviour); serving a stale frame corrupts the next turn.
+            val drained = conn.inbox.isEmpty
+            val poolable = cause == null && completed
+            if (poolable && drained) {
                 conn.busy.set(false)
                 synchronized(lock) { // touch: completed rounds move their connection to MRU
                     connections.remove(key)?.let { connections[key] = it }
                 }
             } else {
+                if (poolable) {
+                    log("[ws] $key frames arrived after the round terminal — killing rather than pooling\n")
+                }
                 // Cancelled (watchdog/client-gone) or torn: leftover frames of a half-consumed
                 // round poison reuse — kill, next round reconnects (full send, status quo).
                 failRound(conn, key)
@@ -347,3 +359,43 @@ private val wsJson = Json {
     ignoreUnknownKeys = true
     isLenient = true
 }
+
+/**
+ * The WS seam the generic head drives (ws-transport WS-3). It lives in :provider-spi because the
+ * module law forbids :gateway from naming a dialect type (splice.module-law.gradle.kts:15-31), so
+ * every Responses-specific decision — the round-terminal vocabulary, the chaining frame, the
+ * pre-content failure test — is supplied by the provider behind this interface.
+ *
+ * Contract: [attempt] returns null for "serve this round over SSE", which is the answer to every
+ * failure (NEVER-BELOW-STATUS-QUO). The head then runs its normal upstream POST, and SSE keeps
+ * sole ownership of retry, the single-flight 401 refresh and the shared 429 cooldown (L5).
+ */
+public interface WsRoundRunner {
+
+    /** Attempt one round; null = ride SSE. [turnHeaders] are the PER-TURN headers the SSE path
+     *  would send — they participate in connection identity, because a WebSocket's handshake
+     *  headers are fixed for the socket's life and a turn needing a different set must not reuse
+     *  a socket opened without it (adversarial review of WS-3: a lite marker was silently dropped). */
+    public suspend fun attempt(
+        bodyJson: String,
+        meta: TurnMeta,
+        turnHeaders: Map<String, String>,
+        creds: Credentials,
+    ): Flow<JsonObject>?
+
+    /** True when [event] ends the round in FAILURE. The head uses this to bail to SSE while the
+     *  client has still seen nothing, so an upstream error keeps SSE's retry/refresh/cooldown
+     *  rather than being served raw over the WebSocket. */
+    public fun isFailureTerminal(event: JsonObject): Boolean
+
+    /** Called once the round is over: [ok] true only for a clean, fully-consumed terminal.
+     *  Anything else must clear the chaining state — a response id that was never completed would
+     *  anchor the next turn onto context the server never finished building. */
+    public fun roundEnded(meta: TurnMeta, ok: Boolean)
+}
+
+/** Thrown by the head when a WS round failed BEFORE the client saw any content, so the round is
+ *  re-served over SSE. A plain RuntimeException on purpose: the stream translators' catch lists
+ *  (IOException / SerializationException / IllegalArgumentException) must not swallow it, the same
+ *  reason [StreamTornBeforeClient] is one. */
+public class WsRoundNeedsSse : RuntimeException("websocket round failed before any client frame")

--- a/gateway/provider-spi/src/test/kotlin/WsUpstreamTest.kt
+++ b/gateway/provider-spi/src/test/kotlin/WsUpstreamTest.kt
@@ -1,0 +1,652 @@
+// NEW (ws-transport WS-A, 2026-07-31): WsUpstream's lifecycle suite. WsUpstream is the component
+// NEVER-BELOW-STATUS-QUO rests on — every failure mode must return null so the caller rides SSE, and
+// a round that ends any way other than the terminal predicate must poison its connection so leftover
+// frames cannot bleed into the next round. It landed with zero tests.
+//
+// The fake mirrors java.net.http.WebSocket where it MATTERS, not where it is convenient:
+//   * sendText NEVER throws its real failure class — it returns a CompletableFuture that completes
+//     exceptionally (JDK contract: the returned future "can complete exceptionally with IOException
+//     / IllegalStateException"). A fake that threw synchronously would make the send-failure test
+//     green against code that cannot actually observe a send failure.
+//   * onClose closes the inbox with NO cause; onError closes it WITH an IOException cause. Those are
+//     different shapes, and only the second one ever worked.
+//   * frames are delivered on the CALLER's thread, exactly as InboxListener.trySend allows — so the
+//     whole suite is deterministic with zero real time and zero threads. runTest's virtual clock is
+//     also the instrument for "did this fall back promptly or burn the whole budget".
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import splice.spi.InboxListener
+import splice.spi.WsConnection
+import splice.spi.WsUpstream
+import java.io.IOException
+import java.net.URI
+import java.net.http.WebSocket
+import java.nio.ByteBuffer
+import java.util.concurrent.CompletableFuture
+
+private const val KEY = "conv-1"
+private const val WSS_URL = "wss://chatgpt.com/backend-api/codex/responses"
+private const val FRAME = """{"type":"response.create","input":[]}"""
+private const val BUDGET = 15_000L
+private const val CREATED = """{"type":"response.created"}"""
+private const val DELTA = """{"type":"response.output_text.delta","delta":"hi"}"""
+private const val DONE = """{"type":"response.completed"}"""
+private const val CAP = 2
+
+private val HEADERS = mapOf("OpenAI-Beta" to "responses_websockets=v2", "Authorization" to "Bearer t")
+private val TERMINAL: (JsonObject) -> Boolean = { it.type() == "response.completed" }
+
+private fun JsonObject.type(): String = this["type"]?.jsonPrimitive?.content ?: "?"
+
+// ------------------------------------------------------------------- the scripted fake socket ---
+
+private class FakeSocket(private val fx: Fixture) : WebSocket {
+    lateinit var listener: WebSocket.Listener
+    val sent = mutableListOf<String>()
+    var aborts = 0
+    var requests = 0
+
+    override fun sendText(data: CharSequence, last: Boolean): CompletableFuture<WebSocket> {
+        sent += data.toString()
+        fx.sendThrows?.let { throw it }
+        fx.reply(this, data.toString())
+        return fx.sendFuture(this)
+    }
+
+    override fun sendBinary(data: ByteBuffer, last: Boolean): CompletableFuture<WebSocket> = ok()
+
+    override fun sendPing(message: ByteBuffer): CompletableFuture<WebSocket> = ok()
+
+    override fun sendPong(message: ByteBuffer): CompletableFuture<WebSocket> = ok()
+
+    override fun sendClose(statusCode: Int, reason: String): CompletableFuture<WebSocket> = ok()
+
+    override fun request(n: Long) {
+        requests += 1
+    }
+
+    override fun getSubprotocol(): String = "responses_websockets"
+
+    override fun isOutputClosed(): Boolean = false
+
+    override fun isInputClosed(): Boolean = false
+
+    override fun abort() {
+        aborts += 1
+    }
+
+    private fun ok(): CompletableFuture<WebSocket> = CompletableFuture.completedFuture(this)
+
+    // --- server-side pushes, delivered the way the JDK delivers them ---
+
+    fun push(json: String) {
+        pushRaw(json, last = true)
+    }
+
+    fun pushRaw(text: String, last: Boolean) {
+        listener.onText(this, text, last)
+    }
+
+    fun pushBinary() {
+        listener.onBinary(this, ByteBuffer.allocate(1), true)
+    }
+
+    /** The shape that used to escape round(): a close with NO cause. */
+    fun closeClean() {
+        listener.onClose(this, WebSocket.NORMAL_CLOSURE, "bye")
+    }
+
+    fun failWith(cause: Throwable) {
+        listener.onError(this, cause)
+    }
+}
+
+// ----------------------------------------------------------------------------- the fixture ---
+
+private class Fixture {
+    val opened = mutableListOf<FakeSocket>()
+    val handed = mutableListOf<WsConnection>()
+    val log = mutableListOf<String>()
+    val uris = mutableListOf<URI>()
+    val headers = mutableListOf<Map<String, String>>()
+    var connects = 0
+
+    var connectFailure: Throwable? = null
+    var connectGate: CompletableDeferred<Unit>? = null
+    var onHandshake: (FakeSocket) -> Unit = { }
+    var reply: (FakeSocket, String) -> Unit = { _, _ -> }
+    var sendThrows: Throwable? = null
+    var sendFuture: (FakeSocket) -> CompletableFuture<WebSocket> =
+        { CompletableFuture.completedFuture(it) }
+
+    lateinit var up: WsUpstream
+
+    private val connector: suspend (URI, Map<String, String>, WebSocket.Listener) -> WebSocket =
+        { uri, hdrs, listener ->
+            connects += 1
+            uris += uri
+            headers += hdrs
+            connectGate?.await()
+            connectFailure?.let { throw it }
+            val socket = FakeSocket(this)
+            socket.listener = listener
+            opened += socket
+            listener.onOpen(socket)
+            onHandshake(socket)
+            socket
+        }
+
+    fun start(firstEventTimeoutMs: Long = BUDGET, maxConnections: Int = 32): Fixture {
+        up = WsUpstream(
+            firstEventTimeoutMs = firstEventTimeoutMs,
+            maxConnections = maxConnections,
+            log = { log += it },
+            connector = connector,
+        )
+        return this
+    }
+
+    suspend fun go(key: String = KEY, frame: String = FRAME): Flow<JsonObject>? =
+        up.round(key, HEADERS, WSS_URL, TERMINAL) { conn ->
+            handed += conn
+            frame
+        }
+
+    /** Drive a round to completion and return its event types. */
+    suspend fun types(key: String = KEY): List<String> =
+        (go(key) ?: error("round $key unexpectedly fell back to SSE")).toList().map { it.type() }
+
+    fun logged(fragment: String): Boolean = log.any { it.contains(fragment) }
+}
+
+private fun replyWith(vararg events: String): (FakeSocket, String) -> Unit =
+    { socket, _ -> events.forEach { socket.push(it) } }
+
+/**
+ * Collect [flow] INCREMENTALLY (never toList(), which would discard everything seen before a
+ * mid-round tear) and report the event types seen plus the IOException that ended it.
+ */
+private suspend fun collectTorn(flow: Flow<JsonObject>): Pair<List<String>, Throwable?> {
+    val seen = mutableListOf<String>()
+    var torn: Throwable? = null
+    try {
+        flow.collect { seen += it.type() }
+    } catch (e: IOException) {
+        torn = e
+    }
+    return seen to torn
+}
+
+// testScheduler/runCurrent/advanceUntilIdle are the virtual clock this suite measures fallback
+// PROMPTNESS with (a 15s budget costs 0 real seconds); they carry the coroutines experimental marker.
+@OptIn(ExperimentalCoroutinesApi::class)
+class WsUpstreamTest {
+
+    // ============================================================ acquire / connect / registry ===
+
+    @Test
+    fun `a failed handshake returns null and registers nothing`() = runTest {
+        val fx = Fixture().apply { connectFailure = IOException("handshake refused") }.start()
+        assertNull(fx.go(), "a failed connect must ride SSE, never surface as an error")
+        assertEquals(1, fx.connects)
+        assertNull(fx.go(), "still SSE on the second attempt")
+        assertEquals(2, fx.connects, "a failed connect leaves NO registry entry to reuse")
+        assertTrue(fx.logged("connect failed"), "the failure must be diagnosable from daemon.log")
+    }
+
+    @Test
+    fun `a malformed wss url falls back instead of throwing`() = runTest {
+        val fx = Fixture().start()
+        val flow = fx.up.round("k", HEADERS, "wss://host/ path", TERMINAL) { _ -> FRAME }
+        assertNull(flow, "URI.create's IllegalArgumentException must degrade to SSE")
+        assertEquals(0, fx.connects, "the URL is rejected before the connector is reached")
+    }
+
+    @Test
+    fun `the handshake carries the url and headers and frameFor gets the LIVE connection`() = runTest {
+        val fx = Fixture().apply { reply = replyWith(DONE) }.start()
+        assertEquals(listOf("response.completed"), fx.types())
+        assertEquals(WSS_URL, fx.uris.single().toString())
+        assertEquals(HEADERS, fx.headers.single())
+        assertSame(fx.opened.single(), fx.handed.single().socket, "frameFor must see the live connection")
+        assertEquals(listOf(FRAME), fx.opened.single().sent, "exactly one frame per round")
+    }
+
+    @Test
+    fun `a completed round returns the connection to the pool and the next round reuses it`() = runTest {
+        val fx = Fixture().apply { reply = replyWith(CREATED, DELTA, DONE) }.start()
+        assertEquals(
+            listOf("response.created", "response.output_text.delta", "response.completed"),
+            fx.types(),
+        )
+        val generation = fx.handed.single().generation
+        assertEquals(3, fx.types().size)
+        assertEquals(1, fx.connects, "a healthy connection is REUSED, never reconnected")
+        assertSame(fx.handed[0], fx.handed[1])
+        assertEquals(generation, fx.handed[1].generation, "reuse must NOT bump the generation")
+        assertEquals(0, fx.opened.single().aborts)
+    }
+
+    @Test
+    fun `a poisoned connection is never reused and the reconnect gets a NEW generation`() = runTest {
+        val fx = Fixture().start(firstEventTimeoutMs = BUDGET)
+        assertNull(fx.go(), "no first event -> SSE")
+        val dead = fx.handed.single()
+        assertTrue(dead.dead.get(), "the timed-out connection is poisoned")
+        fx.reply = replyWith(DONE)
+        assertEquals(listOf("response.completed"), fx.types())
+        assertEquals(2, fx.connects)
+        assertTrue(
+            fx.handed[1].generation > dead.generation,
+            "a reconnect MUST bump the generation — it is the chaining layer's only reconnect signal",
+        )
+    }
+
+    @Test
+    fun `a reconnect after any poisoning yields a STRICTLY greater generation`() = runTest {
+        val fx = Fixture().apply { reply = replyWith(DONE) }.start()
+        val generations = mutableListOf<Long>()
+        repeat(3) {
+            assertEquals(1, fx.types().size)
+            generations += fx.handed.last().generation
+            fx.handed.last().kill() // simulate any tear: the next round must reconnect
+        }
+        assertEquals(3, fx.connects, "each killed connection forces a real reconnect")
+        assertTrue(
+            generations.zipWithNext().all { (a, b) -> b > a },
+            "generations must be STRICTLY increasing, got $generations",
+        )
+    }
+
+    @Test
+    fun `a second round on a key whose round is still in flight returns null`() = runTest {
+        val fx = Fixture().apply { reply = replyWith(CREATED) }.start()
+        assertNotNull(fx.go(), "the first round commits")
+        assertNull(fx.go(), "never two response-create frames on one socket")
+        assertEquals(1, fx.connects)
+        assertEquals(1, fx.opened.single().sent.size, "the rejected round must not have sent a frame")
+        assertTrue(fx.logged("busy"))
+    }
+
+    @Test
+    fun `KNOWN GAP - a round whose flow is never collected wedges its key busy forever`() = runTest {
+        val fx = Fixture().apply { reply = replyWith(DONE) }.start()
+        assertNotNull(fx.go(), "the round commits and hands back a flow")
+        advanceUntilIdle()
+        assertNull(fx.go(), "busy is cleared only by onCompletion, so an abandoned flow pins the key")
+        assertEquals(1, fx.connects)
+    }
+
+    @Test
+    fun `KNOWN GAP - concurrent COLD rounds on one key both connect, the second tears the first`() = runTest {
+        val fx = Fixture().apply {
+            connectGate = CompletableDeferred()
+            reply = replyWith(CREATED)
+        }.start()
+        val first = async { fx.go() }
+        val second = async { fx.go() }
+        runCurrent()
+        assertTrue(fx.connectGate?.complete(Unit) == true, "both rounds are parked in the handshake")
+        val flowA = first.await()
+        assertNotNull(second.await(), "the second round also commits")
+        assertNotNull(flowA, "both took the existing==null branch — the busy CAS never saw them")
+        assertEquals(2, fx.connects, "the busy flag only guards an EXISTING connection")
+        assertEquals(1, fx.opened[0].aborts, "the second connect kills the first mid-round")
+        val (seen, torn) = collectTorn(flowA ?: error("no flow"))
+        assertEquals(listOf("response.created"), seen)
+        assertNotNull(torn, "the victim round tears rather than truncating silently")
+    }
+
+    // ================================================================================ sendFrame ===
+
+    @Test
+    fun `a send that throws synchronously returns null and poisons the connection`() = runTest {
+        val fx = Fixture().apply { sendThrows = IOException("output closed") }.start()
+        assertNull(fx.go(), "a failed send must ride SSE")
+        assertTrue(fx.handed.single().dead.get(), "a failed send poisons the connection")
+        assertEquals(1, fx.opened.single().aborts)
+        assertTrue(fx.logged("send failed"))
+    }
+
+    @Test
+    fun `a poisoned connection is DEREGISTERED, not left occupying a registry slot`() = runTest {
+        val fx = Fixture().apply { reply = replyWith(DONE) }.start(maxConnections = CAP)
+        assertEquals(1, fx.types("a").size) // registry: [a]
+        fx.sendThrows = IOException("output closed")
+        assertNull(fx.go("b"), "b's send fails") // registry: [a] iff failRound deregisters
+        fx.sendThrows = null
+        assertEquals(1, fx.types("c").size) // registry: [a, c] — still at cap, no eviction
+        assertEquals(
+            0,
+            fx.opened[0].aborts,
+            "a must survive: had the dead b kept its slot, adding c would have evicted a",
+        )
+    }
+
+    @Test
+    fun `a send whose FUTURE fails asynchronously falls back at once, not after the whole budget`() = runTest {
+        val fx = Fixture().apply {
+            sendFuture = { CompletableFuture.failedFuture(IOException("Output closed")) }
+        }.start(firstEventTimeoutMs = BUDGET)
+        val before = testScheduler.currentTime
+        assertNull(fx.go(), "a failed send must ride SSE")
+        val elapsed = testScheduler.currentTime - before
+        assertTrue(
+            elapsed < BUDGET,
+            "sendText reports failure through its FUTURE, never a synchronous throw; unobserved, a dead " +
+                "socket costs the whole ${BUDGET}ms first-event budget before falling back (measured ${elapsed}ms)",
+        )
+        assertTrue(fx.handed.single().dead.get(), "an async send failure poisons the connection")
+        assertTrue(fx.logged("send failed async"))
+    }
+
+    // ========================================================================== awaitFirstEvent ===
+
+    @Test
+    fun `no first event within the budget returns null and poisons the connection`() = runTest {
+        val fx = Fixture().start(firstEventTimeoutMs = BUDGET)
+        val before = testScheduler.currentTime
+        assertNull(fx.go())
+        assertEquals(BUDGET, testScheduler.currentTime - before, "the wait runs the full budget")
+        assertTrue(fx.handed.single().dead.get(), "the connection's state is indeterminate — never reuse it")
+        assertEquals(1, fx.opened.single().aborts)
+        assertTrue(fx.logged("no first event"))
+    }
+
+    @Test
+    fun `a CLEAN close before the first event returns null instead of throwing`() = runTest {
+        val fx = Fixture().apply {
+            reply = { socket, _ -> socket.closeClean() }
+        }.start(firstEventTimeoutMs = BUDGET)
+        val before = testScheduler.currentTime
+        assertNull(fx.go(), "a server that closes before answering must degrade to SSE, never surface an error")
+        assertTrue(
+            testScheduler.currentTime - before < BUDGET,
+            "a closed inbox must end the wait immediately, not burn the budget",
+        )
+        assertTrue(fx.handed.single().dead.get())
+    }
+
+    @Test
+    fun `an ERRORED close before the first event returns null and poisons`() = runTest {
+        val fx = Fixture().apply {
+            reply = { socket, _ -> socket.failWith(IOException("connection reset")) }
+        }.start(firstEventTimeoutMs = BUDGET)
+        val before = testScheduler.currentTime
+        assertNull(fx.go())
+        assertTrue(testScheduler.currentTime - before < BUDGET, "an errored close ends the wait at once")
+        assertTrue(fx.handed.single().dead.get())
+        assertTrue(fx.logged("inbox closed before first event"))
+    }
+
+    // ================================================================================ roundFlow ===
+
+    @Test
+    fun `a terminal FIRST event completes the round with a single emission`() = runTest {
+        val fx = Fixture().apply { reply = replyWith(DONE) }.start()
+        assertEquals(listOf("response.completed"), fx.types())
+        assertFalse(fx.handed.single().dead.get(), "a clean round never poisons")
+        assertNotNull(fx.go(), "and the connection went back to the pool")
+        assertEquals(1, fx.connects)
+    }
+
+    @Test
+    fun `events after the terminal one are NOT emitted - the round stops at the predicate`() = runTest {
+        val fx = Fixture().apply { reply = replyWith(CREATED, DONE, DELTA) }.start()
+        assertEquals(listOf("response.created", "response.completed"), fx.types())
+    }
+
+    @Test
+    fun `a mid-round CLEAN tear throws IOException and poisons the connection`() = runTest {
+        val fx = Fixture().apply {
+            reply = { socket, _ ->
+                socket.push(CREATED)
+                socket.push(DELTA)
+                socket.closeClean()
+            }
+        }.start()
+        val (seen, torn) = collectTorn(fx.go() ?: error("round fell back"))
+        assertEquals(listOf("response.created", "response.output_text.delta"), seen, "no silent truncation")
+        assertNotNull(torn, "a torn round must throw IOException — the type the torn-stream path owns")
+        assertEquals("websocket stream ended mid-round", torn?.message)
+        assertTrue(fx.handed.single().dead.get(), "a torn round poisons its connection")
+        assertEquals(1, fx.opened.single().aborts)
+    }
+
+    @Test
+    fun `a mid-round ERRORED tear throws IOException carrying the cause and poisons`() = runTest {
+        val fx = Fixture().apply {
+            reply = { socket, _ ->
+                socket.push(CREATED)
+                socket.failWith(IOException("reset by peer"))
+            }
+        }.start()
+        val (seen, torn) = collectTorn(fx.go() ?: error("round fell back"))
+        assertEquals(listOf("response.created"), seen)
+        assertEquals("websocket stream ended mid-round", torn?.message)
+        assertEquals("websocket error", torn?.cause?.message, "the upstream cause must survive the wrap")
+        assertTrue(fx.handed.single().dead.get())
+    }
+
+    @Test
+    fun `flow cancellation mid-round poisons the connection instead of returning it to the pool`() = runTest {
+        val fx = Fixture().apply { reply = replyWith(CREATED) }.start()
+        val flow = fx.go() ?: error("round fell back")
+        val conn = fx.handed.single()
+        val seen = mutableListOf<String>()
+        val job = launch { flow.collect { seen += it.type() } }
+        runCurrent()
+        assertEquals(listOf("response.created"), seen, "the committed first event is emitted before the cancel")
+        job.cancelAndJoin()
+        assertTrue(conn.dead.get(), "a watchdog-cancelled round must NEVER return its socket to the pool")
+        assertEquals(1, fx.opened[0].aborts)
+        fx.reply = replyWith(DONE)
+        assertEquals(listOf("response.completed"), fx.types(), "and the key is free for a fresh connection")
+        assertEquals(2, fx.connects)
+    }
+
+    @Test
+    fun `a collector that throws mid-round poisons the connection so leftover frames cannot bleed`() = runTest {
+        val fx = Fixture().apply { reply = replyWith(CREATED, DELTA, DONE) }.start()
+        val flow = fx.go() ?: error("round fell back")
+        val conn = fx.handed.single()
+        var boom: Throwable? = null
+        try {
+            flow.collect { throw IllegalArgumentException("translator blew up on ${it.type()}") }
+        } catch (e: IllegalArgumentException) {
+            boom = e
+        }
+        assertNotNull(boom, "the collector's failure propagates")
+        assertTrue(conn.dead.get(), "DELTA and DONE still sit in the inbox — reuse would hand them to the next round")
+        fx.reply = replyWith(DONE)
+        assertEquals(listOf("response.completed"), fx.types())
+        assertEquals(2, fx.connects, "the poisoned socket must not be reused")
+    }
+
+    // ========================================================================= bounded registry ===
+
+    @Test
+    fun `the registry evicts and closes the least-recently-used connection past its cap`() = runTest {
+        val fx = Fixture().apply { reply = replyWith(DONE) }.start(maxConnections = CAP)
+        assertEquals(1, fx.types("a").size)
+        assertEquals(1, fx.types("b").size)
+        assertEquals(0, fx.opened[0].aborts, "nothing is evicted below the cap")
+        assertEquals(1, fx.types("c").size)
+        assertEquals(3, fx.connects)
+        assertEquals(1, fx.opened[0].aborts, "the oldest connection is evicted AND closed at the cap")
+        assertEquals(0, fx.opened[1].aborts)
+        assertEquals(0, fx.opened[2].aborts)
+        assertEquals(1, fx.types("a").size, "an evicted key reconnects — eviction costs a full send, never an error")
+        assertEquals(4, fx.connects)
+    }
+
+    @Test
+    fun `a completed round moves its connection to MRU so eviction takes the truly-oldest`() = runTest {
+        val fx = Fixture().apply { reply = replyWith(DONE) }.start(maxConnections = CAP)
+        assertEquals(1, fx.types("a").size)
+        assertEquals(1, fx.types("b").size)
+        assertEquals(1, fx.types("a").size)
+        assertEquals(2, fx.connects, "a was reused, not reconnected")
+        assertEquals(1, fx.types("c").size)
+        assertEquals(0, fx.opened[0].aborts, "a was touched to MRU by its second round and must survive")
+        assertEquals(1, fx.opened[1].aborts, "b is the true LRU")
+    }
+
+    // ============================================================================ InboxListener ===
+
+    @Test
+    fun `fragmented text frames assemble into ONE event`() = runTest {
+        val fx = Fixture().apply {
+            reply = { socket, _ ->
+                socket.pushRaw("""{"type":"response.comp""", last = false)
+                socket.pushRaw("""leted"}""", last = true)
+            }
+        }.start()
+        assertEquals(listOf("response.completed"), fx.types(), "a fragmented frame is ONE event, not two")
+    }
+
+    @Test
+    fun `an unparseable text frame is a protocol anomaly and poisons the connection`() = runTest {
+        val fx = Fixture().apply {
+            reply = { socket, _ -> socket.pushRaw("not json at all", last = true) }
+        }.start(firstEventTimeoutMs = BUDGET)
+        val before = testScheduler.currentTime
+        assertNull(fx.go(), "an anomaly must ride SSE")
+        assertTrue(testScheduler.currentTime - before < BUDGET, "the poisoned inbox ends the wait at once")
+        assertTrue(fx.handed.single().dead.get())
+        assertTrue(fx.logged("unparseable frame"))
+    }
+
+    @Test
+    fun `valid JSON that is not an object is a protocol anomaly`() = runTest {
+        val fx = Fixture().apply {
+            reply = { socket, _ -> socket.pushRaw("[1,2]", last = true) }
+        }.start(firstEventTimeoutMs = BUDGET)
+        val before = testScheduler.currentTime
+        assertNull(fx.go(), "jsonObject throws IllegalArgumentException on an array — that is an anomaly")
+        assertTrue(testScheduler.currentTime - before < BUDGET, "the poisoned inbox ends the wait at once")
+        assertTrue(fx.handed.single().dead.get())
+        assertTrue(fx.logged("unparseable frame"))
+    }
+
+    @Test
+    fun `a binary frame is a protocol anomaly and poisons the connection`() = runTest {
+        val fx = Fixture().apply {
+            reply = { socket, _ -> socket.pushBinary() }
+        }.start(firstEventTimeoutMs = BUDGET)
+        val before = testScheduler.currentTime
+        assertNull(fx.go())
+        // The load-bearing assertion. Without it the test passes even when onBinary only LOGS: the
+        // round then just times out, which also ends null + poisoned. Promptness is what separates
+        // "the anomaly poisoned the connection" from "the budget eventually expired".
+        assertTrue(
+            testScheduler.currentTime - before < BUDGET,
+            "a binary frame must poison at once, not leave the round waiting out the whole budget",
+        )
+        assertTrue(fx.handed.single().dead.get(), "a binary frame means we misunderstand the stream")
+        assertTrue(fx.logged("unexpected binary frame"))
+    }
+
+    @Test
+    fun `KNOWN GAP - an anomaly during the handshake window cannot poison anything yet`() = runTest {
+        val fx = Fixture().apply {
+            onHandshake = { socket -> socket.pushBinary() }
+            reply = replyWith(DONE)
+        }.start()
+        assertEquals(listOf("response.completed"), fx.types(), "the round proceeds regardless")
+        assertFalse(
+            fx.handed.single().dead.get(),
+            "pins the gap: onAnomaly fires into a null holder until connect() publishes the connection",
+        )
+        assertTrue(fx.logged("unexpected binary frame"), "it is logged, just not acted on")
+    }
+}
+
+/** InboxListener drives the frame->event boundary and is a separate production class; its tests
+ *  poke it directly with a small Channel, which is how inbox overflow is a 3-frame test instead of
+ *  a 1025-frame one. Split from WsUpstreamTest along the same seam the production code splits on
+ *  (detekt LargeClass, threshold 400, DOES analyse test sources here). */
+@OptIn(ExperimentalCoroutinesApi::class)
+class WsUpstreamInboxListenerTest {
+    @Test
+    fun `sequential fragmented events do not bleed into each other`() {
+        val inbox = Channel<JsonObject>(Channel.UNLIMITED)
+        var anomalies = 0
+        val socket = FakeSocket(Fixture())
+        val listener = InboxListener(inbox, { }, { anomalies += 1 })
+        listener.onText(socket, """{"type":"a""", false)
+        listener.onText(socket, """"}""", true)
+        listener.onText(socket, """{"type":"b""", false)
+        listener.onText(socket, """"}""", true)
+        assertEquals(0, anomalies, "both events parse — the assembly buffer must reset between them")
+        assertEquals("a", inbox.tryReceive().getOrNull()?.type())
+        assertEquals("b", inbox.tryReceive().getOrNull()?.type(), "event 2 must not carry event 1's text")
+    }
+
+    @Test
+    fun `every text frame re-arms request - a missed re-arm deadlocks the stream silently`() {
+        val inbox = Channel<JsonObject>(Channel.UNLIMITED)
+        val socket = FakeSocket(Fixture())
+        val listener = InboxListener(inbox, { }, { })
+        listener.onOpen(socket)
+        assertEquals(1, socket.requests, "onOpen arms the first read")
+        listener.onText(socket, """{"type":"a""", false)
+        assertEquals(2, socket.requests, "a NON-final fragment must re-arm too, or assembly stalls forever")
+        listener.onText(socket, """"}""", true)
+        assertEquals(3, socket.requests)
+    }
+
+    @Test
+    fun `an inbox that overflows is an anomaly, never a silently dropped frame`() {
+        val inbox = Channel<JsonObject>(CAP)
+        var anomalies = 0
+        val socket = FakeSocket(Fixture())
+        val listener = InboxListener(inbox, { }, { anomalies += 1 })
+        repeat(CAP + 1) { listener.onText(socket, """{"type":"e$it"}""", true) }
+        assertEquals(1, anomalies, "the frame past the buffer poisons the connection")
+    }
+
+    @Test
+    fun `a frame arriving on a closed inbox is an anomaly`() {
+        val inbox = Channel<JsonObject>(CAP)
+        var anomalies = 0
+        val socket = FakeSocket(Fixture())
+        val listener = InboxListener(inbox, { }, { anomalies += 1 })
+        inbox.close()
+        listener.onText(socket, DONE, true)
+        assertEquals(1, anomalies)
+    }
+
+    @Test
+    fun `onClose closes the inbox with NO cause and onError closes it with an IOException`() = runTest {
+        val clean = Channel<JsonObject>(1)
+        InboxListener(clean, { }, { }).onClose(FakeSocket(Fixture()), WebSocket.NORMAL_CLOSURE, "bye")
+        val closed = clean.receiveCatching()
+        assertTrue(closed.isClosed)
+        assertNull(closed.exceptionOrNull(), "a clean close carries NO cause — this is the shape that used to escape")
+
+        val errored = Channel<JsonObject>(1)
+        InboxListener(errored, { }, { }).onError(FakeSocket(Fixture()), IOException("reset"))
+        val cause = errored.receiveCatching().exceptionOrNull()
+        assertTrue(cause is IOException, "an errored close carries an IOException, got $cause")
+        assertEquals("websocket error", cause?.message)
+    }
+}

--- a/gateway/provider-spi/src/test/kotlin/WsUpstreamTest.kt
+++ b/gateway/provider-spi/src/test/kotlin/WsUpstreamTest.kt
@@ -319,8 +319,12 @@ class WsUpstreamTest {
 
     @Test
     fun `a send that throws synchronously returns null and poisons the connection`() = runTest {
-        val fx = Fixture().apply { sendThrows = IOException("output closed") }.start()
+        // IllegalStateException, not IOException: production separates the SYNCHRONOUS throw
+        // ("Send pending" / output closed, an ISE) from the ASYNCHRONOUS future failure (IOException),
+        // and only ISE exercises this branch. The sibling test covers the future path (review of #72).
+        val fx = Fixture().apply { sendThrows = IllegalStateException("Send pending") }.start()
         assertNull(fx.go(), "a failed send must ride SSE")
+        assertTrue(fx.logged("send failed sync"), "the SYNCHRONOUS diagnostic, distinct from the async one")
         assertTrue(fx.handed.single().dead.get(), "a failed send poisons the connection")
         assertEquals(1, fx.opened.single().aborts)
         assertTrue(fx.logged("send failed"))
@@ -591,7 +595,12 @@ class WsUpstreamInboxListenerTest {
         val inbox = Channel<JsonObject>(Channel.UNLIMITED)
         var anomalies = 0
         val socket = FakeSocket(Fixture())
-        val listener = InboxListener(inbox, { }, { anomalies += 1 })
+        val listener = InboxListener(
+            inbox,
+            { },
+            terminalSeen = { false },
+            onAnomaly = { anomalies += 1 },
+        )
         listener.onText(socket, """{"type":"a""", false)
         listener.onText(socket, """"}""", true)
         listener.onText(socket, """{"type":"b""", false)
@@ -605,7 +614,12 @@ class WsUpstreamInboxListenerTest {
     fun `every text frame re-arms request - a missed re-arm deadlocks the stream silently`() {
         val inbox = Channel<JsonObject>(Channel.UNLIMITED)
         val socket = FakeSocket(Fixture())
-        val listener = InboxListener(inbox, { }, { })
+        val listener = InboxListener(
+            inbox,
+            { },
+            terminalSeen = { false },
+            onAnomaly = { },
+        )
         listener.onOpen(socket)
         assertEquals(1, socket.requests, "onOpen arms the first read")
         listener.onText(socket, """{"type":"a""", false)
@@ -619,7 +633,12 @@ class WsUpstreamInboxListenerTest {
         val inbox = Channel<JsonObject>(CAP)
         var anomalies = 0
         val socket = FakeSocket(Fixture())
-        val listener = InboxListener(inbox, { }, { anomalies += 1 })
+        val listener = InboxListener(
+            inbox,
+            { },
+            terminalSeen = { false },
+            onAnomaly = { anomalies += 1 },
+        )
         repeat(CAP + 1) { listener.onText(socket, """{"type":"e$it"}""", true) }
         assertEquals(1, anomalies, "the frame past the buffer poisons the connection")
     }
@@ -629,7 +648,12 @@ class WsUpstreamInboxListenerTest {
         val inbox = Channel<JsonObject>(CAP)
         var anomalies = 0
         val socket = FakeSocket(Fixture())
-        val listener = InboxListener(inbox, { }, { anomalies += 1 })
+        val listener = InboxListener(
+            inbox,
+            { },
+            terminalSeen = { false },
+            onAnomaly = { anomalies += 1 },
+        )
         inbox.close()
         listener.onText(socket, DONE, true)
         assertEquals(1, anomalies)
@@ -638,13 +662,15 @@ class WsUpstreamInboxListenerTest {
     @Test
     fun `onClose closes the inbox with NO cause and onError closes it with an IOException`() = runTest {
         val clean = Channel<JsonObject>(1)
-        InboxListener(clean, { }, { }).onClose(FakeSocket(Fixture()), WebSocket.NORMAL_CLOSURE, "bye")
+        InboxListener(clean, { }, terminalSeen = { false }, onAnomaly = { })
+            .onClose(FakeSocket(Fixture()), WebSocket.NORMAL_CLOSURE, "bye")
         val closed = clean.receiveCatching()
         assertTrue(closed.isClosed)
         assertNull(closed.exceptionOrNull(), "a clean close carries NO cause — this is the shape that used to escape")
 
         val errored = Channel<JsonObject>(1)
-        InboxListener(errored, { }, { }).onError(FakeSocket(Fixture()), IOException("reset"))
+        InboxListener(errored, { }, terminalSeen = { false }, onAnomaly = { })
+            .onError(FakeSocket(Fixture()), IOException("reset"))
         val cause = errored.receiveCatching().exceptionOrNull()
         assertTrue(cause is IOException, "an errored close carries an IOException, got $cause")
         assertEquals("websocket error", cause?.message)

--- a/gateway/spikes/results/prompt-cache-drain.md
+++ b/gateway/spikes/results/prompt-cache-drain.md
@@ -145,8 +145,16 @@ behaviour is near-perfect. It is **not** portable to splice as it stands:
   the ChatGPT backend. The chaining is connection state, not server-side storage, so adopting it
   does not imply retaining conversation data upstream.
 
-Adopting it means implementing the Responses WebSocket transport plus its connection lifecycle and
-fallback logic. That is a separate project and an operator decision, not a bug fix.
+**UPDATE 2026-08-01 — this landed.** The `ws-transport` campaign implemented exactly that: a JDK
+`java.net.http.WebSocket` transport (`WsUpstream`), a bail-closed delta classifier
+(`ResponsesWsSession`), and the daemon wiring, all behind `[providers.codex.quirks] websocket`,
+**default false**. Any failure at any stage degrades to the SSE path, which keeps sole ownership of
+retry, the single-flight 401 refresh and the shared 429 cooldown. Measured on a 12-round tool loop:
+wire bytes go FLAT (~2.4KB) while the full send grows linearly — 92.5% less at round 12, 86% over
+the whole loop, and the saving widens with conversation length. Billed input tokens do NOT drop (the
+server reconstructs the same context); what drops is the client-side re-send and, with it, the whole
+class of mid-array prefix drift this document measures. See
+`gateway/spikes/results/responses-websocket.md` for the live protocol receipt.
 
 ### Known residual limitations (review of #71 round 2)
 

--- a/gateway/spikes/results/responses-websocket.md
+++ b/gateway/spikes/results/responses-websocket.md
@@ -1,0 +1,59 @@
+# Can splice use the Responses WebSocket + previous_response_id chaining? (2026-07-31)
+
+**Verdict: GO — all three facts. The ChatGPT codex backend accepts splice's own OAuth on the v2
+WebSocket, streams the same event vocabulary the SSE translator already consumes, and honors
+`previous_response_id` chaining with `store: false`.**
+
+One live probe (scratchpad `ws_probe.py`, Python `websockets`), no codex CLI involved — splice's
+own credentials from `~/.codex/auth.json`.
+
+## The three facts
+
+| # | question | observed |
+|---|---|---|
+| 1 | does the handshake succeed? | **101** on `wss://chatgpt.com/backend-api/codex/responses` with `Authorization: Bearer` + `ChatGPT-Account-ID` + `OpenAI-Beta: responses_websockets=2026-02-06` + `originator: codex_cli_rs` |
+| 2 | does a `response.create` stream? | full turn: `response.created → … → response.output_text.delta → response.completed`, `usage` present |
+| 3 | does chaining work? | **turn 2 sent ONLY the new user message + `previous_response_id`** (no history) and the model answered correctly in context; `store: false` throughout |
+
+Payload frames are plain JSON — one event per text message, `{"type":"response.create", …}` out,
+the standard `response.*` events back. WS-only extras observed: `codex.rate_limits`,
+`codex.response.metadata`, `responsesapi.websocket_timing` — all fall into the reducer's
+`else -> Unit`, so the existing `ResponsesStreamTranslator` consumes a WS round unchanged.
+
+Contract sources: codex-rs `client.rs` (`RESPONSES_WEBSOCKETS_V2_BETA_HEADER_VALUE =
+"responses_websockets=2026-02-06"`; `ResponseCreateWsRequest` = the HTTP request + `type` +
+`previous_response_id` + optional `generate:false` prewarm; attestation header is **optional** —
+`include_attestation` gate, provider may be absent) and the captured 0.145 frames.
+
+## What the leverage actually is — stated precisely
+
+- **Billed input tokens do NOT drop.** Turn 2's usage counted the full logical context (44 tokens
+  = turn 1's context + the new message): the server reconstructs and processes the whole context
+  either way.
+- **What drops is the client's reconstruction of history** — and with it the entire class of
+  mid-array prefix drift this repo spent two review rounds fixing. The server-held context cannot
+  disagree with itself, so the prompt cache should sit at its ceiling instead of being hostage to
+  byte-perfect client rebuilds.
+- **Wire upload collapses** from ~480KB per tool round to ~1KB (the delta), removing the
+  re-serialization and upload latency from every one of the ~95.6% of turns that are tool
+  round-trips.
+
+## Caveats, honestly
+
+- **Chaining is presumed per-connection.** codex's own comment ties `previous_response_id` reuse
+  to the cached connection; cross-connection chaining was not probed. Design consequence:
+  reconnect ⇒ full resend (which is exactly today's behavior, so the floor is status quo).
+- **Tiny-context probe.** 25/44 input tokens is below the caching threshold (`cached=0` proves
+  nothing about cache economics either way). The cache-ceiling claim is an inference from the
+  mechanism, to be verified from live telemetry after the transport lands (ledger WS-5).
+- One model (`gpt-5.6-sol`), toolless turns, one connection, one account. Tool-round chaining
+  (function_call_output as the delta) is exercised by the transport's tests and WS-5, not by this
+  probe.
+- Auth tokens were read from `~/.codex/auth.json` and never logged.
+
+## Consequence
+
+The `previous_response_id` section of `prompt-cache-drain.md` ("not portable — separate project")
+is now the **ws-transport campaign** (`dev/campaigns/ws-transport.toml`): WsUpstream (JDK
+`java.net.http.WebSocket`, no new dependencies) + a bail-closed delta classifier + default-off
+`quirks.websocket`, SSE fallback at every stage.


### PR DESCRIPTION
**The leverage point.** 95.6% of claudex turns are tool round-trips, and every one re-uploads the whole conversation (~177k tokens, ~480KB) to collect a ~175-token tool call. The cache work made each re-send cheaper; this makes the re-send **not happen** — the server keeps the previous response's context per connection, so a continuation turn sends `previous_response_id` plus only the genuinely-new items.

## Measured

12-round tool loop, 2KB tool results, driven through the real builder:

| round | full send | wire | saved |
|---|---|---|---|
| 1 | 2,985 | 3,010 | −0.8% (envelope) |
| 6 | 16,060 | 2,385 | 85.1% |
| 12 | 31,882 | 2,387 | **92.5%** |
| **total** | 208,674 | 29,250 | **86.0%** |

Wire bytes go **flat** while the full send grows linearly — the saving widens with conversation length.

Billed input tokens do **not** drop (the server rebuilds the same context). What drops is the client-side re-send and, with it, the entire class of mid-array prefix drift that `prompt-cache-drain.md` measured at 350M wasted tokens.

## Verified live before any code

A GO/NO-GO spike against the real backend with **splice's own OAuth**, no codex CLI: handshake 101 on `wss://chatgpt.com/backend-api/codex/responses`; the stream carries the **same event vocabulary** the SSE translator already consumes (WS-only `codex.*` frames land in the reducer's `else -> Unit`); and chaining works with `store: false` — turn 2 sent only the new message and answered in context. Receipt: `gateway/spikes/results/responses-websocket.md`, caveats included.

## Default off, and proven so

With the key absent **no WebSocket is constructed and not one line of the overlay executes**. `WsQuirkWiringTest` pins that in both directions; inverting the production condition turns 3 tests red — previously that mutation left all 828 tests green.

## Adversarial review found real defects, including in my own code

Two loop runs. The first found **three defects in `WsUpstream` as shipped**, all confirmed by re-running the commands rather than trusting the report:

- `ClosedReceiveChannelException` extends `NoSuchElementException`, outside `runCatchingCancellable`'s catch list — so a clean server close **escaped `round()`** and the caller never got the `null` the whole fallback design depends on. **7 of 33 tests go red against the parent commit.**
- `sendText` returns a `CompletableFuture` — the async failure was discarded, costing the full 15s budget before fallback.
- `sendFrame`'s catch was inert: the sync throw is `IllegalStateException`, which `runCatchingCancellable` deliberately cannot catch (`CancellationException extends IllegalStateException`).

The second run escalated the wiring with **seven** objections after a repair round. Its artifact was **not applied**; each was adjudicated and closed here — the unfalsifiable switch, a stale-frame leak across pooled rounds, a **chain-key collision** (`stablePromptCacheKey` is first-message-*text* only, so two conversations opening with the same words shared an anchor), silently dropped per-turn headers, a `response.failed` terminal served raw (bypassing retry/401-refresh/429-cooldown), log hygiene, and a non-injective key encoding.

## Safety

`:gateway` may name only `:core` and `:provider-spi` (module law, enforced at Gradle configuration time), so the seam is an SPI interface and every Responses-specific decision stays in the dialect. SSE keeps **sole** ownership of retry, the single-flight 401 refresh and the shared 429 cooldown — none of it is reimplemented on the WS side. Every failure path returns `null` and the round rides SSE.

Full `./gradlew build` green (every module, detekt, konsist); `ast-grep` walls clean.

## Not done

**WS-5, live verification, is operator-gated** and deliberately not attempted here: deploy default-off, flip the key on the codex head, then confirm from telemetry that chaining engages and the cache hit holds against the 90% baseline. One known gap to wire during that step — `codex.rate_limits` arrives as a WS event where the SSE path reads rate-limit *headers*, so the statusline soft-warn goes stale on a WS-only head until it is mapped.

Ledger: `dev/campaigns/ws-transport.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)