### PR TITLE
fix(login): capture the paste only while the key is missing, and flag the stale claudeor link

### DIFF
--- a/.github/secret-scan-allow.README.md
+++ b/.github/secret-scan-allow.README.md
@@ -1,0 +1,46 @@
+# secret-scan-allow.txt
+
+Exemptions for the org secret-scan's supplementary pattern pass.
+
+**The documentation lives here, not in the file itself.** The scan applies the allowlist as
+`grep -vEf`, and `grep -f` has no comment syntax — so every line of that file is a live regex,
+prose included. Three separate ways a "comment" has broken scanning, all in PR #81:
+
+| # | Hazard | Effect |
+|---|--------|--------|
+| 1 | Unanchored entry | Appending a credential to the allowed declaration bypassed the scan entirely. |
+| 2 | A bare `#` separator | An unanchored regex matching any hit *containing* `#` — silently exempted every credential in a shell/Python/YAML/TOML comment, repo-wide. |
+| 3 | Unbalanced `(` in prose | Made the whole file an **invalid** pattern set, so `grep -vEf` errors instead of filtering. |
+
+None was caught by review. All three are caught by a planted canary in under a second, which is
+why the file is now patterns-only and verified mechanically.
+
+## Rules
+
+1. **No blank lines.** An empty regex matches every hit and disables the scan while CI stays green.
+2. **Every line anchored.** Prose lines start `^#`; exemptions are anchored `^`…`$`. A hit always
+   arrives from `grep -nIE` as `<line>:<content>`, so it begins with a **digit** — a `^#` line can
+   therefore never match one, which is what makes it inert.
+3. **Every line a valid ERE.** Balanced parens and brackets. Prefer prose with no metacharacters.
+4. **Keep prose out.** Add reasoning to this README instead. The file should stay near-empty.
+5. **Never verify by eye.** Run `bash checks/secret-scan-allow-selftest.sh` after any edit; it is
+   wired into `npm run gate`.
+
+## The current entry
+
+```
+^[0-9]+:[[:space:]]*const val CUSTOM_API[_]KEY_RESPONSES = "customApiKeyResponses"[[:space:]]*$
+```
+
+This is the Claude Code `settings.json` key **name**, not a credential. The scan's ASSIGN pattern
+fires on `API_?KEY[A-Za-z_]*` followed by `= "<15+ chars>"`, which the constant declaration matches
+by shape, while its value is a literal JSON field name Claude Code itself defines — the
+approved/rejected list for custom API keys.
+
+It is anchored to the whole line so any *other* assignment appended to it is still scanned, and it
+permits only trailing whitespace after the closing quote.
+
+**Self-exemption:** the allowlist is scanned too, and an entry quoting a credential-shaped
+declaration is itself credential-shaped. The `[_]` character class keeps the regex matching the
+real declaration while breaking the literal the ASSIGN pattern looks for, so the file does not have
+to exempt itself.

--- a/.github/secret-scan-allow.txt
+++ b/.github/secret-scan-allow.txt
@@ -1,0 +1,15 @@
+# Exemptions for the org secret-scan's supplementary pattern pass.
+# ONE EXTENDED REGEX PER LINE. The scan applies this file as `grep -vEf` against the
+# lines its patterns matched, so every line here is a REGEX, not a filename.
+#
+# ⚠ NEVER LEAVE A BLANK LINE IN THIS FILE. An empty line is an empty regex, which matches
+# EVERY hit — it would silently disable the entire supplementary scan while the check stayed
+# green. That failure is invisible in CI output, so keep this file dense and keep each entry
+# as narrow as the exact line it exempts.
+#
+# Entry: the Claude Code settings.json key NAME, not a credential. The scan's ASSIGN pattern
+# fires on `API_?KEY[A-Za-z_]*` followed by `= "<15+ chars>"`, which this constant declaration
+# matches by shape while its value is a literal JSON field name that Claude Code itself defines
+# (settings.json "customApiKeyResponses" — the approved/rejected list for custom API keys).
+# Pinned to the whole declaration, so any OTHER assignment near it is still scanned.
+const val CUSTOM_API_KEY_RESPONSES = "customApiKeyResponses"

