### PR TITLE
fix(server): stop reflecting exception text from the log-tail endpoints

### DIFF
--- a/server/src/control/api.mjs
+++ b/server/src/control/api.mjs
@@ -162,7 +162,13 @@ function tailLog(key, tailN) {
     const lines = readFileSync(path, 'utf8').split('\n').filter(Boolean);
     return { key, path, lines: lines.slice(-tailN) };
   } catch (err) {
-    return { key, path, lines: [], note: String(err?.message || err) };
+    // Detail to stderr, generic to the client (CodeQL js/stack-trace-exposure, alert 1). This is
+    // the same fix dashboard.mjs already carries; these two log-tail sites were missed by it.
+    // The reflected text is a real leak, not just a query heuristic: a readFileSync failure
+    // reports errno plus the absolute path verbatim. `path` is returned deliberately as part of
+    // LogsPayload, but the FAILURE MODE of the host filesystem is not the client's business.
+    process.stderr.write(`[control] log tail failed for ${path}: ${err?.stack || err?.message || err}\n`);
+    return { key, path, lines: [], note: 'log unavailable — see the daemon log' };
   }
 }
 

--- a/server/src/mgmt/api.mjs
+++ b/server/src/mgmt/api.mjs
@@ -64,7 +64,10 @@ function readLogsTail(proxy, tailN) {
     const lines = readFileSync(path, 'utf8').split('\n').filter(Boolean);
     return { path, lines: lines.slice(-tailN) };
   } catch (err) {
-    return { path, lines: [], note: String(err?.message || err) };
+    // Detail to stderr, generic to the client (CodeQL js/stack-trace-exposure, alert 1) — the
+    // mgmt twin of the control-plane site above; both were missed when dashboard.mjs was fixed.
+    process.stderr.write(`[mgmt] log tail failed for ${path}: ${err?.stack || err?.message || err}\n`);
+    return { path, lines: [], note: 'log unavailable — see the daemon log' };
   }
 }
 

--- a/server/test/control-server.test.mjs
+++ b/server/test/control-server.test.mjs
@@ -142,6 +142,35 @@ test('GET / serves the dashboard (html when built)', async () => {
   assert.ok(status === 200 || status === 503, 'committed dist → 200, otherwise 503');
 });
 
+// WALL for CodeQL js/stack-trace-exposure (alert 1) — the control-plane twin of the mgmt case in
+// mgmt.test.mjs. tailLog() used to return `String(err?.message || err)` as the response note, so a
+// readFileSync failure reflected errno and the absolute host path to the client. Both sites were
+// missed when dashboard.mjs was fixed for this class; both are pinned now.
+//
+// EISDIR is forced by making the log path a DIRECTORY, which drives the exact catch branch the
+// CodeQL flow ran through.
+test('GET /api/logs: a read failure does not reflect the exception text', async () => {
+  const { logsDir, getConfig } = await import('../src/config.mjs');
+  const { proxyLogName } = await import('../src/mgmt/api.mjs');
+  const { HEAD_REGISTRY } = await import('../launcher/heads.mjs');
+  const { rmSync } = await import('node:fs');
+
+  const entry = HEAD_REGISTRY.codex;
+  const logPath = join(logsDir(), proxyLogName(entry.name, getConfig()[entry.portKey]));
+  mkdirSync(logPath, { recursive: true });
+  try {
+    const { status, json } = await call('GET', '/api/logs/codex?tail=10');
+    assert.equal(status, 200);
+    assert.deepEqual(json.lines, []);
+    assert.ok(json.note, 'a failed read still reports SOMETHING to the operator');
+    for (const leak of ['EISDIR', 'illegal operation', logPath, logsDir()]) {
+      assert.ok(!json.note.includes(leak), `note leaked exception detail (${leak}): ${json.note}`);
+    }
+  } finally {
+    rmSync(logPath, { recursive: true, force: true });
+  }
+});
+
 test('unknown /api route → 404', async () => {
   assert.equal((await call('GET', '/api/nope')).status, 404);
 });

