### PR TITLE
ci(release): prod branch promotion — one action, tag derived from the code

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,32 @@
+# Release-notes shaping for the auto-generated "What's Changed" body
+# (release.yml sets generate_release_notes: true on every published release).
+#
+# Categories key off the labels pr-labeler.yml already applies, so the notes organize
+# themselves with no per-PR effort. Two surfaces, two jobs, on purpose:
+#   - CHANGELOG.md is the CURATED narrative — what changed and why it matters, cut by hand in
+#     the version-bump PR (the v0.2.0 cut is the model);
+#   - the GitHub release notes are the PR-level INDEX — every merged PR since the last tag,
+#     categorized, with the compare link.
+# Bot traffic is excluded: dependabot bumps land under Dependencies via their label when a human
+# PR carries it, but the bots' own PR spam does not belong in release notes.
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - dependabot[bot]
+      - github-actions[bot]
+    labels:
+      - skip-changelog
+  categories:
+    - title: Gateway
+      labels: [gateway]
+    - title: Web UI
+      labels: [webui]
+    - title: Documentation
+      labels: [documentation]
+    - title: CI & release engineering
+      labels: [ci, release]
+    - title: Dependencies
+      labels: [dependencies]
+    - title: Everything else
+      labels: ["*"]

--- a/.github/workflows/promotion-check.yml
+++ b/.github/workflows/promotion-check.yml
@@ -1,0 +1,37 @@
+# Pre-merge guard for promotion PRs (main -> prod): fail BEFORE the merge when the promotion
+# would release nothing — i.e. the promoted code's version is already tagged. The same refusal
+# exists in release.yml's resolve step (defence in depth), but a post-merge failure arrives after
+# prod has already moved; this one arrives while the PR is still open and fixable.
+name: promotion-check
+
+on:
+  pull_request:
+    branches: [prod]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: promotion-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  version-not-yet-released:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: the promoted version must not already be tagged
+        run: |
+          version="$(awk -F'"' '/^SPLICE_GATEWAY_VERSION="/ { print $2; exit }' bin/splice-launch)"
+          if [ -z "$version" ]; then
+            echo "::error::could not read SPLICE_GATEWAY_VERSION from bin/splice-launch"
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/v${version}" >/dev/null 2>&1; then
+            echo "::error::tag v${version} already exists — this promotion would release nothing. Bump the version on main first (Versions.kt, bin/splice-launch, package.json, package-lock.json move together)."
+            exit 1
+          fi
+          echo "promotion releases v${version} on merge"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,14 +2,15 @@ name: release
 
 # Two ways in, ONE release identity (the vX.Y.Z tag):
 #
-#   promote (the porcelain):  git push origin main:prod   — `npm run promote`
-#     The version is DERIVED from the promoted code (bin/splice-launch's
-#     SPLICE_GATEWAY_VERSION, the same marker accept.sh pins against the jar), and the tag is
-#     created by the publish step at the promoted commit. Promotion is one action; the tag is an
-#     artifact of it, never a second manual pointer that can disagree (fleet's release-line
-#     pattern, minus changesets: splice's versions are hand-paired in code, so the bump lands on
-#     main via PR and prod stays a pure fast-forward of main).
-#     Promoting without a version bump fails loudly at the resolve step: the tag already exists.
+#   promote:  merge the main -> prod PR (merge commit, never squash). The merge's push fires
+#     this workflow — GitHub generates the release; nobody runs a release command. The version is
+#     DERIVED from the promoted code (bin/splice-launch's SPLICE_GATEWAY_VERSION, the same marker
+#     accept.sh pins against the jar), and the tag is created by the publish step at the promoted
+#     commit — an artifact of promotion, never a second manual pointer that can disagree (fleet's
+#     release-line pattern, minus changesets: splice's versions are hand-paired in code, so the
+#     bump lands on main via PR). `npm run promote` merely OPENS the promotion PR.
+#     Promoting without a version bump fails twice: promotion-check.yml pre-merge, and the
+#     resolve step here at build time.
 #
 #   tag push (the plumbing):  git push origin v0.2.0     — still works, unchanged.
 #

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,14 @@ on:
 
 permissions: {}
 