--- a/.github/secret-scan-allow.txt
+++ b/.github/secret-scan-allow.txt
@@ -12,4 +12,12 @@
 # matches by shape while its value is a literal JSON field name that Claude Code itself defines
 # (settings.json "customApiKeyResponses" — the approved/rejected list for custom API keys).
 # Pinned to the whole declaration, so any OTHER assignment near it is still scanned.
-const val CUSTOM_API_KEY_RESPONSES = "customApiKeyResponses"
+# ANCHORED (review of #81): unanchored, this entry also matched a line that merely CONTAINS the
+# declaration — so appending a real credential to it (`… "customApiKeyResponses"; val
+# OPENROUTER_API_KEY = "sk-or-v1-…"`) bypassed the scan entirely. Reproduced before fixing.
+# The scan feeds `grep -nIE` output, so a hit arrives as `<line>:<content>`; anchor accordingly
+# and allow only trailing whitespace after the closing quote.
+^[0-9]+:[[:space:]]*const val CUSTOM_API[_]KEY_RESPONSES = "customApiKeyResponses"[[:space:]]*$
+# Self-exemption: this file is scanned too, and the entry above is itself credential-SHAPED.
+# The [_] class keeps the regex matching the real declaration while breaking the literal that
+# the scan's ASSIGN pattern looks for, so the allowlist does not have to exempt itself.

--- a/.github/secret-scan-allow.txt
+++ b/.github/secret-scan-allow.txt
@@ -1,23 +1,2 @@
-# Exemptions for the org secret-scan's supplementary pattern pass.
-# ONE EXTENDED REGEX PER LINE. The scan applies this file as `grep -vEf` against the
-# lines its patterns matched, so every line here is a REGEX, not a filename.
-#
-# ⚠ NEVER LEAVE A BLANK LINE IN THIS FILE. An empty line is an empty regex, which matches
-# EVERY hit — it would silently disable the entire supplementary scan while the check stayed
-# green. That failure is invisible in CI output, so keep this file dense and keep each entry
-# as narrow as the exact line it exempts.
-#
-# Entry: the Claude Code settings.json key NAME, not a credential. The scan's ASSIGN pattern
-# fires on `API_?KEY[A-Za-z_]*` followed by `= "<15+ chars>"`, which this constant declaration
-# matches by shape while its value is a literal JSON field name that Claude Code itself defines
-# (settings.json "customApiKeyResponses" — the approved/rejected list for custom API keys).
-# Pinned to the whole declaration, so any OTHER assignment near it is still scanned.
-# ANCHORED (review of #81): unanchored, this entry also matched a line that merely CONTAINS the
-# declaration — so appending a real credential to it (`… "customApiKeyResponses"; val
-# OPENROUTER_API_KEY = "sk-or-v1-…"`) bypassed the scan entirely. Reproduced before fixing.
-# The scan feeds `grep -nIE` output, so a hit arrives as `<line>:<content>`; anchor accordingly
-# and allow only trailing whitespace after the closing quote.
+^# Read secret-scan-allow.README.md before editing. Every line here is a live regex.
 ^[0-9]+:[[:space:]]*const val CUSTOM_API[_]KEY_RESPONSES = "customApiKeyResponses"[[:space:]]*$
-# Self-exemption: this file is scanned too, and the entry above is itself credential-SHAPED.
-# The [_] class keeps the regex matching the real declaration while breaking the literal that
-# the scan's ASSIGN pattern looks for, so the allowlist does not have to exempt itself.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@
 
 ### Fixed
 
+- The paste-capture hook is installed ONLY while an api-key head's key is missing. On a configured
+  head it was pure downside: a bare `sk-or-…` message was swallowed and stored, silently
+  overwriting a working credential, and the message never reached the model — so merely discussing
+  a key by pasting one broke the session's auth. The key-missing advertiser was already gated this
+  way; the hook that acts on the paste was not.
+- `install.sh` now detects a stale `claudeor` symlink left by the rename and prints the one command
+  that clears it. It does not delete anything: that bin dir holds links splice did not create. The
+  notice is scoped to a symlink pointing at splice's own launch shim, so a user's unrelated
+  `claudeor` script is never mentioned.
 - The OAuth callback page said "close this tab and head back to your terminal", but `/login` is
   usually invoked from inside a session where there is no terminal to return to. It now names the
   destination, matching what xAI's CLI does ("You can close this window and return to Grok Build").

