### PR TITLE
feat(login): confirm the sign-in in the session, accept a pasted code, and cover /login end-to-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,24 @@
   --all` links the topology's commands but never prunes one whose name disappeared, so the old
   wrapper survives and resolves to no head. Remove it once: `rm ~/.local/bin/claudeor`.
 
+### Added
+
+- `/login` now reports its outcome back INTO the session. The sign-in runs detached, so everything
+  it printed was lost and the session never learned whether it worked; it writes a one-line receipt
+  that the head's `/login` hook reads and consumes on the next prompt. This is the only channel
+  that can confirm a kimi login at all — an RFC 8628 device flow has no browser redirect to render
+  a page in, which is why opencode and Kilo Code both confirm in-client rather than via a callback.
+  Failures are reported too, which is the case that previously said nothing at all.
+- The browser login accepts a PASTED redirect URL (or a bare code) on stdin, racing the loopback
+  callback. A loopback can simply never arrive — browser on another machine, SSH, a container
+  without shared localhost — and the only outcome was a silent five-minute timeout. xAI's own CLI
+  accepts both channels for this reason.
+
 ### Fixed
 
+- The OAuth callback page said "close this tab and head back to your terminal", but `/login` is
+  usually invoked from inside a session where there is no terminal to return to. It now names the
+  destination, matching what xAI's CLI does ("You can close this window and return to Grok Build").
 - `/login` on an api-key head promised "a masked terminal prompt is asking for your key" while
   spawning `<command> login` DETACHED with output to `/dev/null`. Detached means no TTY, so
   `System.console()` was null, the CLI printed its pipe-instead hint into the void, and the

--- a/gateway/app/src/main/kotlin/splice/app/Daemon.kt
+++ b/gateway/app/src/main/kotlin/splice/app/Daemon.kt
@@ -33,6 +33,7 @@ import splice.core.config.StatePaths
 import splice.core.head.Head
 import splice.core.launch.ClaudeConfigMaterializer
 import splice.core.launch.ClaudePolicy
+import splice.core.launch.LoginOutcomeFile
 import splice.core.model.ModelCatalog
 import splice.core.topology.Dialect
 import splice.core.topology.HeadConfig
@@ -738,6 +739,9 @@ public class Daemon(
             signInLabel = signIn.label,
             signInViaBrowser = signIn.viaBrowser,
             tokenCapture = signIn.tokenCapture,
+            // The receipt path MUST match what LoginCommand writes (same StatePaths, same head
+            // key), or a detached sign-in reports into a file nothing reads.
+            loginOutcomeFile = LoginOutcomeFile.pathFor(StatePaths().stateDir, key).toString(),
             advertiseKeySetup = signIn.tokenCapture != null && !keyPresent,
             policy = ClaudePolicy(share = topology.claude.share.toSet(), isolate = head.claude.isolate.toSet()),
             port = head.port,

--- a/gateway/app/src/main/kotlin/splice/app/OAuthLoginFlow.kt
+++ b/gateway/app/src/main/kotlin/splice/app/OAuthLoginFlow.kt
@@ -41,6 +41,12 @@ public data class LoginSpec(
 public object OAuthLoginFlow {
 
     private const val CALLBACK_TIMEOUT_S = 300L
+
+    /** `code=` in a pasted redirect URL or query fragment. */
+    private val CODE_PARAM = Regex("""[?&#]code=([^&\s]+)""")
+
+    /** Shortest thing accepted as a BARE code — below this it is almost certainly a stray key. */
+    private const val MIN_BARE_CODE = 8
     private const val HTTP_OK = 200
     private const val HTTP_BAD_REQUEST = 400
     private const val ERR_BODY_CAP = 300
@@ -89,8 +95,15 @@ public object OAuthLoginFlow {
             println("splice: open this URL to sign in:")
             println(spec.authorizeUrl)
         }
+        // LOOPBACK **OR** STDIN PASTE. A loopback callback can simply never arrive — a browser on
+        // another machine, an SSH session, a container without a shared localhost, a redirect the
+        // provider fires at a different port. xAI's own CLI accepts both for exactly this reason
+        // ("OIDC: waiting for auth code (loopback + stdin)"), and without a second channel the only
+        // outcome is a silent timeout. Racing them means whichever lands first wins; the pasted
+        // value goes through the SAME exchange, so nothing about the token path changes.
+        pasteFallback(spec, latch, codeRef)
         if (!latch.await(CALLBACK_TIMEOUT_S, TimeUnit.SECONDS)) {
-            println("splice: login timed out waiting for the callback.")
+            println("splice: login timed out waiting for the callback (${CALLBACK_TIMEOUT_S}s).")
             return null
         }
         errRef.get()?.let {
@@ -101,6 +114,41 @@ public object OAuthLoginFlow {
             println("splice: login failed: no authorization code received.")
             null
         }
+    }
+
+    /** Read a pasted `code=` value (or a whole redirect URL) from stdin, racing the loopback.
+     *
+     *  Daemon thread on purpose: when the loopback wins, this reader is still parked on a blocking
+     *  read that nothing will ever satisfy, and a non-daemon thread would keep the JVM alive after
+     *  a successful login. Silently no-ops without a console, which is also the detached case. */
+    private fun pasteFallback(spec: LoginSpec, latch: CountDownLatch, codeRef: AtomicReference<String?>) {
+        if (System.console() == null) return
+        println("splice: if the browser cannot reach this machine, paste the redirect URL (or just the code) here:")
+        val t = Thread {
+            runCatchingCancellable {
+                generateSequence(::readlnOrNull).forEach { line ->
+                    if (latch.count == 0L) return@Thread // the loopback already won
+                    extractCode(line)?.let { code ->
+                        codeRef.compareAndSet(null, code)
+                        latch.countDown()
+                        return@Thread
+                    }
+                    if (line.isNotBlank()) println("splice: that is not an authorization code — try again:")
+                }
+            }.discard("stdin closed or unreadable; the loopback callback is still live")
+        }
+        t.isDaemon = true
+        t.name = "splice-login-paste-${spec.head}"
+        t.start()
+    }
+
+    /** A pasted redirect URL, a bare `code=...` fragment, or a bare code. Null when it is neither. */
+    internal fun extractCode(raw: String): String? {
+        val line = raw.trim()
+        if (line.isEmpty()) return null
+        CODE_PARAM.find(line)?.let { return it.groupValues[1] }
+        // A bare code: no scheme, no spaces, and long enough not to be a stray keystroke.
+        return line.takeIf { !it.contains("://") && !it.contains(' ') && it.length >= MIN_BARE_CODE }
     }
 
     private fun handleCallback(
@@ -149,7 +197,10 @@ public object OAuthLoginFlow {
         val cls = if (ok) "ok" else "err"
         val title = if (ok) "Signed in to splice" else "Login didn’t complete"
         val sub = if (ok) {
-            "You’re all set — close this tab and head back to your terminal."
+            // Name the DESTINATION, not "your terminal": /login is usually invoked from inside a
+            // Claude Code session, where there is no terminal to go back to. xAI's own CLI does
+            // exactly this — "You can close this window and return to Grok Build."
+            "You’re all set — close this window and return to your splice session."
         } else {
             "Something went wrong signing in. You can close this tab and try again."
         }

--- a/gateway/app/src/main/kotlin/splice/app/cli/LoginCommand.kt
+++ b/gateway/app/src/main/kotlin/splice/app/cli/LoginCommand.kt
@@ -12,6 +12,8 @@ import splice.app.LoginSpec
 import splice.app.OAuthLoginFlow
 import splice.app.TopologyLoader
 import splice.core.config.KeyStore
+import splice.core.config.StatePaths
+import splice.core.launch.LoginOutcomeFile
 import splice.core.topology.ProviderConfig
 import splice.core.topology.Topology
 import splice.core.topology.ambiguousHeadMessage
@@ -50,6 +52,20 @@ internal suspend fun login(headArg: String?): Boolean {
     }
     val ok = runLoginFlow(headKey, providerKey, provider, topology)
     if (!ok) println("splice: login for '$headKey' did not complete.")
+    // THE RECEIPT (2026-08-01). /login runs this detached, so everything printed above is lost and
+    // the session that asked never learns the result. One line on disk, read back by the head's
+    // /login hook on the next prompt — the only channel that also works for kimi, whose device flow
+    // has no browser redirect to confirm in. Written for BOTH outcomes: "it failed" is the message
+    // a user most needs and least gets today.
+    LoginOutcomeFile.write(
+        StatePaths().stateDir,
+        headKey,
+        if (ok) {
+            "signed in — this session is using the new credentials."
+        } else {
+            "sign-in did not complete. Run `$headKey login` in a terminal to see why."
+        },
+    )
     return ok
 }
 

--- a/gateway/app/src/test/kotlin/OAuthPasteFallbackTest.kt
+++ b/gateway/app/src/test/kotlin/OAuthPasteFallbackTest.kt
@@ -1,0 +1,52 @@
+// WALLS for the /login stdin paste fallback (2026-08-01). A loopback callback can simply never
+// arrive — a browser on another machine, an SSH session, a container without a shared localhost,
+// a provider redirecting to a different port. xAI's own CLI accepts BOTH channels for exactly this
+// reason ("OIDC: waiting for auth code (loopback + stdin)"); without a second channel the only
+// outcome is a silent five-minute timeout, which is the symptom being reported.
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import splice.app.OAuthLoginFlow
+
+class OAuthPasteFallbackTest {
+
+    /** The realistic paste: the whole redirect URL straight out of the browser bar. */
+    @Test
+    fun `a pasted redirect URL yields its code`() {
+        assertEquals(
+            "abc123XYZ",
+            OAuthLoginFlow.extractCode("http://127.0.0.1:1455/auth/callback?code=abc123XYZ&state=s1"),
+        )
+        assertEquals(
+            "abc123XYZ",
+            OAuthLoginFlow.extractCode("  http://localhost:8080/callback?state=s1&code=abc123XYZ  "),
+            "order must not matter, and surrounding whitespace is normal when pasting",
+        )
+    }
+
+    /** Some providers put the code in the fragment rather than the query. */
+    @Test
+    fun `a fragment-delivered code is found too`() {
+        assertEquals("frag-code-1", OAuthLoginFlow.extractCode("http://127.0.0.1:1455/cb#code=frag-code-1"))
+    }
+
+    /** The other realistic paste: the user copies just the code out of the URL. */
+    @Test
+    fun `a bare code is accepted`() {
+        assertEquals("ac_01HXYZabcdef", OAuthLoginFlow.extractCode("ac_01HXYZabcdef"))
+    }
+
+    /** Anything that is plainly not a code must be REJECTED, so the reader can re-prompt rather
+     *  than exchanging a stray keystroke and burning the login attempt. */
+    @Test
+    fun `noise is rejected rather than exchanged`() {
+        assertNull(OAuthLoginFlow.extractCode(""), "a bare Enter is not a code")
+        assertNull(OAuthLoginFlow.extractCode("   "), "whitespace is not a code")
+        assertNull(OAuthLoginFlow.extractCode("y"), "a stray keystroke is not a code")
+        assertNull(OAuthLoginFlow.extractCode("no thanks"), "prose is not a code")
+        assertNull(
+            OAuthLoginFlow.extractCode("https://accounts.x.ai/sign-in"),
+            "a URL with no code parameter must not be mistaken for a bare code",
+        )
+    }
+}

--- a/gateway/app/src/test/kotlin/splice/app/SignInPlanMatrixTest.kt
+++ b/gateway/app/src/test/kotlin/splice/app/SignInPlanMatrixTest.kt
@@ -1,0 +1,130 @@
+// WALLS for /login across EVERY head kind (operator request, 2026-08-01). Nothing tested the
+// auth.kind -> /login shape mapping before, which is how two regressions landed in one week:
+//
+//  1. api-key heads promised "a masked terminal prompt is asking for your key" while spawning a
+//     DETACHED login that has no TTY and could never prompt — a dead end nothing caught;
+//  2. a fix for (1) then removed /login from api-key heads without a capture pattern, deleting
+//     working behaviour, because no test asserted that EVERY head keeps /login.
+//
+// THE INVARIANT THIS FILE HOLDS: every head in the topology has a sign-in path — that is what
+// being in the topology means. /login is therefore wired for ALL of them. What varies is only
+// the WORDING and whether a browser is spawned.
+package splice.app
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import splice.core.topology.AuthConfig
+import splice.core.topology.ClaudeWrapperConfig
+import splice.core.topology.Dialect
+import splice.core.topology.HeadConfig
+import splice.core.topology.ProviderConfig
+
+private fun head(provider: String, command: String) = HeadConfig(
+    provider = provider,
+    port = 3100,
+    discoveryPrefix = "claude-$provider--",
+    pinnedModel = "m",
+    claude = ClaudeWrapperConfig(command = command),
+)
+
+private fun providerCfg(authKind: String, envVar: String? = null) = ProviderConfig(
+    dialect = Dialect.OPENAI_RESPONSES,
+    baseUrl = "https://example.invalid",
+    auth = AuthConfig(kind = authKind, env = envVar),
+)
+
+class SignInPlanMatrixTest {
+
+    /** THE LOAD-BEARING ONE. Every supported head kind gets a /login command. A blank command is
+     *  what makes LoginInterception.wire() skip the hook entirely, so a blank here means the head
+     *  silently loses /login — the exact regression this pins against. */
+    @Test
+    fun `EVERY head kind gets a login command — none is silently skipped`() {
+        val cases = listOf(
+            "chatgpt-oauth" to head("codex", "claudex"),
+            "grok-oauth" to head("xai", "claude-grok"),
+            "kimi-oauth" to head("kimi", "claude-kimi"),
+            API_KEY to head("openrouter", "claude-openrouter"), // known token shape
+            API_KEY to head("fireworks", "claude-fireworks"), // NO known token shape
+        )
+        for ((kind, h) in cases) {
+            val plan = signInPlan(providerCfg(kind), h, h.provider)
+            assertTrue(
+                plan.command.isNotBlank(),
+                "$kind (${h.provider}) lost its /login command — wire() would skip the hook entirely",
+            )
+            assertEquals("${h.claude.command} login", plan.command, "the command must name the head's wrapper")
+            assertTrue(plan.label.isNotBlank(), "$kind needs a label for the /login wording")
+        }
+    }
+
+    /** Browser heads open a browser; api-key heads must NOT, because a detached login has no TTY
+     *  and the prompt it promises can never appear. */
+    @Test
+    fun `only browser-based kinds are marked viaBrowser`() {
+        assertTrue(signInPlan(providerCfg("chatgpt-oauth"), head("codex", "claudex"), "codex").viaBrowser)
+        assertTrue(signInPlan(providerCfg("grok-oauth"), head("xai", "claude-grok"), "xai").viaBrowser)
+        assertTrue(signInPlan(providerCfg("kimi-oauth"), head("kimi", "claude-kimi"), "kimi").viaBrowser)
+        assertFalse(
+            signInPlan(providerCfg(API_KEY), head("openrouter", "claude-openrouter"), "openrouter").viaBrowser,
+            "an api-key head has no browser flow — claiming one is what produced the dead-end prompt",
+        )
+    }
+
+    /** ONE PROVIDER AT A TIME: capture is opt-in per vendor whose token shape splice actually
+     *  knows. This scopes CAPTURE only — never whether /login exists (asserted above). */
+    @Test
+    fun `token capture is enabled only for vendors whose token shape splice knows`() {
+        val openrouter = signInPlan(providerCfg(API_KEY), head("openrouter", "claude-openrouter"), "openrouter")
+        assertNotNull(openrouter.tokenCapture, "OpenRouter's sk-or- prefix is unambiguous — capture is safe")
+        assertEquals("OPENROUTER_API_KEY", openrouter.tokenCapture?.envVar)
+        assertTrue(openrouter.tokenCapture!!.tokenPattern.startsWith("sk-or-"))
+
+        for (vendor in listOf("fireworks", "openai", "moonshot")) {
+            assertNull(
+                signInPlan(providerCfg(API_KEY), head(vendor, "claude-$vendor"), vendor).tokenCapture,
+                "$vendor has no pinned token shape — guessing one risks capturing ordinary prose",
+            )
+        }
+    }
+
+    /** An OAuth head never captures pastes: its secret never appears in the prompt box at all. */
+    @Test
+    fun `oauth kinds never enable paste capture`() {
+        for (kind in listOf("chatgpt-oauth", "grok-oauth", "kimi-oauth")) {
+            assertNull(
+                signInPlan(providerCfg(kind), head("p", "claude-p"), "p").tokenCapture,
+                "$kind signs in through the browser — there is no token to paste",
+            )
+        }
+    }
+
+    /** An UNKNOWN auth kind is the one case with no sign-in path, and it must stay blank so
+     *  wire() skips /login rather than advertising something that cannot work. */
+    @Test
+    fun `an unknown auth kind gets no login command`() {
+        val plan = signInPlan(providerCfg("some-future-kind"), head("x", "claude-x"), "x")
+        assertEquals("", plan.command, "no known flow => no /login, rather than a broken one")
+        assertNull(plan.tokenCapture)
+    }
+
+    /** The env var the capture hook writes must be the one the auth provider READS, or a captured
+     *  key lands somewhere nothing looks. Pinned for the explicit-env case too. */
+    @Test
+    fun `capture writes the same env var the provider resolves`() {
+        val explicit = signInPlan(
+            providerCfg(API_KEY, envVar = "CUSTOM_OR_KEY"),
+            head("openrouter", "claude-openrouter"),
+            "openrouter",
+        )
+        assertEquals(
+            "CUSTOM_OR_KEY",
+            explicit.tokenCapture?.envVar,
+            "an explicit auth.env must win, or the key is stored under a name nothing reads",
+        )
+    }
+}

--- a/gateway/control/src/main/kotlin/splice/control/LaunchService.kt
+++ b/gateway/control/src/main/kotlin/splice/control/LaunchService.kt
@@ -32,6 +32,9 @@ public data class LaunchSpec(
     val tokenCapture: TokenCaptureSpec? = null,
     /** Install the SessionStart key-missing advertiser (daemon sets it only while unconfigured). */
     val advertiseKeySetup: Boolean = false,
+    /** Absolute path of this head's login receipt (LoginOutcomeFile) — the channel a DETACHED
+     *  sign-in uses to tell the session what happened. Empty = no in-session confirmation. */
+    val loginOutcomeFile: String = "",
     val policy: ClaudePolicy,
     val port: Int,
     /** Per-install local gateway credential; shared with the head's inbound verifier. */
@@ -72,6 +75,7 @@ public class LaunchService(
                 signInViaBrowser = spec.signInViaBrowser,
                 tokenCapture = spec.tokenCapture,
                 advertiseKeySetup = spec.advertiseKeySetup,
+                loginOutcomeFile = spec.loginOutcomeFile,
             ),
         )
         val env = buildEnv(spec)

--- a/gateway/core/src/main/kotlin/splice/core/launch/ClaudeConfigMaterializer.kt
+++ b/gateway/core/src/main/kotlin/splice/core/launch/ClaudeConfigMaterializer.kt
@@ -70,6 +70,9 @@ public data class MaterializeSpec(
     // api-key heads: capture a BARE provider token pasted as the whole message into the KeyStore,
     // blocked before it reaches the model context. Null disables capture.
     val tokenCapture: TokenCaptureSpec? = null,
+    /** Absolute path of this head's login receipt (LoginOutcomeFile). Empty disables the
+     *  in-session confirmation — the detached sign-in still works, it just cannot report back. */
+    val loginOutcomeFile: String = "",
     // Install the SessionStart key-missing advertiser. The daemon sets this only while the head's
     // key is unconfigured and re-materializes on every launch, so the advertiser removes itself
     // once the key lands. Requires tokenCapture for the paste instruction to be true.
@@ -97,6 +100,7 @@ public class ClaudeConfigMaterializer(
                 globalCommands = if (shares(spec.policy, Keys.COMMANDS)) globalDir().resolve(Keys.COMMANDS) else null,
                 viaBrowser = spec.signInViaBrowser,
                 tokenCapture = spec.tokenCapture,
+                loginOutcomeFile = spec.loginOutcomeFile,
             ),
             if (spec.advertiseKeySetup && spec.tokenCapture != null) {
                 LoginInterception.keySetupAdvertiser(spec.configDir, spec.tokenCapture, spec.loginCommand)

--- a/gateway/core/src/main/kotlin/splice/core/launch/LoginHookScripts.kt
+++ b/gateway/core/src/main/kotlin/splice/core/launch/LoginHookScripts.kt
@@ -15,15 +15,21 @@ internal fun loginCommandMd(signInLabel: String, sentinel: String): String =
     |$sentinel
     """.trimMargin() + "\n"
 
-internal fun loginHookScript(
-    loginCommand: String,
-    signInLabel: String,
-    viaBrowser: Boolean,
-    sentinel: String,
+/** Everything the /login hook needs for ONE head — a parameter object because these six always
+ *  travel together and describe a single thing: how this head signs in. */
+internal data class LoginHookSpec(
+    val loginCommand: String,
+    val signInLabel: String,
+    val viaBrowser: Boolean,
+    val sentinel: String,
+    /** Absolute path of this head's login receipt — see LoginOutcomeFile. */
+    val outcomeFile: String,
     /** True when this head can capture a bare token pasted into the prompt box. Decides the whole
      *  shape of /login for an api-key head — see [lead] below. */
-    canCapturePaste: Boolean,
-): String =
+    val canCapturePaste: Boolean,
+)
+
+internal fun loginHookScript(hook: LoginHookSpec): String =
     buildString {
         val d = "$" // keep the shell $ out of Kotlin interpolation
         // WHY THREE WORDINGS (2026-08-01): the api-key branch used to promise "a masked terminal
@@ -34,28 +40,46 @@ internal fun loginHookScript(
         // capture a paste is therefore told the path that actually works, and nothing is spawned.
         val lead =
             when {
-                viaBrowser ->
-                    "Opening your browser to sign in to $signInLabel — finish there, then continue. " +
-                        "If it did not open, run: $loginCommand"
-                canCapturePaste ->
-                    "Paste your $signInLabel API key as your next message. splice stores it to " +
+                hook.viaBrowser ->
+                    "Opening your browser to sign in to ${hook.signInLabel} — finish there, then continue. " +
+                        "If it did not open, run: ${hook.loginCommand}"
+                hook.canCapturePaste ->
+                    "Paste your ${hook.signInLabel} API key as your next message. splice stores it to " +
                         "~/.config/splice/keys.toml (0600) and BLOCKS it before it reaches the model, " +
                         "so it is never sent upstream. Note: the session log on disk still records the " +
-                        "pasted line — for a fully masked entry, run `$loginCommand` in a terminal " +
+                        "pasted line — for a fully masked entry, run `${hook.loginCommand}` in a terminal " +
                         "instead. Then wait."
                 else ->
-                    "This head signs in with an API key. Run `$loginCommand` in a terminal — it asks " +
+                    "This head signs in with an API key. Run `${hook.loginCommand}` in a terminal — it asks " +
                         "for the key with a masked prompt. It cannot be asked for from inside this " +
                         "session."
             }
         appendLine("#!/usr/bin/env bash")
-        appendLine("# NEW (splice): /login interception — route to this head's $signInLabel sign-in,")
+        appendLine("# NEW (splice): /login interception — route to this head's ${hook.signInLabel} sign-in,")
         appendLine("# not Claude Code's disabled Anthropic login. Blocks the model turn.")
         appendLine("input=\"$d(cat)\"")
+        // THE LOGIN RECEIPT (2026-08-01). The sign-in runs detached, so everything it prints is
+        // lost; without this the session never learns whether the login worked. kimi CANNOT be
+        // confirmed in a browser at all (device flow: no redirect target), so the confirmation has
+        // to arrive here — the same in-client status surface opencode and Kilo Code settled on.
+        // Checked on EVERY prompt, not just /login, because the user finishes in the browser and
+        // then types something ordinary.
+        appendLine("receipt=\"${hook.outcomeFile}\"")
+        appendLine("if [ -f \"${d}receipt\" ]; then")
+        appendLine("  msg=\"$d(cat \"${d}receipt\" 2>/dev/null)\"")
+        appendLine("  rm -f \"${d}receipt\"")
+        appendLine("  if [ -n \"${d}msg\" ]; then")
+        append("    printf '%s' \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":")
+        append("\\\"UserPromptSubmit\\\",\\\"additionalContext\\\":\\\"splice ")
+        append("${hook.signInLabel} login: ${d}msg\\\"}}\"")
+        appendLine()
+        appendLine("    exit 0")
+        appendLine("  fi")
+        appendLine("fi")
         appendLine("case \"${d}input\" in")
-        appendLine("  *$sentinel*|*'\"prompt\":\"/login\"'*|*'\"prompt\": \"/login\"'*)")
+        appendLine("  *${hook.sentinel}*|*'\"prompt\":\"/login\"'*|*'\"prompt\": \"/login\"'*)")
         // Only the browser flow is spawned. A detached api-key login has no TTY and cannot prompt.
-        if (viaBrowser) appendLine("    nohup $loginCommand >/dev/null 2>&1 &")
+        if (hook.viaBrowser) appendLine("    nohup ${hook.loginCommand} >/dev/null 2>&1 &")
         append("    printf '%s' '{\"decision\":\"block\",\"reason\":")
         append("\"$lead\"}'")
         appendLine()

--- a/gateway/core/src/main/kotlin/splice/core/launch/LoginInterception.kt
+++ b/gateway/core/src/main/kotlin/splice/core/launch/LoginInterception.kt
@@ -60,6 +60,7 @@ internal object LoginInterception {
         globalCommands: Path?,
         viaBrowser: Boolean = true,
         tokenCapture: TokenCaptureSpec? = null,
+        loginOutcomeFile: String = "",
     ): Map<String, List<JsonObject>> {
         if (loginCommand.isBlank() && tokenCapture == null) return emptyMap()
         return runCatchingCancellable {
@@ -71,11 +72,14 @@ internal object LoginInterception {
                         configDir,
                         LOGIN_HOOK_SH,
                         loginHookScript(
-                            loginCommand,
-                            signInLabel,
-                            viaBrowser,
-                            LOGIN_SENTINEL,
-                            canCapturePaste = tokenCapture != null,
+                            LoginHookSpec(
+                                loginCommand = loginCommand,
+                                signInLabel = signInLabel,
+                                viaBrowser = viaBrowser,
+                                sentinel = LOGIN_SENTINEL,
+                                outcomeFile = loginOutcomeFile,
+                                canCapturePaste = tokenCapture != null,
+                            ),
                         ),
                     )
                     upsHooks += hookEntry(script, HOOK_TIMEOUT_SECONDS)

--- a/gateway/core/src/main/kotlin/splice/core/launch/LoginOutcomeFile.kt
+++ b/gateway/core/src/main/kotlin/splice/core/launch/LoginOutcomeFile.kt
@@ -1,0 +1,62 @@
+// NEW: (login UX, 2026-08-01) the in-session login receipt.
+//
+// THE PROBLEM. `/login` runs the sign-in DETACHED, so every message the flow prints — "signed in",
+// "the code expired", the kimi user code — goes to /dev/null. The session that asked for the login
+// therefore never learns what happened. That is what "kimi and grok don't confirm the login" is:
+// not a missing browser page but a missing channel back.
+//
+// A browser page CANNOT be the answer for every head. kimi is an RFC 8628 device flow: the browser
+// stays on the provider's own page and there is no redirect target for splice to render. Both
+// opencode's Kimi plugin and Kilo Code (which deliberately MIGRATED from browser-callback OAuth to
+// device auth, PR #4178) confirm in-client for exactly this reason — a status surface, not a
+// redirect. This file is that surface for splice.
+//
+// SHAPE. The login writes one short line; the head's /login hook reads and deletes it on the next
+// prompt. Deliberately NOT a socket or a daemon call: the login may outlive the session, run
+// before the daemon is up, or be run from a plain terminal, and a file survives all three. Stale
+// receipts self-expire so a login from an hour ago cannot confirm today's prompt.
+package splice.core.launch
+
+import splice.core.util.discard
+import splice.core.util.runCatchingCancellable
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+
+public object LoginOutcomeFile {
+
+    /** Older than this and the receipt is ignored: a login the user has since forgotten about must
+     *  not surface as a confirmation for an unrelated prompt. */
+    private const val FRESH_WINDOW_MS: Long = 10 * 60 * 1000
+
+    public fun pathFor(stateDir: Path, head: String): Path =
+        stateDir.resolve("login-outcome-${head.replace(Regex("[^A-Za-z0-9_-]"), "_")}.txt")
+
+    /** Record the outcome. Best-effort by construction: a login that SUCCEEDED must never be
+     *  reported as failed because its receipt could not be written. */
+    public fun write(stateDir: Path, head: String, message: String) {
+        runCatchingCancellable {
+            Files.createDirectories(stateDir)
+            val path = pathFor(stateDir, head)
+            Files.write(
+                path,
+                (message.replace('\n', ' ').trim() + "\n").toByteArray(),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.WRITE,
+                StandardOpenOption.TRUNCATE_EXISTING,
+            )
+        }.discard("the login itself already succeeded or failed; the receipt is a courtesy")
+    }
+
+    /** Read and CONSUME a fresh receipt, or null. Consuming is the point: a confirmation is shown
+     *  once, not on every prompt for the rest of the session. */
+    public fun consume(stateDir: Path, head: String, nowMs: Long = System.currentTimeMillis()): String? =
+        runCatchingCancellable {
+            val path = pathFor(stateDir, head)
+            if (!Files.isRegularFile(path)) return@runCatchingCancellable null
+            val age = nowMs - Files.getLastModifiedTime(path).toMillis()
+            val text = Files.readString(path).trim()
+            Files.deleteIfExists(path) // consumed either way — a stale receipt must not linger
+            text.takeIf { it.isNotEmpty() && age in 0..FRESH_WINDOW_MS }
+        }.getOrNull()
+}

--- a/gateway/core/src/test/kotlin/LoginOutcomeFileTest.kt
+++ b/gateway/core/src/test/kotlin/LoginOutcomeFileTest.kt
@@ -1,0 +1,79 @@
+// WALLS for the in-session login receipt (2026-08-01). This is the ONLY channel by which a
+// DETACHED sign-in can tell the session what happened — and for kimi it is the only channel at
+// all, since an RFC 8628 device flow has no browser redirect to confirm in (the reason opencode
+// and Kilo Code both confirm in-client rather than via a callback page).
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import splice.core.launch.LoginOutcomeFile
+import java.nio.file.Files
+import java.nio.file.Path
+
+class LoginOutcomeFileTest {
+
+    @Test
+    fun `a written receipt is read back once, then consumed`(@TempDir tmp: Path) {
+        LoginOutcomeFile.write(tmp, "claudex", "signed in — this session is using the new credentials.")
+        assertEquals(
+            "signed in — this session is using the new credentials.",
+            LoginOutcomeFile.consume(tmp, "claudex"),
+        )
+        assertNull(
+            LoginOutcomeFile.consume(tmp, "claudex"),
+            "a confirmation shows ONCE — otherwise every later prompt re-announces an old login",
+        )
+    }
+
+    /** The failure receipt matters more than the success one: today a detached login that fails
+     *  says nothing at all, and the user waits on a session that will never work. */
+    @Test
+    fun `a failure receipt reaches the session too`(@TempDir tmp: Path) {
+        LoginOutcomeFile.write(tmp, "claude-kimi", "sign-in did not complete.")
+        assertEquals("sign-in did not complete.", LoginOutcomeFile.consume(tmp, "claude-kimi"))
+    }
+
+    /** A login from an hour ago must not confirm an unrelated prompt today. */
+    @Test
+    fun `a stale receipt is discarded, not shown`(@TempDir tmp: Path) {
+        LoginOutcomeFile.write(tmp, "claudex", "signed in")
+        val hourLater = System.currentTimeMillis() + 60 * 60 * 1000
+        assertNull(LoginOutcomeFile.consume(tmp, "claudex", nowMs = hourLater))
+        assertFalse(
+            Files.exists(LoginOutcomeFile.pathFor(tmp, "claudex")),
+            "stale receipts are deleted on read — a file left behind would surface later",
+        )
+    }
+
+    /** Heads must never read each other's confirmations. */
+    @Test
+    fun `receipts are per head`(@TempDir tmp: Path) {
+        LoginOutcomeFile.write(tmp, "claudex", "codex signed in")
+        LoginOutcomeFile.write(tmp, "claude-grok", "grok signed in")
+        assertEquals("codex signed in", LoginOutcomeFile.consume(tmp, "claudex"))
+        assertEquals("grok signed in", LoginOutcomeFile.consume(tmp, "claude-grok"))
+    }
+
+    /** A head name reaches this from the topology, so it must not be able to escape the dir. */
+    @Test
+    fun `a hostile head name cannot escape the state dir`(@TempDir tmp: Path) {
+        val path = LoginOutcomeFile.pathFor(tmp, "../../etc/passwd")
+        assertEquals(tmp, path.parent, "the receipt must stay inside the state dir")
+        assertFalse(path.toString().contains(".."))
+    }
+
+    /** Newlines would break the one-line shell read-back in the hook. */
+    @Test
+    fun `a multi-line message is flattened to one line`(@TempDir tmp: Path) {
+        LoginOutcomeFile.write(tmp, "claudex", "line one\nline two")
+        val read = LoginOutcomeFile.consume(tmp, "claudex")
+        assertEquals("line one line two", read)
+        assertFalse(read!!.contains('\n'), "the hook reads ONE line; an embedded newline truncates it")
+    }
+
+    @Test
+    fun `no receipt means no confirmation`(@TempDir tmp: Path) {
+        assertNull(LoginOutcomeFile.consume(tmp, "never-logged-in"))
+    }
+}


### PR DESCRIPTION
**Continuation of #75.** That PR merged at its then-head (`0cba0f9`), so the two commits pushed after the merge never landed. This carries exactly those, cherry-picked onto current `main` — no conflicts, and the reviews on #75 were all resolved before it merged.

The three findings here all come from reading what the reference implementations actually do, rather than guessing.

## 1. The callback page named the wrong place

It said *"close this tab and head back to your terminal"* — but `/login` is usually invoked from inside a session, where there is no terminal to return to. xAI's own CLI (`grok 0.2.99`, `auth/oidc/login.rs`) names the **destination**:

```
"Signed in"
"You can close this window and return to Grok Build."
```

splice now does the same. **This affects codex too**, not just grok.

## 2. The loopback is now raced with a stdin paste

A loopback callback can simply never arrive — a browser on another machine, an SSH session, a container without shared localhost, a provider redirecting elsewhere. The only outcome was a silent five-minute timeout, which is the reported symptom.

The same grok binary shows xAI hit this and solved it identically:

```
OIDC: waiting for auth code (loopback + stdin)
OIDC: received code via stdin paste
```

splice now accepts a pasted redirect URL, a `#code=` fragment, or a bare code. Whichever channel lands first wins, and the pasted value goes through the **identical** exchange. The reader is a daemon thread, so a won loopback can't keep the JVM alive on a blocking read; noise is rejected rather than exchanged.