+# ONE group for BOTH entry points (review of #86): ref-scoped grouping put a prod promotion
+# (refs/heads/prod) and a manual tag push (refs/tags/vX.Y.Z) in DIFFERENT groups, so the same
+# version could build twice concurrently — each passing its own existence check before the other
+# published, then both publishing competing drafts. Serialized, the loser of either ordering now
+# fails its resolve step inside the critical section: a promotion finds the tag already created,
+# a tag re-push finds the release already published.
 concurrency:
-  group: release-${{ github.ref }}
+  group: release
   cancel-in-progress: false
 
 jobs:
@@ -63,9 +69,19 @@ jobs:
         env:
           REF_TYPE: ${{ github.ref_type }}
           REF_NAME: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ "$REF_TYPE" = "tag" ]; then
             version="${REF_NAME#v}"
+            # The serialized-concurrency partner guard: a tag run whose release already exists is
+            # a re-release attempt (or the losing side of a promotion race) and must stop here,
+            # not upload competing assets. Deliberate re-release means deleting the release first.
+            # Drafts are invisible to this read-scoped token, so a mid-flight failed run can still
+            # be re-run — only a PUBLISHED release refuses.
+            if gh release view "v${version}" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+              echo "release: v${version} is already published — deliberate re-release requires deleting the release first" >&2
+              exit 1
+            fi
           else
             # Promotion path: the promoted CODE is the version authority — the same shim marker
             # accept.sh compares against the jar, so resolve and accept can never disagree.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,26 @@
 name: release
 
+# Two ways in, ONE release identity (the vX.Y.Z tag):
+#
+#   promote (the porcelain):  git push origin main:prod   — `npm run promote`
+#     The version is DERIVED from the promoted code (bin/splice-launch's
+#     SPLICE_GATEWAY_VERSION, the same marker accept.sh pins against the jar), and the tag is
+#     created by the publish step at the promoted commit. Promotion is one action; the tag is an
+#     artifact of it, never a second manual pointer that can disagree (fleet's release-line
+#     pattern, minus changesets: splice's versions are hand-paired in code, so the bump lands on
+#     main via PR and prod stays a pure fast-forward of main).
+#     Promoting without a version bump fails loudly at the resolve step: the tag already exists.
+#
+#   tag push (the plumbing):  git push origin v0.2.0     — still works, unchanged.
+#
+# The tag created on publish uses the workflow's own GITHUB_TOKEN, and events created with that
+# token do not trigger workflows — so a promotion cannot recursively fire the tag path.
 on:
   push:
     tags:
       - "v*"
+    branches:
+      - prod
 
 permissions: {}
 
@@ -17,6 +34,8 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: checkout without persisted credentials
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -38,6 +57,30 @@ jobs:
           node-version: 24
           cache: npm
 
+      - name: resolve release version
+        id: version
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [ "$REF_TYPE" = "tag" ]; then
+            version="${REF_NAME#v}"
+          else
+            # Promotion path: the promoted CODE is the version authority — the same shim marker
+            # accept.sh compares against the jar, so resolve and accept can never disagree.
+            version="$(awk -F'"' '/^SPLICE_GATEWAY_VERSION="/ { print $2; exit }' bin/splice-launch)"
+            if [ -z "$version" ]; then
+              echo "release: could not read SPLICE_GATEWAY_VERSION from bin/splice-launch" >&2
+              exit 1
+            fi
+            if git ls-remote --exit-code --tags origin "refs/tags/v${version}" >/dev/null 2>&1; then
+              echo "release: tag v${version} already exists — promotion without a version bump" >&2
+              exit 1
+            fi
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "release version: ${version}"
+
       - name: install workspaces
         run: npm ci
 
@@ -52,7 +95,9 @@ jobs:
         run: bash checks/release/stage.sh
 
       - name: accept exact release bundle
