### PR TITLE
chore(release): v0.2.0 — reasoning continuity, the cache-drain fix, and every-head login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## splice v0.2.0 — reasoning continuity, the cache-drain fix, and every-head login - 2026-08-02
 
 ### Changed — BREAKING
 
@@ -11,6 +11,31 @@
 
 ### Added
 
+- **Gateway-held reasoning cache** (codex provider, default on): each turn's
+  `reasoning.encrypted_content` envelopes are held in memory per conversation and replayed on tool
+  round-trips, restoring the reasoning continuity the codex CLI gets natively. Retention is
+  activity-based with hard caps (256 rounds / 64 MB across a head, whole-conversation eviction);
+  the envelopes are opaque ciphertext, never written to disk, and scoped to their conversation so
+  concurrent sessions can never receive each other's. `quirks = { reasoning_cache = false }`
+  disables it. Documented in SECURITY.md.
+- **Deferred tool surface**: responses-dialect heads advertise a small eager slice of the tool
+  surface and defer the rest behind a gateway-answered `tool_search` — the model asks, the gateway
+  answers from the deferred inventory, and the continuation round is invisible to the client. Cuts
+  tens of KB from every upstream request; across a full daemon log, well under 1% of turns needed a
+  search round.
+- **Responses WebSocket transport** (opt-in, `websocket = true`, default off): rides the upstream
+  v2 WebSocket with `previous_response_id` chaining, sending per-round deltas instead of the full
+  replay. Cuts wire bytes and prefix drift. Measured NOT to reduce billed input tokens — the
+  receipt (`gateway/spikes/results/responses-websocket.md`) is explicit — so this is a latency and
+  robustness lever, not a quota one.
+- **Mid-stream re-anchoring**: a turn torn by a provider brownout after frames were already
+  forwarded is re-anchored upstream and continued instead of failed.
+- **Turn-scoped summary dedup**, and continuation rounds no longer re-request reasoning summaries:
+  detailed reasoning on every round with zero duplicated summary text.
+- **Loop guard**: a circuit breaker for the identical-failed-tool-call pathology, which previously
+  burned rounds repeating a call that could never succeed.
+- **API-key store and token capture** for api-key heads: `splice key`, and paste-to-store during
+  `/login` for providers whose token shape splice knows (today: OpenRouter).
 - `/login` now reports its outcome back INTO the session. The sign-in runs detached, so everything
   it printed was lost and the session never learned whether it worked; it writes a one-line receipt
   that the head's `/login` hook reads and consumes on the next prompt. This is the only channel
@@ -24,6 +49,15 @@
 
 ### Fixed
 
+- **The prompt-cache drain.** The reasoning cache expired envelopes on ACTIVE conversations, which
+  rewrote the replayed prompt prefix mid-conversation and invalidated the provider's prefix cache
+  turn after turn — measured at 350,920,932 wasted input tokens across 7,056 turns in one window,
+  a 66.6% hit rate against 98.0% (grok) and 96.3% (kimi) on the same daemon
+  (`gateway/spikes/results/prompt-cache-drain.md`). Envelopes now expire wholesale on idle
+  conversations only; the measured hit rate recovered to ~90%.
+- responses-lite turns send `tool_choice=auto` — fixes broken tool-calling on gpt-5.6.
+- `tool_search_call.arguments` is emitted as a JSON object, not a string.
+- Catalog membership recognizes `[1m]`-suffixed models — unbreaks kimi k3.
 - The paste-capture hook is installed ONLY while an api-key head's key is missing. On a configured
   head it was pure downside: a bare `sk-or-…` message was swallowed and stored, silently
   overwriting a working credential, and the message never reached the model — so merely discussing
@@ -48,8 +82,12 @@
   gets the in-session paste path; one it does not gets pointed at `<command> login` in a terminal,
   with the reason stated. Capture patterns stay deliberately one-provider-at-a-time (today:
   OpenRouter) — that scoping applies to CAPTURE, never to whether `/login` exists.