## 3. The sign-in reports back into the session

This is the actual *"kimi and grok don't confirm the login"* bug: `/login` runs the flow **detached**, so everything it prints — the success line, the failure reason, kimi's user code — goes to `/dev/null`.

**A browser page cannot fix this for kimi at all.** RFC 8628 device flow has no redirect target; the browser stays on Moonshot's page. Both opencode's Kimi plugin and Kilo Code confirm **in-client** for exactly this reason — Kilo Code deliberately *migrated away* from browser-callback OAuth to device auth (PR #4178) and built a status card rather than a redirect.

`LoginOutcomeFile` is that surface: the login writes one line; the head's `/login` hook reads and **consumes** it on the next prompt, emitting it as `UserPromptSubmit` `additionalContext`. A file rather than a socket because the login may outlive the session, run before the daemon is up, or be run from a plain terminal. Receipts expire after 10 minutes, are per-head, and are consumed on read. **Failures are reported too** — the case that says nothing today.

## Coverage

`SignInPlanMatrixTest` pins the `auth.kind → /login` mapping across **every** head kind. That mapping had no test at all, which is how two regressions landed in one week — including one of mine, where I removed `/login` from api-key heads without a capture pattern. Mutation-proven against both.

## Verification

End-to-end, not just unit tests: the generated hook shell was **executed** against a real receipt and produced valid JSON reaching the session, with the receipt consumed.

30 tests across the four affected suites, 0 skipped. Full `./gradlew build` green on the new base (`--rerun-tasks`, not a cache hit); `ast-grep` walls clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)