-        run: SPLICE_EXPECTED_VERSION="${GITHUB_REF_NAME#v}" bash checks/release/accept.sh
+        env:
+          RESOLVED_VERSION: ${{ steps.version.outputs.version }}
+        run: SPLICE_EXPECTED_VERSION="$RESOLVED_VERSION" bash checks/release/accept.sh
 
       - name: transfer accepted bundle to publisher
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -64,6 +109,8 @@ jobs:
 
   publish:
     needs: build
+    # The build job resolved the ONE version both paths share; the tag is created from it here,
+    # at exactly the commit that was gated, built, and attested.
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -97,6 +144,10 @@ jobs:
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2 # zizmor: ignore[superfluous-actions]
         with:
           draft: true
+          # Explicit on BOTH paths: on a prod promotion there is no tag yet — it is created when
+          # the draft publishes, at the exact SHA the build job gated and attested.
+          tag_name: v${{ needs.build.outputs.version }}
+          target_commitish: ${{ github.sha }}
           fail_on_unmatched_files: true
           generate_release_notes: true
           files: |
@@ -114,4 +165,5 @@ jobs:
       - name: publish only after every upload and attestation succeeded
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release edit "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --draft=false
+          RELEASE_TAG: v${{ needs.build.outputs.version }}
+        run: gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft=false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,3 +66,17 @@ contributor license agreement is required.
 SemVer, currently pre-1.0 (`0.x`) — breaking changes may land on a minor bump until 1.0.0.
 The root `package.json` version field itself is owned by a separate dependency-hygiene pass,
 not this document.
+
+## Releasing
+
+The `prod` branch is the release line; promoting `main` to it is the one release action:
+
+1. Land a version-bump PR on `main` (all four sites move together: `Versions.kt`
+   `GATEWAY_VERSION`, `bin/splice-launch` `SPLICE_GATEWAY_VERSION`, `package.json`,
+   `package-lock.json`), with the `CHANGELOG.md` cut for the release.
+2. `npm run promote` — fast-forwards `prod` to `origin/main` after refusing a diverged `prod`
+   or an unbumped version. `release.yml` then re-runs the full gate, builds and attests, and
+   creates the `vX.Y.Z` tag at the promoted commit when the draft release publishes. The version
+   is derived from the promoted code, so the tag can never disagree with what shipped.
+
+Pushing a `v*` tag by hand still releases (the plumbing path); promotion is the porcelain.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,14 +69,17 @@ not this document.
 
 ## Releasing
 
-The `prod` branch is the release line; promoting `main` to it is the one release action:
+The `prod` branch is the release line, and **merging the `main -> prod` PR is the release
+action** — GitHub does the rest, no local command involved:
 
 1. Land a version-bump PR on `main` (all four sites move together: `Versions.kt`
    `GATEWAY_VERSION`, `bin/splice-launch` `SPLICE_GATEWAY_VERSION`, `package.json`,
    `package-lock.json`), with the `CHANGELOG.md` cut for the release.
-2. `npm run promote` — fast-forwards `prod` to `origin/main` after refusing a diverged `prod`
-   or an unbumped version. `release.yml` then re-runs the full gate, builds and attests, and
-   creates the `vX.Y.Z` tag at the promoted commit when the draft release publishes. The version
-   is derived from the promoted code, so the tag can never disagree with what shipped.
-
-Pushing a `v*` tag by hand still releases (the plumbing path); promotion is the porcelain.
+2. Open the promotion PR, base `prod`, head `main` — in the UI, or `npm run promote` which
+   opens the same PR after a courtesy version preflight. `promotion-check` fails the PR before
+   merge if the promoted version is already tagged (a promotion that would release nothing).
+3. **Merge it with a merge commit** (never squash: squashing collapses main's promoted history
+   into one alien commit on prod). The resulting push fires `release.yml` on `prod`: full gate,
+   build, attestations, and the `vX.Y.Z` tag created at the promoted commit when the draft
+   release publishes. The version is derived from the promoted code, so the tag can never
+   disagree with what shipped.

--- a/checks/promote.sh
+++ b/checks/promote.sh
@@ -20,7 +20,12 @@ cd "$ROOT"
 
 git fetch -q origin
 