-
-## Unreleased
+- The frozen migration oracle's `--check` mode never compared against the committed fixtures, so
+  no behaviour drift could fail it despite being wired as a verification gate. It now diffs fixture
+  bytes, the vendored mock's checksum, and the scenario roster in both directions.
+- Three ast-grep walls were narrower than their own messages claimed: the cancellation wall
+  accepted a type check without the rethrow it demands; the `pkill` wall fired on unrelated string
+  concatenation in exec arguments; the silent-`Result`-collapse wall missed `var` bindings.
 
 ### Security
 
@@ -76,15 +114,16 @@
 - The `/grant` installer no longer reports a repo carrying the pre-signature gate as already
   installed; it refuses loudly rather than silently leaving a forgeable gate in place. Re-running
   it also no longer revokes an active grant out from under the operator.
-
-### Fixed
-
-- The frozen migration oracle's `--check` mode never compared against the committed fixtures, so
-  no behaviour drift could fail it despite being wired as a verification gate. It now diffs fixture
-  bytes, the vendored mock's checksum, and the scenario roster in both directions.
-- Three ast-grep walls were narrower than their own messages claimed: the cancellation wall
-  accepted a type check without the rethrow it demands; the `pkill` wall fired on unrelated string
-  concatenation in exec arguments; the silent-`Result`-collapse wall missed `var` bindings.
+- Closed every open CodeQL alert: a measured ReDoS, an unescaped OAuth-callback echo, error
+  de-leaking, and the legacy Node log-tail endpoints reflecting exception text — errno plus the
+  absolute host path — back to clients. Detail goes to stderr, a fixed string to the wire; the
+  Kotlin gateway's own log endpoint was never affected.
+- Dependency floors: netty 4.2.16.Final and jackson on the Gradle plugin classpath — the alerts
+  Dependabot could not raise PRs for.
+- The secret-scan allowlist is now GENERATED from a TOML source. The three `grep -vEf` hazards
+  that blinded the scan during review (an unanchored entry, prose acting as a live regex, an
+  invalid ERE breaking the whole pattern file) are inexpressible rather than merely detected, and
+  a canary self-test guards the generator's output in the gate.
 
 ## splice v0.1.1 — release integrity and supported defaults - 2026-07-21
 

--- a/bin/splice-launch
+++ b/bin/splice-launch
@@ -58,7 +58,7 @@ DANGEROUS="false"
 # — bump both together whenever this shim's behavior changes. No code generation.
 SPLICE_SHIM_VERSION="shim-2"
 # Hand-paired with splice.core.GATEWAY_VERSION. Release acceptance verifies the marker.
-SPLICE_GATEWAY_VERSION="0.1.1"
+SPLICE_GATEWAY_VERSION="0.2.0"
 
 need_jar() {
   if [ ! -f "$JAR" ]; then

--- a/checks/release/launcher-test.sh
+++ b/checks/release/launcher-test.sh
@@ -2,6 +2,19 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# The mock daemon's "current" version is DERIVED from the shim under test, never hardcoded — a
+# snapshot literal here goes stale on the first version bump and flips every "up" daemon to
+# "stale", sending the launcher down the replace path against the mock (found by the v0.2.0 bump:
+# the hardcoded 0.1.1 made this test fail on exactly the commit that mattered). Same awk as
+# checks/release/accept.sh — one idiom for reading the marker.
+GATEWAY_VERSION="$(awk -F'"' '/^SPLICE_GATEWAY_VERSION="/ { print $2; exit }' "$ROOT/bin/splice-launch")"
+SHIM_VERSION="$(awk -F'"' '/^SPLICE_SHIM_VERSION="/ { print $2; exit }' "$ROOT/bin/splice-launch")"
+[ -n "$GATEWAY_VERSION" ] && [ -n "$SHIM_VERSION" ] || {
+  echo "launcher test: could not read version markers from bin/splice-launch" >&2
+  exit 1
+}
+
 SANDBOX="$(mktemp -d)"
 trap 'rm -rf "$SANDBOX"' EXIT
 
@@ -34,7 +47,7 @@ done
 case "$url" in
   */health)
     case "$(cat "$LAUNCHER_DAEMON_STATE")" in
