### PR TITLE
feat(grok): the xhigh reasoning rung for grok-4.6

### DIFF
--- a/gateway/dialect-openai-chat/src/main/kotlin/splice/dialect/chat/ChatRequestBuilder.kt
+++ b/gateway/dialect-openai-chat/src/main/kotlin/splice/dialect/chat/ChatRequestBuilder.kt
@@ -77,7 +77,7 @@ public class ChatRequestBuilder(
             body.messages.forEach { msg -> appendMessage(this, msg.role, msg.content) }
         }
         val emitTools = quirks.supportsTools && !compact && body.tools.isNotEmpty()
-        val effort = chatReasoningEffort(body)
+        val effort = chatReasoningEffort(body, upstreamModel)
         // TIER-1 (#924): the request is a CLOSED ChatRequest DTO (see chatRequestObject) — a knob
         // that doesn't belong can't be added without a field.
         val cacheKey = quirks.sessionCacheKeyPrefix?.let { prefix -> sessionId?.let { "$prefix:$it" } }
@@ -336,11 +336,15 @@ public class ChatRequestBuilder(
  * effort (AGENTS cache law — a mismatched effort cold-starts the prompt cache); tools are
  * stripped separately, effort is deliberately not compact-aware.
  */
-private fun chatReasoningEffort(body: AnthropicRequest): String? {
+private fun chatReasoningEffort(body: AnthropicRequest, upstreamModel: String): String? {
     if (body.thinking?.disabled == true) return null
     val budget = body.thinking?.budgetTokens
     return when {
         budget == null -> "high"
+        // grok-4.6+ (xAI docs 2026-08; older groks clamp xhigh to high). Gated on the model
+        // because this dialect also serves arbitrary OpenAI-compatible vendors, and an unknown
+        // enum there may be an error rather than a clamp.
+        budget >= XHIGH_BUDGET_FLOOR && XHIGH_MODELS.containsMatchIn(upstreamModel) -> "xhigh"
         budget >= HIGH_BUDGET_FLOOR -> "high"
         budget >= MEDIUM_BUDGET_FLOOR -> "medium"
         budget > 0L -> "low"
@@ -349,5 +353,10 @@ private fun chatReasoningEffort(body: AnthropicRequest): String? {
 }
 
 // /effort picker budget_tokens -> chat reasoning_effort tier floors
+private const val XHIGH_BUDGET_FLOOR = 64_000L
 private const val HIGH_BUDGET_FLOOR = 32_000L
 private const val MEDIUM_BUDGET_FLOOR = 8_000L
+
+// xhigh is native on grok-4.6 and later (4.6..4.9, 4.10+). grok-5+ lands here when it exists —
+// a one-line extension, not a silent cap on a shipped model.
+private val XHIGH_MODELS = Regex("grok-4\\.(?:[6-9]|[1-9]\\d)")

--- a/gateway/dialect-openai-chat/src/test/kotlin/ChatRequestBuilderTest.kt
+++ b/gateway/dialect-openai-chat/src/test/kotlin/ChatRequestBuilderTest.kt
@@ -19,10 +19,15 @@ import splice.dialect.chat.withReasoningEffortToml
 
 private val CHAT = ChatQuirks(providerTag = "kimi")
 
-private fun build(json: String, quirks: ChatQuirks = CHAT, compact: Boolean = false): JsonObject {
+private fun build(
+    json: String,
+    quirks: ChatQuirks = CHAT,
+    compact: Boolean = false,
+    model: String = "kimi-k2",
+): JsonObject {
     val body = parseAnthropicBody(json).typed
     return ChatRequestBuilder(quirks)
-        .build(body, upstreamModel = "kimi-k2", originalModel = "claude-kimi--kimi-k2", compact = compact)
+        .build(body, upstreamModel = model, originalModel = "claude-kimi--$model", compact = compact)
         .req
 }
 
@@ -193,6 +198,18 @@ class ChatRequestBuilderTest {
         )
         assertFalse(off.containsKey("reasoning_effort"))
         assertFalse(off.containsKey("reasoning"))
+    }
+
+    @Test
+    fun `top thinking budget emits xhigh on grok-4_6, high elsewhere`() {
+        // Grok 4.6 adds the xhigh rung (xAI docs 2026-08: native on 4.6+; older models clamp it
+        // to high upstream). The chat dialect serves arbitrary vendors, so the rung is gated on
+        // the upstream model — an unknown vendor must never see an enum it may reject.
+        val withBudget = """{"model":"m","messages":[{"role":"user","content":"hard"}],
+            "thinking":{"type":"enabled","budget_tokens":64000}}"""
+        assertEquals("xhigh", build(withBudget, model = "grok-4.6")["reasoning_effort"]?.jsonPrimitive?.content)
+        assertEquals("high", build(withBudget, model = "grok-4.5")["reasoning_effort"]?.jsonPrimitive?.content)
+        assertEquals("high", build(withBudget, model = "deepseek-reasoner")["reasoning_effort"]?.jsonPrimitive?.content)
     }
 
     @Test

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesRequestBuilder.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesRequestBuilder.kt
@@ -498,7 +498,7 @@ public class ResponsesRequestBuilder(private val quirks: ResponsesQuirks) {
     }
 }
 
-private val GROK_EFFORTS = setOf("low", EFFORT_MEDIUM, "high")
+private val GROK_EFFORTS = setOf("low", EFFORT_MEDIUM, "high", EFFORT_XHIGH)
 
 /**
  * Visibility floor: never RAISES a deliberate low/medium/high pick, only floors none/minimal to
@@ -826,8 +826,10 @@ private fun normalizeCodexEffort(s: String): String? = when (s) {
 }
 
 private fun normalizeGrokEffort(s: String): String? = when (s) {
-    "high", EFFORT_XHIGH, "max", "ultra", "ultracode", "extra_high", "extra-high",
-    "extrahigh", "heavy", "extended",
+    // grok-4.6+ (xAI docs 2026-08): xhigh is the top rung; older groks clamp it to high upstream.
+    "max", "ultra", "ultracode", "extra_high", "extra-high", "extrahigh", EFFORT_XHIGH,
+    -> EFFORT_XHIGH
+    "high", "heavy", "extended",
     -> "high"
     EFFORT_MEDIUM, "standard", "normal" -> EFFORT_MEDIUM
     "low", EFFORT_MINIMAL, "none", "off", "fast", "light" -> "low"
@@ -861,6 +863,7 @@ public fun normalizeSummary(raw: String?): String? {
 public fun effortFromBudget(budget: Long, ladder: EffortLadder): String? = when (ladder) {
     EffortLadder.CODEX -> codexBudgetEffort(budget)
     EffortLadder.GROK -> when {
+        budget >= BUDGET_MAX -> EFFORT_XHIGH
         budget >= BUDGET_HIGH -> "high"
         budget >= BUDGET_MEDIUM -> EFFORT_MEDIUM
         else -> "low"

--- a/gateway/dialect-openai-responses/src/test/kotlin/ResponsesRequestBuilderTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ResponsesRequestBuilderTest.kt
@@ -93,6 +93,28 @@ class ResponsesRequestBuilderTest {
     }
 
     @Test
+    fun `grok ladder reaches xhigh on the top budget rung and the ultracode alias`() {
+        // Grok 4.6 adds the xhigh rung (xAI docs 2026-08: native on 4.6+; older groks clamp it
+        // to high upstream), so the ladder emits it model-blind — a stale gate would silently
+        // cap every future grok at high. Before this the GROK ladder topped out at high and the
+        // ultracode alias clamped to high.
+        var req = build(
+            """{"model":"grok-4.6","thinking":{"type":"enabled","budget_tokens":64000},
+                "messages":[{"role":"user","content":"x"}]}""",
+            quirks = GROK,
+            options = opts(model = "grok-4.6"),
+        )
+        assertEquals("xhigh", req["reasoning"]?.jsonObject?.get("effort")?.jsonPrimitive?.content)
+        req = build(
+            """{"model":"grok-4.6","effort":"ultracode","thinking":{"type":"enabled","budget_tokens":2000},
+                "messages":[{"role":"user","content":"x"}]}""",
+            quirks = GROK,
+            options = opts(model = "grok-4.6"),
+        )
+        assertEquals("xhigh", req["reasoning"]?.jsonObject?.get("effort")?.jsonPrimitive?.content)
+    }
+
+    @Test
     fun `visibility floor lifts none-minimal to low but never a deliberate pick`() {
         var req = build(
             """{"model":"m","effort":"minimal","messages":[{"role":"user","content":"x"}]}""",
@@ -332,14 +354,18 @@ class ResponsesRequestBuilderTest {
     }
 
     @Test
-    fun `grok ladder clamps xhigh to high, emits tool_choice, floors disabled to low`() {
+    fun `grok ladder passes xhigh through (upstream clamps pre-4_6), emits tool_choice, floors disabled to low`() {
+        // 2026-08-13: the clamp moved UPSTREAM. xhigh is native on grok-4.6+; xAI documents
+        // treating it as high on older models, and this provider only ever talks to api.x.ai,
+        // so the ladder emits it model-blind instead of keeping a client-side gate that would
+        // silently cap every future grok at high.
         val req = build(
             """{"model":"grok-4.5","effort":"xhigh","tools":[{"name":"t","input_schema":{"type":"object"}}],
                 "tool_choice":{"type":"any"},"messages":[{"role":"user","content":"x"}]}""",
             quirks = GROK,
             options = opts(model = "grok-4.5"),
         )
-        assertEquals("high", req["reasoning"]?.jsonObject?.get("effort")?.jsonPrimitive?.content)
+        assertEquals("xhigh", req["reasoning"]?.jsonObject?.get("effort")?.jsonPrimitive?.content)
         // Full reasoning visibility: detailed summary is requested so the stream fills the
         // thinking channel (xAI's public form of "full" reasoning text).
         assertEquals("detailed", req["reasoning"]?.jsonObject?.get("summary")?.jsonPrimitive?.content)

--- a/gateway/provider-grok/src/test/kotlin/grok/GrokProviderTest.kt
+++ b/gateway/provider-grok/src/test/kotlin/grok/GrokProviderTest.kt
@@ -144,14 +144,16 @@ class GrokProviderTest {
     }
 
     @Test
-    fun `grok quirks - effort clamps to high, detailed summary for full thinking, session cache key`() = runBlocking {
+    fun `grok quirks - xhigh passes through (upstream clamps pre-4_6), detailed summary, session cache key`() = runBlocking {
         val parsed = parseAnthropicBody(
             """{"model":"grok-4.5","effort":"xhigh","messages":[{"role":"user","content":"first"}]}""",
         )
         val grokProvider = provider(oauthAuth(Files.createTempDirectory("q")))
         val built = grokProvider.buildTurn(parsed, compact = false, sessionId = "s1")
         val reasoning = built.requestBody["reasoning"]!!.jsonObject
-        assertEquals("high", reasoning["effort"]?.jsonPrimitive?.content) // xhigh clamped to high
+        // 2026-08-13: xhigh is native on grok-4.6+; on 4.5 xAI clamps it to high server-side.
+        // Emitted model-blind — a client-side gate would silently cap every future grok at high.
+        assertEquals("xhigh", reasoning["effort"]?.jsonPrimitive?.content)
         // detailed summary is the fullest public form of Grok reasoning Claude Code can display
         assertEquals("detailed", reasoning["summary"]?.jsonPrimitive?.content)
         assertEquals("claude-grok:s1", built.requestBody["prompt_cache_key"]?.jsonPrimitive?.content)


### PR DESCRIPTION
Grok 4.6 adds an **xhigh** reasoning rung above low/medium/high ([xAI docs](https://docs.x.ai/developers/model-capabilities/text/reasoning)). Splice's grok effort ladders predated it:

- the chat dialect (the live grok path) capped every thinking budget at `high`
- the responses ladder clamped the `ultracode`/`xhigh` aliases to `high`, and `flooredForGrok` could send `xhigh` **down** to `low`

## Changes

- **Chat dialect** (`ChatRequestBuilder`): the top budget rung (≥64k) now emits `xhigh`, gated on the upstream model being grok-4.6+ — this dialect also serves arbitrary OpenAI-compatible vendors, where an unknown enum may error rather than clamp.
- **Responses dialect** (`ResponsesRequestBuilder`, xAI-only provider): emits `xhigh` model-blind. xAI documents clamping it to `high` on pre-4.6 models, and a client-side gate would silently cap every future grok at `high`.
- Two tests pinned the pre-4.6 client-side clamp; both updated to the new contract with the reason recorded inline.

## Verification

`npm run gate` PASS locally (detekt, all module tests, walls, oracle, webui). New tests: chat builder (grok-4.6 → xhigh; grok-4.5 and unknown vendors → high) and responses builder (64k budget and ultracode alias → xhigh on the GROK ladder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)