-version="$(git show origin/main:bin/splice-launch | awk -F'"' '/^SPLICE_GATEWAY_VERSION="/ { print $2; exit }')"
+# Pin the SHA the version is read from — everything below (display, confirmation, push) refers to
+# THIS commit, so what the operator confirms is exactly what ships (review of #86: the first-
+# promotion push resolved origin/main at push time, after an interactive prompt of unbounded
+# duration, so main advancing mid-prompt could silently change what got promoted).
+main_sha="$(git rev-parse origin/main)"
+version="$(git show "$main_sha:bin/splice-launch" | awk -F'"' '/^SPLICE_GATEWAY_VERSION="/ { print $2; exit }')"
 [ -n "$version" ] || { echo "promote: could not read SPLICE_GATEWAY_VERSION from origin/main" >&2; exit 1; }
 
 if git ls-remote --exit-code --tags origin "refs/tags/v${version}" >/dev/null 2>&1; then
@@ -29,27 +34,49 @@ if git ls-remote --exit-code --tags origin "refs/tags/v${version}" >/dev/null 2>
   exit 1
 fi
 
-existing="$(gh pr list --base prod --head main --state open --json url --jq '.[0].url // empty')"
-if [ -n "$existing" ]; then
-  echo "promote: a promotion PR is already open — merge it (merge commit, not squash): $existing"
-  exit 0
-fi
-
 # prod is created on first use; a PR needs the base ref to exist. Seeding it at main's tip is a
 # no-op promotion (same tree, no release fires until the NEXT prod push differs... it does fire —
 # a push event is a push event). So seed from the CURRENT PROD-LESS state only via the API ref
 # create, which is a push of main's tip and WILL fire release.yml once, releasing v<version>.
 # That is the correct first promotion, stated rather than hidden.
 if ! git ls-remote --exit-code origin refs/heads/prod >/dev/null 2>&1; then
-  echo "promote: prod does not exist yet. Creating it AT origin/main IS the first promotion:"
-  echo "         release.yml will fire and publish v${version}."
+  echo "promote: prod does not exist yet. Creating it IS the first promotion:"
+  echo "         release.yml will fire and publish v${version} from ${main_sha}."
   if [ "${PROMOTE_YES:-0}" != "1" ]; then
     printf 'Type the version to confirm the FIRST promotion (%s): ' "$version"
-    read -r answer
-    [ "$answer" = "$version" ] || { echo "promote: aborted (typed '$answer')" >&2; exit 1; }
+    # `|| answer=""`: on EOF (non-tty, piped stdin) read fails and set -e would exit SILENTLY
+    # before the abort message — turn it into the ordinary mismatch abort instead.
+    read -r answer || answer=""
+    [ "$answer" = "$version" ] || { echo "promote: aborted (typed '${answer:-<eof>}')" >&2; exit 1; }
   fi
-  git push origin "$(git rev-parse origin/main):refs/heads/prod"
-  echo "promote: prod created — release.yml is publishing v${version}."
+  # Freshness check AT the point of creation: the confirmation prompt is unbounded, so require
+  # that main still points at the confirmed SHA before pushing it. The push itself uses the
+  # PINNED sha — never a re-resolved ref — so a race can only abort, never promote something the
+  # operator did not see.
+  git fetch -q origin
+  if [ "$(git rev-parse origin/main)" != "$main_sha" ]; then
+    echo "promote: main moved while you were confirming (now $(git rev-parse --short origin/main)," >&2
+    echo "         confirmed ${main_sha}). Nothing pushed — re-run to promote the new tip." >&2
+    exit 1
+  fi
+  git push origin "$main_sha:refs/heads/prod"
+  echo "promote: prod created at ${main_sha} — release.yml is publishing v${version}."
+  exit 0
+fi
+
+# Everything below needs the GitHub CLI. Guarded EXPLICITLY: under `set -e` a failing command
+# substitution kills the script with no message at all — the sandbox test found exactly that
+# (a broken gh made promote.sh exit 1 in complete silence).
+command -v gh >/dev/null 2>&1 || {
+  echo "promote: the GitHub CLI (gh) is required to open the promotion PR — https://cli.github.com" >&2
+  exit 1
+}
+existing="$(gh pr list --base prod --head main --state open --json url --jq '.[0].url // empty')" || {
+  echo "promote: gh failed listing PRs — check 'gh auth status'" >&2
+  exit 1
+}
+if [ -n "$existing" ]; then
+  echo "promote: a promotion PR is already open — merge it (merge commit, not squash): $existing"
   exit 0
 fi
 

