### PR TITLE
fix(ws): digest the connection key in transport logs — the stale-review sweep

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,19 @@ SemVer, currently pre-1.0 (`0.x`) — breaking changes may land on a minor bump 
 The root `package.json` version field itself is owned by a separate dependency-hygiene pass,
 not this document.
 
+### What compatibility means here
+
+splice ships as an **application** — one shadow jar plus a launcher — and publishes no artifact
+to any registry. The Kotlin `public` surface exists for the internal module graph (`:core`,
+`:provider-spi`, the dialects), not for external compiled consumers, so changes to public
+data-class shapes (constructor arity, `copy`/`componentN` signatures) are **not** treated as
+breaking. Review findings about JVM ABI drift on these types have this standing answer: nothing
+outside this repository links against them.
+
+The contracts that ARE stable, and gated as such: the `/v1` Anthropic wire surface (frozen
+migration oracle), the `/api/*` payload shapes (`WebuiContractTest`), the state-file names
+(`StatePaths` header), and the TOML config keys. Break one of those and a test must move with it.
+
 ## Releasing
 
 The `prod` branch is the release line, and **merging the `main -> prod` PR is the release

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/WsUpstream.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/WsUpstream.kt
@@ -136,6 +136,14 @@ public class WsUpstream(
         }
     }
 