-      up|new) printf '{"ok":true,"version":"0.1.1","wantShimVersion":"shim-2"}\n' ;;
+      up|new) printf '{"ok":true,"version":"%s","wantShimVersion":"%s"}\n' "$LAUNCHER_GATEWAY_VERSION" "$LAUNCHER_SHIM_VERSION" ;;
       old) printf '{"ok":true,"version":"0.0.9","wantShimVersion":"shim-1"}\n' ;;
       down) ;;
     esac
@@ -75,6 +88,8 @@ run_launcher() {
   SPLICE_SHARE_DIR="$SANDBOX/share" \
   CLAUDEX_STATE_DIR="$SANDBOX/state" \
   LAUNCHER_DAEMON_STATE="$SANDBOX/daemon-state" \
+  LAUNCHER_GATEWAY_VERSION="$GATEWAY_VERSION" \
+  LAUNCHER_SHIM_VERSION="$SHIM_VERSION" \
   LAUNCHER_URL_CAPTURE="$SANDBOX/url" \
   LAUNCHER_BODY_CAPTURE="$SANDBOX/body" \
   LAUNCHER_SHUTDOWN_CAPTURE="$SANDBOX/shutdown" \

--- a/gateway/core/src/main/kotlin/splice/core/Versions.kt
+++ b/gateway/core/src/main/kotlin/splice/core/Versions.kt
@@ -3,7 +3,7 @@
 // /health). Single daemon (P4): one version restarts every head together (documented change).
 package splice.core
 
-public const val GATEWAY_VERSION: String = "0.1.1"
+public const val GATEWAY_VERSION: String = "0.2.0"
 
 // Hand-paired with the SPLICE_SHIM_VERSION marker embedded in bin/splice-launch (same
 // hand-paired pattern as GATEWAY_VERSION/wantVersion already used for head staleness in

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "splice",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "splice",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "workspaces": [
         "server",
         "webui"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "splice",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.2.0",
   "engines": {
     "node": ">=24"
   },


### PR DESCRIPTION
Cuts **v0.2.0** — 72 commits since v0.1.1, including one **BREAKING** change (`claudeor` → `claude-openrouter`), so pre-1.0 SemVer says minor.

## What this PR does

**Version bump** in all four hand-paired sites — `Versions.kt` `GATEWAY_VERSION`, `bin/splice-launch` `SPLICE_GATEWAY_VERSION`, `package.json`, `package-lock.json`. `SHIM_VERSION` stays `shim-2`: the shim is byte-unchanged since v0.1.1. Verified exactly as the tag build will:

```
SPLICE_EXPECTED_VERSION=0.2.0 bash checks/release/accept.sh
release accept: OK (splice 0.2.0)
```

**Changelog cut.** The two `Unreleased` sections are merged into one v0.2.0 section — and the release's actual substance, absent from the file entirely, is written in: the gateway-held reasoning cache, the deferred tool surface, the WebSocket transport (with its honestly-stated *non*-effect on billed input), mid-stream re-anchoring, summary dedup, the loop guard, the prompt-cache drain fix (350,920,932 wasted tokens measured; 66.6% → ~90% hit rate), the CodeQL closures, and the dependency floors. Numbers cite the committed receipts in `gateway/spikes/results/`, not memory.

**One test fixed, found *by* this bump:** `checks/release/launcher-test.sh` hardcoded the mock daemon's version as `"0.1.1"`, so the first version bump flipped every "up" daemon to "stale" and failed the gate on exactly the commit that mattered. The mock now derives `GATEWAY_VERSION`/`SHIM_VERSION` from the shim under test — the snapshot literal is inexpressible rather than corrected (#924). Red observed live; green verified after.

## Release procedure after merge

Tag the squash commit `v0.2.0` and push. `release.yml` then re-runs the full gate, builds the jar + SBOM, attests provenance, uploads everything to an **unpublished draft**, and publishes only after every attestation succeeds.

`GATE: PASS` in a clean worktree off `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)