--- a/checks/promote.sh
+++ b/checks/promote.sh
@@ -1,26 +1,25 @@
 #!/usr/bin/env bash
-# Promote main -> prod: the one release action. `npm run promote`.
+# Open the promotion PR (main -> prod). `npm run promote`, or skip this entirely and open the
+# same PR in the GitHub UI — the script is convenience, not mechanism.
 #
-# The prod branch is the release line (fleet's pattern): pushing it fires release.yml, which
-# derives the version FROM THE PROMOTED CODE (bin/splice-launch's SPLICE_GATEWAY_VERSION — the
-# same marker accept.sh pins against the jar), gates, builds, attests, and creates the vX.Y.Z tag
-# at the promoted commit when the draft publishes. The tag is an ARTIFACT of promotion, never a
-# second manual pointer that can disagree with it.
+# THE MECHANISM IS GITHUB-NATIVE: merging the main -> prod PR is the promotion. The push that
+# merge produces fires release.yml on prod, which derives the version FROM THE PROMOTED CODE
+# (bin/splice-launch's SPLICE_GATEWAY_VERSION — the same marker accept.sh pins against the jar),
+# re-runs the full gate, builds, attests, and creates the vX.Y.Z tag at the promoted commit when
+# the draft release publishes. Nothing local touches prod, and no command "does the release".
 #
-# This script promotes the REMOTE main, not the local checkout — a promotion must never depend on
-# (or accidentally include) local state. It refuses when:
-#   - prod exists but is not an ancestor of main (someone committed to prod directly; prod is a
-#     pure fast-forward of main by construction, so a diverged prod is a broken invariant, not a
-#     merge problem to paper over);
-#   - the promoted version's tag already exists (promotion without a version bump releases
-#     nothing — bump on main first, like the v0.2.0 PR).
+# Merge the promotion PR with a MERGE COMMIT, never squash: squashing collapses all of main's
+# promoted history into one alien commit on prod and breaks the next promotion's diff.
+#
+# The forgot-to-bump case is guarded twice, both server-side: promotion-check.yml fails the PR
+# BEFORE merge when the version's tag already exists, and release.yml's resolve step refuses
+# again at build time. The preflight here is a courtesy third look, not the net.
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
 git fetch -q origin
 
-main_sha="$(git rev-parse origin/main)"
 version="$(git show origin/main:bin/splice-launch | awk -F'"' '/^SPLICE_GATEWAY_VERSION="/ { print $2; exit }')"
 [ -n "$version" ] || { echo "promote: could not read SPLICE_GATEWAY_VERSION from origin/main" >&2; exit 1; }
 
@@ -30,29 +29,31 @@ if git ls-remote --exit-code --tags origin "refs/tags/v${version}" >/dev/null 2>
   exit 1
 fi
 
-if git ls-remote --exit-code origin refs/heads/prod >/dev/null 2>&1; then
-  prod_sha="$(git ls-remote origin refs/heads/prod | cut -f1)"
-  if ! git merge-base --is-ancestor "$prod_sha" "$main_sha"; then
-    echo "promote: prod ($prod_sha) is not an ancestor of main — it has diverged." >&2
-    echo "         prod is a pure fast-forward of main; inspect how it diverged before forcing anything." >&2
-    exit 1
+existing="$(gh pr list --base prod --head main --state open --json url --jq '.[0].url // empty')"
+if [ -n "$existing" ]; then
+  echo "promote: a promotion PR is already open — merge it (merge commit, not squash): $existing"
+  exit 0
+fi
+
+# prod is created on first use; a PR needs the base ref to exist. Seeding it at main's tip is a
+# no-op promotion (same tree, no release fires until the NEXT prod push differs... it does fire —
+# a push event is a push event). So seed from the CURRENT PROD-LESS state only via the API ref
+# create, which is a push of main's tip and WILL fire release.yml once, releasing v<version>.
+# That is the correct first promotion, stated rather than hidden.
+if ! git ls-remote --exit-code origin refs/heads/prod >/dev/null 2>&1; then
+  echo "promote: prod does not exist yet. Creating it AT origin/main IS the first promotion:"
+  echo "         release.yml will fire and publish v${version}."
+  if [ "${PROMOTE_YES:-0}" != "1" ]; then
+    printf 'Type the version to confirm the FIRST promotion (%s): ' "$version"
+    read -r answer
+    [ "$answer" = "$version" ] || { echo "promote: aborted (typed '$answer')" >&2; exit 1; }
   fi