+    /** The operator-facing key form. The connection key deliberately concatenates the CHAIN key
+     *  (the client's session id + conversation identity — raw client-derived text) with the header
+     *  digest, and six log sites here interpolated it verbatim into daemon.log while the runner's
+     *  own logKey existed for exactly this reason (review of #72, the one finding of it that the
+     *  header-digest fix did not finish). Same short stable digest as the runner's: enough to
+     *  correlate connect/busy/kill lines for one connection, nothing recoverable. */
+    private fun logKey(key: String): String = "ws-" + Integer.toHexString(key.hashCode())
+
     /** Receive one event, or null when the inbox is CLOSED.
      *
      *  Why this exists (adversarial review of WS-1, 2026-07-31): `receive()` signals closure by
@@ -156,7 +164,7 @@ public class WsUpstream(
         if (!conn.busy.compareAndSet(false, true)) {
             // A concurrent round of the SAME conversation is already on the socket — never
             // interleave two response.create frames on one connection; the second rides SSE.
-            log("[ws] $key busy — concurrent round rides SSE\n")
+            log("[ws] ${logKey(key)} busy — concurrent round rides SSE\n")
             return null
         }
         // Lost the race with a tear between the registry read and the busy win.
@@ -179,7 +187,7 @@ public class WsUpstream(
         val socket = runCatchingCancellable {
             connector(URI.create(wssUrl), headers, listener)
         }.getOrElse { e ->
-            log("[ws] $key connect failed (${e::class.simpleName}: ${e.message?.take(ERR_SNIPPET)}) — SSE\n")
+            log("[ws] ${logKey(key)} connect failed (${e::class.simpleName}: ${e.message?.take(ERR_SNIPPET)}) — SSE\n")
             return null
         }
         val conn = WsConnection(socket, inbox, generation, log)
@@ -215,7 +223,7 @@ public class WsUpstream(
             return winner
         }
         evicted?.kill()
-        log("[ws] $key connected (generation=$generation)\n")
+        log("[ws] ${logKey(key)} connected (generation=$generation)\n")
         return conn
     }
 
@@ -245,7 +253,7 @@ public class WsUpstream(
         if (failure != null) {
             val (kind, error) = failure
             log(
-                "[ws] $key send failed $kind (${error::class.simpleName}: " +
+                "[ws] ${logKey(key)} send failed $kind (${error::class.simpleName}: " +
                     "${error.message?.take(ERR_SNIPPET)}) — killing connection, round rides SSE\n",
             )
             failRound(conn, key)
@@ -267,7 +275,7 @@ public class WsUpstream(
             } else {
                 "inbox closed before first event (${received.exceptionOrNull()?.message?.take(ERR_SNIPPET) ?: "clean"})"
             }
-            log("[ws] $key $why — killing connection, round rides SSE\n")
+            log("[ws] ${logKey(key)} $why — killing connection, round rides SSE\n")
             failRound(conn, key)
         }
         return first
@@ -315,7 +323,7 @@ public class WsUpstream(
             }
         } else {
             if (poolable) {
-                log("[ws] $key frames arrived after the round terminal — killing rather than pooling\n")
+                log("[ws] ${logKey(key)} frames arrived after the round terminal — killing rather than pooling\n")
             }
             // Cancelled (watchdog/client-gone) or torn: leftover frames of a half-consumed
             // round poison reuse — kill, next round reconnects (full send, status quo).

--- a/gateway/dialect-openai-responses/src/test/kotlin/WsUpstreamTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/WsUpstreamTest.kt
@@ -593,37 +593,6 @@ class WsUpstreamTest {
         )
         assertTrue(fx.logged("unexpected binary frame"), "it is logged, just not acted on")
     }
-
-    // ==================================================================== log hygiene ===
-
-    /** WALL (stale review of #72, the finding its header-digest fix did not finish): the
-     *  connection key concatenates the CHAIN key — the client's session id and conversation
-     *  identity, raw client-derived text — and six transport log sites interpolated it verbatim
-     *  into daemon.log while logKey() existed for exactly this reason. Every operator-facing line
-     *  must carry the short digest, never the key. The key here is deliberately distinctive so a
-     *  substring match cannot false-negative. */
-    @Test
-    fun `no log line ever carries the raw connection key`() = runTest {
-        val rawKey = "9:session-A31:what the user actually typed"
-        // A NON-terminal first reply keeps the round open (an instant DONE would return the
-        // connection to the pool before the busy probe, and nothing would be busy to decline).
-        val fx = Fixture().apply { reply = replyWith(CREATED) }.start()
-        // exercise the chatty paths: connect + a live round, a busy decline, then completion
-        val flow = fx.up.round(rawKey, HEADERS, WSS_URL, TERMINAL) { FRAME }
-        assertTrue(flow != null, "first round should acquire")
-        val gate = Channel<Unit>(1)
-        val collector = launch { flow!!.collect { gate.trySend(Unit) } }
-        gate.receive() // the first (non-terminal) event arrived: the round is live, the socket busy
-        assertTrue(fx.up.round(rawKey, HEADERS, WSS_URL, TERMINAL) { FRAME } == null, "second round declines busy")
-        fx.opened.last().push(DONE) // finish the round
-        collector.join()
-        assertTrue(fx.log.isNotEmpty(), "the paths under test must actually log")
-        fx.log.forEach { line ->
-            assertTrue(!line.contains(rawKey), "raw key leaked into the log: $line")
-            assertTrue(!line.contains("what the user actually typed"), "client text leaked: $line")
-        }
-        assertTrue(fx.log.any { it.contains("ws-") }, "the digest form should appear in the log")
-    }
 }
 
 /** InboxListener drives the frame->event boundary and is a separate production class; its tests
@@ -716,5 +685,92 @@ class WsUpstreamInboxListenerTest {
         val cause = errored.receiveCatching().exceptionOrNull()
         assertTrue(cause is IOException, "an errored close carries an IOException, got $cause")
         assertEquals("websocket error", cause?.message)
+    }
+}
+
+/**
+ * WALL (stale review of #72, finished per review of #88): the connection key concatenates the
+ * CHAIN key — the client's session id and conversation identity, raw client-derived text — and
+ * six transport log sites interpolated it verbatim into daemon.log while logKey() existed for
+ * exactly this reason. One test per log-bearing path, the failure paths included: a first cut
+ * drove only the happy path, so a regression in a failure site would have passed, and it matched
+ * a bare "ws-" prefix, which a constant or wrong-input digest also satisfies (review of #88).
+ * Every test asserts the EXACT digest of its own distinctive key.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class WsUpstreamLogHygieneTest {
+
+    private val clientText = "what the user actually typed"
+
+    private fun rawKey(tag: String) = "9:session-$tag" + "31:$clientText"
+
+    private fun assertSafeLogs(fx: Fixture, rawKey: String) {
+        val expectedDigest = "ws-" + Integer.toHexString(rawKey.hashCode())
+        assertTrue(fx.log.isNotEmpty(), "the path under test must actually log")
+        fx.log.forEach { line ->
+            assertTrue(rawKey !in line, "raw key leaked: $line")
+            assertTrue(clientText !in line, "client text leaked: $line")
+        }
+        assertTrue(
+            fx.log.any { expectedDigest in it },
+            "the digest of THIS key must appear (a constant or wrong-input digest must fail): ${fx.log}",
+        )
+    }
+
+    @Test
+    fun `connect and busy-decline log only the digest`() = runTest {
+        val key = rawKey("A")
+        val fx = Fixture().apply { reply = replyWith(CREATED) }.start()
+        val flow = fx.up.round(key, HEADERS, WSS_URL, TERMINAL) { FRAME }
+        assertTrue(flow != null, "first round should acquire")
+        val gate = Channel<Unit>(1)
+        val collector = launch { flow!!.collect { gate.trySend(Unit) } }
+        gate.receive() // non-terminal first event: the round is live, the socket busy
+        assertTrue(fx.up.round(key, HEADERS, WSS_URL, TERMINAL) { FRAME } == null, "second declines busy")
+        fx.opened.last().push(DONE)
+        collector.join()
+        assertSafeLogs(fx, key)
+    }
+
+    @Test
+    fun `connect failure logs only the digest`() = runTest {
+        val key = rawKey("B")
+        val fx = Fixture().apply { connectFailure = IOException("refused") }.start()
+        assertNull(fx.up.round(key, HEADERS, WSS_URL, TERMINAL) { FRAME })
+        assertSafeLogs(fx, key)
+    }
+
+    @Test
+    fun `synchronous send failure logs only the digest`() = runTest {
+        val key = rawKey("C")
+        val fx = Fixture().apply { sendThrows = IllegalStateException("send pending") }.start()
+        assertNull(fx.up.round(key, HEADERS, WSS_URL, TERMINAL) { FRAME })
+        assertSafeLogs(fx, key)
+    }
+
+    @Test
+    fun `first-event timeout logs only the digest`() = runTest {
+        val key = rawKey("D")
+        val fx = Fixture().start(firstEventTimeoutMs = BUDGET) // no reply configured: silence
+        assertNull(fx.up.round(key, HEADERS, WSS_URL, TERMINAL) { FRAME })
+        assertSafeLogs(fx, key)
+    }
+
+    @Test
+    fun `inbox closed before the first event logs only the digest`() = runTest {
+        val key = rawKey("E")
+        val fx = Fixture().apply { onHandshake = { it.closeClean() } }.start()
+        assertNull(fx.up.round(key, HEADERS, WSS_URL, TERMINAL) { FRAME })
+        assertSafeLogs(fx, key)
+    }
+
+    @Test
+    fun `frames after the round terminal log only the digest`() = runTest {
+        val key = rawKey("F")
+        val fx = Fixture().apply { reply = replyWith(DONE, DELTA) }.start()
+        val flow = fx.up.round(key, HEADERS, WSS_URL, TERMINAL) { FRAME }
+        assertTrue(flow != null, "round should acquire")
+        flow!!.collect { }
+        assertSafeLogs(fx, key)
     }
 }

--- a/gateway/dialect-openai-responses/src/test/kotlin/WsUpstreamTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/WsUpstreamTest.kt
@@ -593,6 +593,37 @@ class WsUpstreamTest {
         )
         assertTrue(fx.logged("unexpected binary frame"), "it is logged, just not acted on")
     }
+
+    // ==================================================================== log hygiene ===
+
+    /** WALL (stale review of #72, the finding its header-digest fix did not finish): the
+     *  connection key concatenates the CHAIN key — the client's session id and conversation
+     *  identity, raw client-derived text — and six transport log sites interpolated it verbatim
+     *  into daemon.log while logKey() existed for exactly this reason. Every operator-facing line
+     *  must carry the short digest, never the key. The key here is deliberately distinctive so a
+     *  substring match cannot false-negative. */
+    @Test
+    fun `no log line ever carries the raw connection key`() = runTest {
+        val rawKey = "9:session-A31:what the user actually typed"
+        // A NON-terminal first reply keeps the round open (an instant DONE would return the
+        // connection to the pool before the busy probe, and nothing would be busy to decline).
+        val fx = Fixture().apply { reply = replyWith(CREATED) }.start()
+        // exercise the chatty paths: connect + a live round, a busy decline, then completion
+        val flow = fx.up.round(rawKey, HEADERS, WSS_URL, TERMINAL) { FRAME }
+        assertTrue(flow != null, "first round should acquire")
+        val gate = Channel<Unit>(1)
+        val collector = launch { flow!!.collect { gate.trySend(Unit) } }
+        gate.receive() // the first (non-terminal) event arrived: the round is live, the socket busy
+        assertTrue(fx.up.round(rawKey, HEADERS, WSS_URL, TERMINAL) { FRAME } == null, "second round declines busy")
+        fx.opened.last().push(DONE) // finish the round
+        collector.join()
+        assertTrue(fx.log.isNotEmpty(), "the paths under test must actually log")
+        fx.log.forEach { line ->
+            assertTrue(!line.contains(rawKey), "raw key leaked into the log: $line")
+            assertTrue(!line.contains("what the user actually typed"), "client text leaked: $line")
+        }
+        assertTrue(fx.log.any { it.contains("ws-") }, "the digest form should appear in the log")
+    }
 }
 
 /** InboxListener drives the frame->event boundary and is a separate production class; its tests


### PR DESCRIPTION
Three merged PRs — **#70, #72, #75** — carried **25 unique review findings** that never got replies because the PRs merged mid-review. Every finding was verified against current `main` before acting.

## The tally

| verdict | count | detail |
|---|---|---|
| **already fixed** | 22 | mostly by follow-up work whose comments literally cite *"review of #72"*: `supportsWebSocket` gating, `chainKey` refusing absent isolation, `roundBypassed`, idle-only eviction, the `terminalSeen` producer fence, the dead-predecessor connect race, `handedOff` cancellation safety, the header **digest** in connection identity, ReasoningCache's conditional `nullByToolId` removal, all six requested tests, `manifest.py`, the ISE send test. Plus #70's four spike findings (fixed inside #70 itself) and #75's two (fixed by #81). |
| **real residual — fixed here** | 1 | see below |
| **answered as policy** | 2 | the ABI triplet + the superseded `/login` test ask |

## The residual

The header-digest fix stopped **credentials** reaching the connection key — but six `WsUpstream` log sites still interpolated the **raw key** into `daemon.log`, and the key concatenates the *chain key*: the client's session id and conversation identity. `ResponsesWsRunner.logKey()` existed for exactly this reason; the transport never used it.

Every transport log site now emits the same short digest. **Walled**: a test drives connect, busy-decline, and completion with a deliberately distinctive raw key and asserts no log line ever contains it — red-green proven by reverting one site.

## The policy answers

The three JVM-ABI findings (`QuirksConfig` / `ResponsesQuirks` / `TurnMeta` data-class shape) assume external compiled consumers. splice ships as an **application** and publishes no artifact — nothing links against these types. CONTRIBUTING now records what compatibility means here (the wire / `/api` / state-file / TOML contracts are the stable surface, each with its own gate), so the answer outlives this sweep. The PR75 test ask was superseded by the operator's ruling that **every head keeps `/login`** (pinned by `SignInPlanMatrixTest`).

## Honesty note

The new wall initially landed in the file's *last* class and the filtered test run reported green **without ever executing it** — caught by counting executed tests against `@Test` occurrences. Moved, watched fail on a wrong harness assumption, fixed, then red-green proven.

All 25 threads on #70/#72/#75 are being replied to with per-item verdicts and resolved.

`GATE: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)