--- a/checks/gate.sh
+++ b/checks/gate.sh
@@ -72,6 +72,7 @@ run "hook tests"     npm run --silent test:hooks
 run "campaign walls"  npm run --silent gate:campaign
 run "campaign selftest" npm run --silent gate:campaign:selftest
 run "config guard"   bash checks/config-guard.sh
+run "secret-scan allowlist" bash checks/secret-scan-allow-selftest.sh
 run "server tests"   npm test -w server
 run "webui lint"     npm run lint -w webui
 run "webui tests"    npm test -w webui

--- a/checks/secret-scan-allow-selftest.sh
+++ b/checks/secret-scan-allow-selftest.sh
@@ -55,17 +55,26 @@ while IFS= read -r line; do
 done < "$ALLOW"
 
 # ── canaries ─────────────────────────────────────────────────────────────────
+# ASSEMBLED AT RUN TIME, never written as literals. A credential-shaped assignment sitting in this
+# file trips the very supplementary scan this script exists to verify — which is exactly what
+# happened on the first push of #81, and is the scan behaving correctly. Splitting each keyword
+# from its `=` keeps the SOURCE clean while the assembled strings stay byte-identical to what the
+# scan sees in real code, so the canaries lose no fidelity.
+K='_KEY'
+S='_SECRET'
+EQ=' = '
+
 # MUST stay reported (i.e. must NOT be exempted by any line in the allowlist).
 must_report=(
-  '43:    const val CUSTOM_API_KEY_RESPONSES = "customApiKeyResponses"; val OPENROUTER_API_KEY = "sk-or-v1-canary000000000"'
-  '44:    const val CLIENT_SECRET = "canary-client-secret-000"'
-  '77:  # leftover from debugging: api_key = "sk-live-canary00000000000"'
-  '78:  AWS_SECRET_ACCESS_KEY = "canary00000000000000000000000000000000000" # rotate me'
-  '79:export GITHUB_TOKEN="ghp_canary0000000000000000000000000000"'
+  "43:    const val CUSTOM_API${K}_RESPONSES${EQ}\"customApiKeyResponses\"; val OPENROUTER_API${K}${EQ}\"sk-or-v1-canary000000000\""
+  "44:    const val CLIENT${S}${EQ}\"canary-client-secret-000\""
+  "77:  # leftover from debugging: api${K}${EQ}\"sk-live-canary00000000000\""
+  "78:  AWS${S}_ACCESS${K}${EQ}\"canary00000000000000000000000000000000000\" # rotate me"
+  "79:export GITHUB_TOKEN=\"ghp_canary0000000000000000000000000000\""
 )
 # MUST be exempted — the one declaration this allowlist exists for.
 must_exempt=(
-  '42:    const val CUSTOM_API_KEY_RESPONSES = "customApiKeyResponses"'
+  "42:    const val CUSTOM_API${K}_RESPONSES${EQ}\"customApiKeyResponses\""
 )
 
 for hit in "${must_report[@]}"; do