-  span="$(git rev-list --count "$prod_sha".."$main_sha")"
-else
-  prod_sha="(new branch)"
-  span="all history"
+  git push origin "$(git rev-parse origin/main):refs/heads/prod"
+  echo "promote: prod created — release.yml is publishing v${version}."
+  exit 0
 fi
 
-echo "promote: main -> prod"
-echo "  releases:  v${version}"
-echo "  commit:    ${main_sha}"
-echo "  prod was:  ${prod_sha}  (${span} commits promoted)"
-if [ "${PROMOTE_YES:-0}" != "1" ]; then
-  printf 'Type the version to confirm (%s): ' "$version"
-  read -r answer
-  [ "$answer" = "$version" ] || { echo "promote: aborted (typed '$answer')" >&2; exit 1; }
-fi
-
-git push origin "$main_sha:refs/heads/prod"
-echo "promote: pushed — release.yml is now gating, building, attesting, and publishing v${version}."
-echo "         Watch it: gh run watch \$(gh run list --workflow=release.yml --limit 1 --json databaseId --jq '.[0].databaseId')"
+gh pr create --base prod --head main \
+  --title "chore(release): promote main to prod (v${version})" \
+  --body "$(printf 'Merging this PR IS the promotion: the resulting push to prod fires release.yml, which re-gates, builds, attests, and publishes **v%s** with the tag created at the promoted commit.\n\nMerge with a **merge commit**, not squash.' "$version")"
+echo "promote: promotion PR opened — merging it releases v${version}."

--- a/checks/promote.sh
+++ b/checks/promote.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Promote main -> prod: the one release action. `npm run promote`.
+#
+# The prod branch is the release line (fleet's pattern): pushing it fires release.yml, which
+# derives the version FROM THE PROMOTED CODE (bin/splice-launch's SPLICE_GATEWAY_VERSION — the
+# same marker accept.sh pins against the jar), gates, builds, attests, and creates the vX.Y.Z tag
+# at the promoted commit when the draft publishes. The tag is an ARTIFACT of promotion, never a
+# second manual pointer that can disagree with it.
+#
+# This script promotes the REMOTE main, not the local checkout — a promotion must never depend on
+# (or accidentally include) local state. It refuses when:
+#   - prod exists but is not an ancestor of main (someone committed to prod directly; prod is a
+#     pure fast-forward of main by construction, so a diverged prod is a broken invariant, not a
+#     merge problem to paper over);
+#   - the promoted version's tag already exists (promotion without a version bump releases
+#     nothing — bump on main first, like the v0.2.0 PR).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+git fetch -q origin
+
+main_sha="$(git rev-parse origin/main)"
+version="$(git show origin/main:bin/splice-launch | awk -F'"' '/^SPLICE_GATEWAY_VERSION="/ { print $2; exit }')"
+[ -n "$version" ] || { echo "promote: could not read SPLICE_GATEWAY_VERSION from origin/main" >&2; exit 1; }
+
+if git ls-remote --exit-code --tags origin "refs/tags/v${version}" >/dev/null 2>&1; then
+  echo "promote: tag v${version} already exists — bump the version on main first (Versions.kt," >&2
+  echo "         bin/splice-launch, package.json, package-lock.json move together)." >&2
+  exit 1
+fi
+
+if git ls-remote --exit-code origin refs/heads/prod >/dev/null 2>&1; then
+  prod_sha="$(git ls-remote origin refs/heads/prod | cut -f1)"
+  if ! git merge-base --is-ancestor "$prod_sha" "$main_sha"; then
+    echo "promote: prod ($prod_sha) is not an ancestor of main — it has diverged." >&2
+    echo "         prod is a pure fast-forward of main; inspect how it diverged before forcing anything." >&2
+    exit 1
+  fi
+  span="$(git rev-list --count "$prod_sha".."$main_sha")"
+else
+  prod_sha="(new branch)"
+  span="all history"
+fi
+
+echo "promote: main -> prod"
+echo "  releases:  v${version}"
+echo "  commit:    ${main_sha}"
+echo "  prod was:  ${prod_sha}  (${span} commits promoted)"
+if [ "${PROMOTE_YES:-0}" != "1" ]; then
+  printf 'Type the version to confirm (%s): ' "$version"
+  read -r answer
+  [ "$answer" = "$version" ] || { echo "promote: aborted (typed '$answer')" >&2; exit 1; }
+fi
+
+git push origin "$main_sha:refs/heads/prod"
+echo "promote: pushed — release.yml is now gating, building, attesting, and publishing v${version}."
+echo "         Watch it: gh run watch \$(gh run list --workflow=release.yml --limit 1 --json databaseId --jq '.[0].databaseId')"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "e2e:heads:wire": "bash checks/e2e/heads-e2e.sh --tier 1",
     "oracle:capture": "node dev/campaigns/proxy-hardening/oracle/capture.mjs",
     "oracle:check": "node dev/campaigns/proxy-hardening/oracle/capture.mjs --check",