--- a/server/test/mgmt.test.mjs
+++ b/server/test/mgmt.test.mjs
@@ -124,6 +124,36 @@ test('GET /mgmt/logs: tolerates missing log file', async () => {
   assert.ok(Array.isArray(json.lines));
 });
 
+// WALL for CodeQL js/stack-trace-exposure (alert 1). The log-tail catch used to put
+// `String(err?.message || err)` straight into the response, so a readFileSync failure reflected
+// errno AND the absolute host path back to the client. dashboard.mjs was fixed for this class in
+// 2026-07-29; this site and its control-plane twin were missed, and nothing pinned them.
+//
+// EISDIR is forced by making the log path a DIRECTORY: existsSync then passes, so the request
+// takes the exact catch branch the CodeQL flow ran through, rather than the missing-file branch.
+test('GET /mgmt/logs: a read failure does not reflect the exception text', async () => {
+  const { logsDir, getConfig } = await import('../src/config.mjs');
+  const { proxyLogName } = await import('../src/mgmt/api.mjs');
+  const { mkdirSync, rmSync } = await import('node:fs');
+
+  const logPath = join(logsDir(), proxyLogName('codex-proxy', getConfig().port));
+  mkdirSync(logPath, { recursive: true });
+  try {
+    const { status, json } = await call('GET', '/mgmt/logs?tail=10');
+    assert.equal(status, 200);
+    assert.deepEqual(json.lines, []);
+    assert.ok(json.note, 'a failed read still reports SOMETHING to the operator');
+    for (const leak of ['EISDIR', 'illegal operation', logPath, logsDir()]) {
+      assert.ok(
+        !json.note.includes(leak),
+        `note leaked exception detail (${leak}): ${json.note}`,
+      );
+    }
+  } finally {
+    rmSync(logPath, { recursive: true, force: true });
+  }
+});
+
 test('unknown mgmt route → 404', async () => {
   assert.equal((await call('GET', '/mgmt/nope')).status, 404);
 });


### PR DESCRIPTION
Closes CodeQL alert [1](https://github.com/torad-labs/splice/security/code-scanning/1) — `js/stack-trace-exposure`, medium, open on `main` since 2026-07-21.

## The flows

Both paths in the SARIF end at the same sink, `server/src/http/server.mjs:20` (`JSON.stringify(obj)`), and both start in a log-tail `catch`:

```
control/api.mjs:164  err -> String(err?.message || err) -> tailLog()      -> sendJson
mgmt/api.mjs:66      err -> String(err?.message || err) -> readLogsTail() -> sendJson
```

## Is it real?

The stack itself is never read, so the query's framing is conservative — but the reflected text is a genuine leak regardless. Both wrap `readFileSync`, so a failure hands the client **errno plus the absolute host path**:

```
EISDIR: illegal operation on a directory, read
```

`path` is returned deliberately as part of `LogsPayload`. The host filesystem's *failure mode* is not the client's business.

`dashboard.mjs` already carries exactly this fix, its comment citing the same query, dated 2026-07-29. These two sites were missed by it and nothing pinned them — so the class came straight back.

## The fix

Detail to stderr, a fixed string to the client. Same idiom as `dashboard.mjs`.

## Walls

One per site, each **red-green proven** by reverting only the `note` line:

| test | endpoint |
|---|---|
| `server/test/mgmt.test.mjs` | `GET /mgmt/logs` |
| `server/test/control-server.test.mjs` | `GET /api/logs/{head}` |

Both force `EISDIR` by making the log path a **directory**, so `existsSync` passes and the request takes the exact `catch` branch the CodeQL flow ran through — not the missing-file branch. Reverted, each fails with `note leaked exception detail (EISDIR)`; restored, **106/106 pass**.

## Scope

`server/` is the legacy Node stack (README:247). The **live Kotlin gateway is unaffected** — its `logsJson` emits no `note` at all, and `LogFileSource` swallows read errors. Fixed anyway: it ships in this repo and is scanned on `main`.

`GATE: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)