--- a/checks/secret-scan-allow-selftest.sh
+++ b/checks/secret-scan-allow-selftest.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Canary self-test for .github/secret-scan-allow.txt.
+#
+# WHY THIS EXISTS. The allowlist is applied by the org scan as `grep -vEf`, so EVERY line in it is
+# a live regex — the prose included, because `grep -f` has no comment syntax. A single careless
+# line silently disables secret scanning while CI stays green, which is the worst possible failure
+# shape: invisible, and it removes a control rather than breaking a build.
+#
+# It has already happened three times in one PR (#81):
+#   - the exemption was UNANCHORED, so appending a real credential to the allowed declaration
+#     bypassed the scan;
+#   - two bare `#` separators were UNANCHORED regexes matching any hit CONTAINING a `#`, which
+#     exempted every credential sitting in a shell/Python/YAML/TOML comment, repo-wide;
+#   - an unbalanced `(` in a prose line made the file an INVALID pattern set, so `grep -vEf`
+#     errors out instead of filtering at all.
+# None was caught by review. All three are caught by a planted canary in under a second, so the
+# verification is mechanical from here on and never done by eye again.
+#
+# The scan feeds `grep -nIE` output, so a hit always arrives as `<line>:<content>` and therefore
+# begins with a DIGIT. Every canary below is written in that shape.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Path is overridable so the hazards below can be exercised against a throwaway copy — a wall
+# nobody has watched fail is not known to work.
+ALLOW="${1:-$ROOT/.github/secret-scan-allow.txt}"
+fail=0
+
+note() { printf '  %s\n' "$1"; }
+bad() { printf '  ✗ %s\n' "$1"; fail=1; }
+
+[ -f "$ALLOW" ] || { echo "✗ missing $ALLOW"; exit 1; }
+
+# ── structural rules ─────────────────────────────────────────────────────────
+# A blank line is an empty regex and matches EVERY hit.
+if grep -qE '^[[:space:]]*$' "$ALLOW"; then
+  bad "blank line present — an empty regex matches every hit and disables the scan"
+fi
+
+# Every line must be either an anchored prose line (^#…, inert against digit-prefixed hits) or a
+# deliberate pattern anchored at both ends. Anything else is an unanchored regex of unknown reach.
+lineno=0
+while IFS= read -r line; do
+  lineno=$((lineno + 1))
+  # An invalid ERE anywhere makes grep reject the WHOLE file — the allowlist stops filtering and
+  # the scan step errors rather than passing. Validate each line in isolation so the message names
+  # the offender instead of just the file.
+  err="$(printf 'x\n' | grep -E -- "$line" 2>&1 >/dev/null)"
+  [ -n "$err" ] && bad "line $lineno is not a valid ERE (breaks the entire file): $(printf '%s' "$err" | head -1)"
+
+  case "$line" in
+    '^#'*) continue ;;                                  # inert prose: a hit starts with a digit
+    '^'*'$') continue ;;                                # fully anchored exemption
+    *) bad "line $lineno unanchored (matches more than the one line it names): [$line]" ;;
+  esac
+done < "$ALLOW"
+
+# ── canaries ─────────────────────────────────────────────────────────────────
+# MUST stay reported (i.e. must NOT be exempted by any line in the allowlist).
+must_report=(
+  '43:    const val CUSTOM_API_KEY_RESPONSES = "customApiKeyResponses"; val OPENROUTER_API_KEY = "sk-or-v1-canary000000000"'
+  '44:    const val CLIENT_SECRET = "canary-client-secret-000"'
+  '77:  # leftover from debugging: api_key = "sk-live-canary00000000000"'
+  '78:  AWS_SECRET_ACCESS_KEY = "canary00000000000000000000000000000000000" # rotate me'
+  '79:export GITHUB_TOKEN="ghp_canary0000000000000000000000000000"'
+)
+# MUST be exempted — the one declaration this allowlist exists for.
+must_exempt=(
+  '42:    const val CUSTOM_API_KEY_RESPONSES = "customApiKeyResponses"'
+)
+
+for hit in "${must_report[@]}"; do
+  if ! printf '%s\n' "$hit" | grep -vEf "$ALLOW" >/dev/null 2>&1; then
+    bad "SILENTLY EXEMPTED (scan blinded): $hit"
+  fi
+done
+
+for hit in "${must_exempt[@]}"; do
+  if printf '%s\n' "$hit" | grep -vEf "$ALLOW" >/dev/null 2>&1; then
+    bad "intended exemption no longer applies: $hit"
+  fi
+done
+
+if [ "$fail" -eq 0 ]; then
+  note "secret-scan allowlist: ${#must_report[@]} canaries still reported, ${#must_exempt[@]} exemption intact"
+fi
+exit "$fail"

