### PR TITLE
ci(secret-scan): generate the allowlist instead of hand-writing it

### DIFF
--- a/.github/secret-scan-allow.README.md
+++ b/.github/secret-scan-allow.README.md
@@ -12,19 +12,37 @@ prose included. Three separate ways a "comment" has broken scanning, all in PR #
 | 2 | A bare `#` separator | An unanchored regex matching any hit *containing* `#` — silently exempted every credential in a shell/Python/YAML/TOML comment, repo-wide. |
 | 3 | Unbalanced `(` in prose | Made the whole file an **invalid** pattern set, so `grep -vEf` errors instead of filtering. |
 
-None was caught by review. All three are caught by a planted canary in under a second, which is
-why the file is now patterns-only and verified mechanically.
+None was caught by review, and hazards 1 and 2 landed in the same file in the same PR hours apart:
+the first was fixed as an instance, so the generator re-derived the class. That is why the answer
+below is a generator rather than another checker.
 
-## Rules
+## The file is GENERATED
 
-1. **No blank lines.** An empty regex matches every hit and disables the scan while CI stays green.
-2. **Every line anchored.** Prose lines start `^#`; exemptions are anchored `^`…`$`. A hit always
-   arrives from `grep -nIE` as `<line>:<content>`, so it begins with a **digit** — a `^#` line can
-   therefore never match one, which is what makes it inert.
-3. **Every line a valid ERE.** Balanced parens and brackets. Prefer prose with no metacharacters.
-4. **Keep prose out.** Add reasoning to this README instead. The file should stay near-empty.
-5. **Never verify by eye.** Run `bash checks/secret-scan-allow-selftest.sh` after any edit; it is
-   wired into `npm run gate`.
+`secret-scan-allow.txt` is emitted from **`secret-scan-allow.toml`** by
+`checks/gen-secret-scan-allow.py`. Do not edit the `.txt`.
+
+That is the fix for all three hazards above, and it is a different KIND of fix: they are now
+impossible to express rather than merely detected (brain concept #924, "you make drift not
+compile"). Hazards 1 and 2 landed in the same file in the same PR hours apart precisely because
+the first was fixed as an instance, so the generator re-derived the class.
+
+| hazard | why it can no longer be written |
+|---|---|
+| unanchored entry | the generator owns `^`...`$`; a `pattern` carrying its own anchors is refused |
+| prose as a live regex | there is no prose slot in the `.txt`; `reason` lives in the TOML and never reaches grep |
+| invalid ERE | generation fails, validated against **grep** (the actual consumer, not Python's `re`) |
+| hand-edited `.txt` | `--check` regenerates and diffs; the gate runs it |
+
+An exemption also cannot be added without a `reason` — an unexplained one is not reviewable.
+
+```bash
+python3 checks/gen-secret-scan-allow.py          # regenerate
+python3 checks/gen-secret-scan-allow.py --check  # what the gate runs
+bash checks/secret-scan-allow-selftest.sh        # canaries over the generated output
+```
+
+The canary self-test stays as defence in depth: it verifies the generator's OUTPUT, so a bug in
+the generator itself is still caught.
 
 ## The current entry
 

--- a/.github/secret-scan-allow.toml
+++ b/.github/secret-scan-allow.toml
@@ -1,0 +1,42 @@
+# SOURCE OF TRUTH for .github/secret-scan-allow.txt.
+#
+# THIS file is safe to comment. Nothing here is ever fed to grep — the .txt is GENERATED from it by
+# checks/gen-secret-scan-allow.py, and the generator owns the parts that kept going wrong.
+#
+# WHY IT IS GENERATED (brain concept #924 — "you make drift not compile"). The .txt is consumed as
+# `grep -vEf`, so every line of it is a live regex, prose included. That format LIES: it looks like
+# a config file with `#` comments, and both humans and agents carry an overwhelming prior that `#`
+# is inert. Three hazards shipped in PR #81 on that prior alone:
+#
+#   1. an UNANCHORED entry, so appending a credential to the allowed declaration bypassed the scan;
+#   2. bare `#` separators — unanchored regexes matching any hit CONTAINING a `#`, which exempted
+#      every credential in a shell/Python/YAML/TOML comment, repo-wide;
+#   3. an unbalanced `(` in prose, making the whole file an INVALID pattern set so `grep -vEf`
+#      errored instead of filtering at all.
+#
+# Hazards 1 and 2 landed in the SAME FILE in the SAME PR, hours apart: the first was fixed as an
+# instance, so the generator simply re-derived the class. Detecting them (canaries, review) is a
+# probabilistic filter. Generating the file makes all three INEXPRESSIBLE:
+#
+#   - prose cannot reach the regex file: there is no slot for it, `reason` stays here;
+#   - an unanchored entry cannot be written: the generator applies `^`...`$` itself;
+#   - an invalid ERE cannot be committed: generation fails.
+#
+# Regenerate:  python3 checks/gen-secret-scan-allow.py
+# The gate runs `--check`, so hand-editing the .txt fails the build.
+
+[[exemption]]
+# A regex FRAGMENT matching the whole source line, WITHOUT anchors — those are the generator's job,
+# and it rejects a pattern that tries to bring its own.
+pattern = 'const val CUSTOM_API[_]KEY_RESPONSES = "customApiKeyResponses"'
+reason = """
+The Claude Code settings.json key NAME, not a credential. The scan's ASSIGN pattern fires on
+API_?KEY[A-Za-z_]* followed by an assignment of a 15+ character quoted string, which this constant
+declaration matches by shape, while its value is a literal JSON field name that Claude Code itself
+defines: the approved/rejected list for custom API keys.
+
+SELF-EXEMPTION: the allowlist and this file are both scanned, and an entry quoting a
+credential-shaped declaration is itself credential-shaped. The [_] character class keeps the regex
+matching the real declaration while breaking the literal the ASSIGN pattern looks for, so neither
+file has to exempt itself.
+"""

--- a/.github/secret-scan-allow.txt
+++ b/.github/secret-scan-allow.txt
@@ -1,2 +1,2 @@
-^# Read secret-scan-allow.README.md before editing. Every line here is a live regex.
+^# GENERATED from secret-scan-allow.toml by checks/gen-secret-scan-allow.py. DO NOT EDIT.
 ^[0-9]+:[[:space:]]*const val CUSTOM_API[_]KEY_RESPONSES = "customApiKeyResponses"[[:space:]]*$

--- a/checks/gate.sh
+++ b/checks/gate.sh
@@ -72,6 +72,9 @@ run "hook tests"     npm run --silent test:hooks
 run "campaign walls"  npm run --silent gate:campaign
 run "campaign selftest" npm run --silent gate:campaign:selftest
 run "config guard"   bash checks/config-guard.sh
+# Two layers, deliberately. The generator makes the hazards inexpressible (#924); the canary
+# selftest is defence in depth over its OUTPUT, so a bug in the generator itself still gets caught.
+run "secret-scan allowlist generated" python3 checks/gen-secret-scan-allow.py --check
 run "secret-scan allowlist" bash checks/secret-scan-allow-selftest.sh
 run "server tests"   npm test -w server
 run "webui lint"     npm run lint -w webui

--- a/checks/gen-secret-scan-allow.py
+++ b/checks/gen-secret-scan-allow.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Generate .github/secret-scan-allow.txt from .github/secret-scan-allow.toml.
+
+WHY THIS EXISTS (brain concept #924 — "you make drift not compile").
+
+The allowlist is consumed as `grep -vEf`, so every line of it is a live regex, prose included.
+That format lies: it looks like a config file with `#` comments, and every prior — human and
+model — says `#` is inert. Three hazards shipped on that prior in PR #81, two of them into the
+SAME FILE in the SAME PR hours apart, because the first was fixed as an instance rather than as
+a class. Canaries and review CAUGHT them; nothing PREVENTED them.
+
+This generator moves all three from detected to inexpressible:
+
+    hazard                          before                    after
+    unanchored entry                hand-written, hopefully   generator applies ^...$
+    prose as a live regex           `#` looks like a comment  no prose slot exists at all
+    invalid ERE breaks the file     silent until CI           generation fails
+
+The remaining hand-edit risk — someone editing the .txt directly — is closed by `--check`, which
+the gate runs (the same regenerate-and-diff idiom already used for webui/dist).
+
+Usage:
+    python3 checks/gen-secret-scan-allow.py            # write the .txt
+    python3 checks/gen-secret-scan-allow.py --check    # verify the committed .txt is current
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / ".github" / "secret-scan-allow.toml"
+OUT = ROOT / ".github" / "secret-scan-allow.txt"
+
+# A hit reaches the allowlist as `grep -nIE` output: `<line>:<content>`. Every emitted pattern is
+# bound to a WHOLE such line, so an exemption can never match a line that merely CONTAINS the
+# declaration — which is how appending a credential to it bypassed the scan.
+PREFIX = r"^[0-9]+:[[:space:]]*"
+SUFFIX = r"[[:space:]]*$"
+
+# The one prose line in the output. Anchored at ^# so it is inert: a hit always begins with a
+# DIGIT, so this can never match one. It is generated rather than typed for exactly the reason
+# this whole script exists.
+HEADER = "^# GENERATED from secret-scan-allow.toml by checks/gen-secret-scan-allow.py. DO NOT EDIT."
+
+
+def die(msg: str) -> None:
+    print(f"secret-scan-allow: {msg}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def valid_ere(pattern: str) -> str | None:
+    """Return grep's error for an invalid ERE, or None. grep is the authority here, not Python's
+    `re` — the consumer is grep, and the two dialects disagree (an unbalanced `(` is fatal to grep
+    and merely different in Python)."""
+    proc = subprocess.run(
+        ["grep", "-E", "--", pattern],
+        input=b"x\n",
+        capture_output=True,
+    )
+    # 0 = matched, 1 = no match; both mean the pattern compiled. 2 = bad regex.
+    return proc.stderr.decode().strip() or "invalid extended regex" if proc.returncode > 1 else None
+
+
+def render() -> str:
+    if not SRC.exists():
+        die(f"missing source: {SRC}")
+    data = tomllib.loads(SRC.read_text())
+    entries = data.get("exemption", [])
+    if not entries:
+        die("no [[exemption]] entries — refusing to emit an empty allowlist")
+
+    lines = [HEADER]
+    for i, entry in enumerate(entries, 1):
+        pattern = entry.get("pattern")
+        reason = (entry.get("reason") or "").strip()
+        if not pattern:
+            die(f"exemption {i}: missing `pattern`")
+        if not reason:
+            die(f"exemption {i}: missing `reason` — an unexplained exemption is not reviewable")
+        # Anchoring belongs to the generator. A pattern that brings its own would let an entry
+        # widen its own reach, which is hazard 1 all over again.
+        if pattern.startswith("^") or pattern.endswith("$"):
+            die(f"exemption {i}: `pattern` must not carry anchors; the generator adds them")
+        if "\n" in pattern:
+            die(f"exemption {i}: `pattern` must be a single line")
+
+        line = f"{PREFIX}{pattern}{SUFFIX}"
+        for candidate, what in ((pattern, "pattern"), (line, "generated line")):
+            err = valid_ere(candidate)
+            if err:
+                die(f"exemption {i}: {what} is not a valid ERE ({err}): {candidate}")
+        lines.append(line)
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    text = render()
+    if "--check" in sys.argv:
+        current = OUT.read_text() if OUT.exists() else ""
+        if current != text:
+            print(
+                "secret-scan-allow.txt is STALE or hand-edited.\n"
+                "  It is generated from .github/secret-scan-allow.toml.\n"
+                "  Run: python3 checks/gen-secret-scan-allow.py",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"  secret-scan allowlist: generated output matches ({len(text.splitlines())} lines)")
+        return 0
+    OUT.write_text(text)
+    print(f"wrote {OUT.relative_to(ROOT)} ({len(text.splitlines())} lines)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Applies brain concept **#924 — "you make drift not compile"** to the file that blinded the scan three times in #81.

## Why a generator and not another checker

The allowlist is consumed as `grep -vEf`, so **every line of it is a live regex, prose included**. That format lies: it looks like a config file with `#` comments, and every prior — human and model — says `#` is inert. Three hazards shipped on that prior:

| # | hazard | effect |
|---|---|---|
| 1 | unanchored entry | appending a credential to the allowed declaration bypassed the scan |
| 2 | bare `#` separators | unanchored regexes matching any hit *containing* `#` — exempted every credential in a shell/Python/YAML/TOML comment, repo-wide |
| 3 | unbalanced `(` in prose | the whole file became an **invalid** pattern set, so `grep -vEf` errored instead of filtering |

**1 and 2 landed in the same file, in the same PR, hours apart.** That is the tell: the first was fixed as an *instance*, so the generator re-derived the class. Canaries and review **caught** all three; nothing **prevented** them — and no number of additional checkers would, because you cannot enumerate what a generator will invent.

## What changes

`.txt` is now emitted from `.github/secret-scan-allow.toml` by `checks/gen-secret-scan-allow.py`. The hazards move from *detected* to *inexpressible*:

| hazard | why it can no longer be written |
|---|---|
| unanchored entry | the generator owns `^`…`$`; a `pattern` carrying its own anchors is refused |
| prose as a live regex | no prose slot exists; `reason` stays in the TOML and never reaches grep |
| invalid ERE | generation fails, validated against **grep** — the actual consumer. Python's `re` disagrees: an unbalanced `(` is fatal to one and merely different to the other |
| hand-edited `.txt` | `--check` regenerates and diffs — the same idiom the gate already uses for `webui/dist` |
| missing `reason` | refused; an unexplained exemption is not reviewable |

Every refusal was verified by **attempting the hazard**, not assumed:

```
hazard 1: entry brings its own anchor    => REFUSED
hazard 3: invalid ERE in a pattern       => REFUSED
unexplained exemption (no reason)        => REFUSED
hazard 2: bare '#' edited into the .txt  => REFUSED (stale/hand-edited)
```

## Defence in depth

The canary self-test from #81 is **kept**, now running over the generator's *output*, so a bug in the generator itself is still caught. Both run in the gate:

```
✓ secret-scan allowlist generated
✓ secret-scan allowlist
```

`GATE: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)