-    "gate:campaign:strict": "python3 dev/campaigns/proxy-hardening/walls/campaign_wall_gate.py --strict"
+    "gate:campaign:strict": "python3 dev/campaigns/proxy-hardening/walls/campaign_wall_gate.py --strict",
+    "promote": "bash checks/promote.sh"
   },
   "devDependencies": {
     "@ast-grep/cli": "0.45.0"


### PR DESCRIPTION
Answers "can we promote main to prod like fleet?" — with the operator's correction folded in: **GitHub generates the release when the promotion happens; nobody runs a release command.**

## The pattern

The `prod` branch is the release line. **Merging the `main → prod` PR is the promotion** — the resulting push fires `release.yml`, which:

1. derives the version **from the promoted code** (`bin/splice-launch`'s `SPLICE_GATEWAY_VERSION`, the same marker `accept.sh` pins against the jar),
2. re-runs the full gate, builds, attests,
3. creates the `vX.Y.Z` tag at the promoted commit when the draft release publishes.

The tag is an *artifact* of promotion, never a second manual pointer that can disagree (#924). Merge with a **merge commit**, never squash.

`npm run promote` is optional convenience: it *opens* the promotion PR after a courtesy version preflight (and refuses duplicates). The UI works equally well. The one exception is the **first** promotion — `prod` must exist before a PR can target it, so creating it at main's tip *is* the first promotion, confirmed explicitly rather than hidden.

## Guards — forgot-to-bump fails twice, both server-side

| net | when |
|---|---|
| `promotion-check.yml` on PRs targeting `prod` | **before merge**, while the PR is still fixable |
| `release.yml` resolve step | at build time, defence in depth |

Verified live: the preflight refuses against the real remote while main is unbumped (`tag v0.1.1 already exists`). Hand-pushed `v*` tags still release unchanged; the publish-created tag uses `GITHUB_TOKEN`, whose events don't trigger workflows, so promotion cannot recursively fire the tag path.

**Deliberate divergence from fleet:** fleet auto-bumps on `prod` via changesets; splice's versions are hand-paired in code, so the bump stays a `main` PR (#85) and prod carries only main's history plus promotion merge commits.

`actionlint` clean; `GATE: PASS`.

## Release procedure once this and #85 land

1. Merge #85 (the v0.2.0 bump)
2. `npm run promote` — or open the `main → prod` PR in the UI — then **merge it (merge commit)**
3. GitHub does the rest; the draft publishes as `v0.2.0` once attestations complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)