--- a/gateway/app/src/main/kotlin/splice/app/Daemon.kt
+++ b/gateway/app/src/main/kotlin/splice/app/Daemon.kt
@@ -738,7 +738,12 @@ public class Daemon(
             loginCommand = signIn.command,
             signInLabel = signIn.label,
             signInViaBrowser = signIn.viaBrowser,
-            tokenCapture = signIn.tokenCapture,
+            // ONLY while the key is MISSING (review of #75). The capture hook swallows a bare
+            // sk-or-… message and stores it; on a head that is already configured that is pure
+            // downside — an accidental paste (or discussing a key as the whole message) silently
+            // OVERWRITES a working credential and the message never reaches the model. The
+            // advertiser below was already gated this way; the hook that acts on the paste was not.
+            tokenCapture = signIn.tokenCapture?.takeIf { !keyPresent },
             // The receipt path MUST match what LoginCommand writes (same StatePaths, same head
             // key), or a detached sign-in reports into a file nothing reads.
             loginOutcomeFile = LoginOutcomeFile.pathFor(StatePaths().stateDir, key).toString(),

--- a/gateway/core/src/test/kotlin/ClaudeConfigMaterializerTest.kt
+++ b/gateway/core/src/test/kotlin/ClaudeConfigMaterializerTest.kt
@@ -218,6 +218,36 @@ class ClaudeConfigMaterializerTest {
         assertTrue(dir.resolve("commands").isSymbolicLink()) // stays a plain shared symlink
     }
 
+    /** THE CAPTURE HOOK IS FOR AN UNCONFIGURED HEAD ONLY (review of #75). On a head whose key is
+     *  already set the hook is pure downside: it swallows any bare `sk-or-…` message, silently
+     *  OVERWRITES a working credential, and the message never reaches the model — so merely
+     *  DISCUSSING a key by pasting one would break the session's auth. The daemon now passes
+     *  tokenCapture only while the key is missing; this pins the materializer side of that. */
+    @Test
+    fun `no capture hook is installed when tokenCapture is absent`(@TempDir tmp: Path) {
+        seedGlobal(tmp)
+        val dir = tmp.resolve(".claude-openrouter-configured")
+        materializer(tmp).materialize(
+            MaterializeSpec(
+                configDir = dir,
+                policy = allPolicy,
+                availableModelIds = listOf("m"),
+                defaultModel = "m",
+                modelOptionsCache = optionsCache,
+                statuslineCommand = statusline,
+                loginCommand = "claude-openrouter login",
+                signInLabel = "OpenRouter",
+                signInViaBrowser = false,
+                tokenCapture = null, // the daemon withholds it once the key resolves
+            ),
+        )
+        assertFalse(
+            dir.resolve("splice-key-capture-hook.sh").toFile().exists(),
+            "a configured head must not install the paste-capture hook",
+        )
+        assertTrue(dir.resolve("splice-login-hook.sh").toFile().exists(), "/login itself still works")
+    }
+
     /** EVERY head keeps /login. A head without a known token shape cannot capture a paste, but it
      *  still HAS a sign-in path (`<command> login` in a terminal) — so /login must still be wired
      *  and must say so. Removing it for those heads was a regression this pins against. */

--- a/install.sh
+++ b/install.sh
@@ -371,6 +371,18 @@ else
   echo "splice: the ✗/! checks above are next steps with their fixes — the install itself landed."
 fi
 
+# Migration notice for the claudeor -> claude-openrouter rename. `install --all` links the
+# topology's commands but never PRUNES one whose name disappeared, so an upgrading user keeps a
+# `claudeor` symlink that resolves to no head. Deleting it here is not our call — this bin dir
+# holds links we did not create — so detect it and print the one command that clears it. Scoped to
+# a symlink pointing at OUR launch shim: a user's unrelated `claudeor` script is never mentioned.
+if [ -L "$BIN_DIR/claudeor" ] && [ "$(readlink -f "$BIN_DIR/claudeor" 2>/dev/null)" = "$(readlink -f "$SHARE_DIR/splice-launch" 2>/dev/null)" ]; then
+  echo
+  echo "splice: the OpenRouter head's command is now 'claude-openrouter' (was 'claudeor')."
+  echo "        The old link is stale — it no longer resolves to a head. Remove it with:"
+  echo "            rm $BIN_DIR/claudeor"
+fi
+
 case ":$PATH:" in
   *":$BIN_DIR:"*)
     echo

--- a/install.sh
+++ b/install.sh
@@ -376,7 +376,22 @@ fi
 # `claudeor` symlink that resolves to no head. Deleting it here is not our call — this bin dir
 # holds links we did not create — so detect it and print the one command that clears it. Scoped to
 # a symlink pointing at OUR launch shim: a user's unrelated `claudeor` script is never mentioned.
-if [ -L "$BIN_DIR/claudeor" ] && [ "$(readlink -f "$BIN_DIR/claudeor" 2>/dev/null)" = "$(readlink -f "$SHARE_DIR/splice-launch" 2>/dev/null)" ]; then
+# FAIL CLOSED (review of #81): BSD readlink (macOS, which install.sh supports — see the platform
+# gate above) has no -f. With errors suppressed BOTH substitutions became empty strings, which
+# compare EQUAL, so the notice fired for ANY claudeor symlink — including one the user made
+# themselves. Resolving to nothing must mean "say nothing", never "assume it is ours".
+resolve_link() {
+  _r="$(readlink -f "$1" 2>/dev/null)" || return 1
+  [ -n "$_r" ] || return 1
+  printf '%s\n' "$_r"
+}
+stale_claudeor=""
+if [ -L "$BIN_DIR/claudeor" ]; then
+  _old="$(resolve_link "$BIN_DIR/claudeor")" || _old=""
+  _shim="$(resolve_link "$SHARE_DIR/splice-launch")" || _shim=""
+  [ -n "$_old" ] && [ -n "$_shim" ] && [ "$_old" = "$_shim" ] && stale_claudeor=1
+fi
+if [ -n "$stale_claudeor" ]; then
   echo
   echo "splice: the OpenRouter head's command is now 'claude-openrouter' (was 'claudeor')."
   echo "        The old link is stale — it no longer resolves to a head. Remove it with:"


### PR DESCRIPTION
Addresses the review of **#75**, which merged before these could land. Three findings — two real, one already resolved by later work. Also carries the secret-scan allowlist that #76 merged without.

## F1 — capture hook installed on configured heads (`SignInPlan.kt:41`)

**Real, and the more serious of the two.** The paste-capture hook was installed on *every* api-key head with a known token shape, configured or not. `advertiseKeySetup` was correctly gated on `!keyPresent` — but `tokenCapture`, the hook that actually *acts* on the paste, was passed unconditionally.

On a head whose key already works that is pure downside: a bare `sk-or-…` message is swallowed and stored, **silently overwriting a working credential**, and the message never reaches the model. Merely *discussing* a key by pasting one would break the session's auth.

The daemon now withholds `tokenCapture` once the key resolves, matching the advertiser's own gating.

## F3 — stale `claudeor` link after the rename (`install.sh:379`)

**Real.** `install --all` links the topology's commands but never *prunes* one whose name disappeared, so upgrading users keep a `claudeor` symlink resolving to no head.

The reviewer's framing is better than the CHANGELOG note I'd settled for: **detect and tell**. The installer now prints the exact `rm` command and deliberately does **not** delete — that bin dir holds links splice did not create. Scoped to a symlink pointing at splice's *own* launch shim, verified across four cases:

| state | behaviour |
|---|---|
| no `claudeor` | silent |
| stale link → our shim | **fires** |
| user's own `claudeor` script | silent |
| unrelated symlink | silent |

## F2 — untested fallback branch (`SignInPlan.kt:49`) — already resolved

The branch it asked for a test of **no longer exists**: `command = if (capture != null) command else ""` was my regression, reverted in `0cba0f9` on operator direction (every head keeps `/login`). The coverage it wanted exists anyway — `SignInPlanMatrixTest` asserts fireworks/openai/moonshot get no capture pattern *while still getting a `/login` command*.

## Also: the secret-scan allowlist

CI's supplementary pass flagged `CUSTOM_API_KEY_RESPONSES = "customApiKeyResponses"` — a Claude Code settings.json **field name**, not a credential, pre-existing since `dfb33d8`, surfaced only because the scan reads whole changed files. Fixed the way the gate itself prescribes: a narrow regex in `.github/secret-scan-allow.txt`.

Verified **both** directions locally against the workflow's exact patterns: the false positive clears, and a file with a planted `OPENROUTER_API_KEY = "sk-or-v1-…"` and `CLIENT_SECRET = "…"` is still caught — 2 of 2. The file documents why it must never contain a blank line: the scan applies it as `grep -vEf`, so an empty line is an empty regex matching every hit, which would silently disable the whole pass while the check stayed green.

## Verification

Red-green: injecting the un-gated capture-hook install turns the new materializer wall red. Full `./gradlew build` green (`--rerun-tasks`, not a cache hit); `ast-grep` walls clean; `install.sh` syntax-checked; the org secret-scan's supplementary pass reproduced locally over the whole diff and clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)