### PR TITLE
ci(gate): fail fast when the catalog outruns verification metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
   walls-annotate:
     # Annotation-only surface for ast-grep wall violations.
-    # The gate job at checks/gate.sh:65 remains the SOLE pass/fail authority
+    # The gate job at checks/gate.sh:70 remains the SOLE pass/fail authority
     # (same checker run twice deliberately). The `|| true` is deliberate:
     # this job exists only to surface violations as PR diff annotations, not
     # to block merges. GitHub caps annotations at roughly 10 error + 10 warning

--- a/checks/catalog-metadata-selftest.sh
+++ b/checks/catalog-metadata-selftest.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# checks/catalog-metadata-selftest.sh — red-green proof for catalog-metadata-sync.py, run by the
+# gate. Same defence-in-depth idiom as secret-scan-allow-selftest.sh: the checker guards the
+# catalog↔verification-metadata seam, this canary guards the CHECKER, so a bug in it (a parser
+# change that starts silently skipping entries, a namespace regression) fails the gate instead of
+# silently waving drift through. Fixtures are synthetic but carry the REAL metadata xmlns — a
+# non-namespace-aware parser must fail HERE, not on the real file.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECKER="$ROOT/checks/catalog-metadata-sync.py"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fail=0
+err() { echo "  ✗ catalog-metadata-selftest: $1"; fail=1; }
+
+# ── fixtures ──────────────────────────────────────────────────────────────────────────────────
+# One of each catalog shape the checker must cover: version.ref library, inline-version library,
+# versionless BOM rider (must be skipped), plugin (must be checked as its marker artifact), and
+# an UNREFERENCED floor version (netty-style: no library uses it, but a bump must still trip the
+# check via version presence).
+cat > "$tmp/catalog.toml" <<'EOF'
+[versions]
+ktor = "3.5.2"
+floor = "9.9.9.Final"
+[libraries]
+ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
+zstd = { module = "com.example:zstd", version = "1.0" }
+bom-rider = { module = "org.junit.jupiter:junit-jupiter" }
+[plugins]
+kover = { id = "org.example.kover", version = "0.9.9" }
+EOF
+
+meta_head='<?xml version="1.0" encoding="UTF-8"?>
+<verification-metadata xmlns="https://schema.gradle.org/dependency-verification" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://schema.gradle.org/dependency-verification https://schema.gradle.org/dependency-verification/dependency-verification-1.3.xsd">
+   <configuration>
+      <verify-metadata>true</verify-metadata>
+      <verify-signatures>false</verify-signatures>
+   </configuration>
+   <components>'
+meta_tail='   </components>
+</verification-metadata>'
+comp() { printf '      <component group="%s" name="%s" version="%s"><artifact name="x.jar"><sha256 value="0" origin="test"/></artifact></component>\n' "$1" "$2" "$3"; }
+
+{ echo "$meta_head"
+  comp io.ktor ktor-server-core 3.5.2
+  comp com.example zstd 1.0
+  comp org.example.kover org.example.kover.gradle.plugin 0.9.9
+  comp io.example transitive-floor 9.9.9.Final
+  echo "$meta_tail"; } > "$tmp/good.xml"
+
+# Each bad fixture removes exactly one obligation from good.xml.
+{ echo "$meta_head"
+  comp io.ktor ktor-server-core 3.5.1
+  comp com.example zstd 1.0
+  comp org.example.kover org.example.kover.gradle.plugin 0.9.9
+  comp io.example transitive-floor 9.9.9.Final
+  echo "$meta_tail"; } > "$tmp/bad-lib.xml"
+
+{ echo "$meta_head"
+  comp io.ktor ktor-server-core 3.5.2
+  comp com.example zstd 1.0
+  comp org.example.kover org.example.kover.gradle.plugin 0.9.8
+  comp io.example transitive-floor 9.9.9.Final
+  echo "$meta_tail"; } > "$tmp/bad-plugin.xml"
+
+{ echo "$meta_head"
+  comp io.ktor ktor-server-core 3.5.2
+  comp com.example zstd 1.0
+  comp org.example.kover org.example.kover.gradle.plugin 0.9.9
+  echo "$meta_tail"; } > "$tmp/bad-floor.xml"
+
+# Marker absent but the plugin's version pinned via another component: the build-logic pattern
+# (plugin applied by bare id inside a precompiled script, implementation jar on that classpath —
+# the marker never resolves, so regeneration can never add it). Obligation degrades to version
+# presence and the checker must PASS.
+{ echo "$meta_head"
+  comp io.ktor ktor-server-core 3.5.2
+  comp com.example zstd 1.0
+  comp org.example kover-gradle-plugin-impl 0.9.9
+  comp io.example transitive-floor 9.9.9.Final
+  echo "$meta_tail"; } > "$tmp/markerless-plugin.xml"
+
+# ── assertions ────────────────────────────────────────────────────────────────────────────────
+run_checker() { python3 "$CHECKER" "$tmp/catalog.toml" "$tmp/$1" > "$tmp/out" 2>&1; }
+
+if run_checker good.xml; then :; else
+  err "compliant fixture must exit 0 (got $?): $(head -3 "$tmp/out" | tr '\n' ' ')"
+fi
+
+if run_checker bad-lib.xml; then
+  err "missing library version must exit 1 (exited 0)"
+elif ! grep -q "io.ktor:ktor-server-core:3.5.2" "$tmp/out"; then
+  err "missing library failure must name io.ktor:ktor-server-core:3.5.2"
+fi
+
+if run_checker bad-plugin.xml; then
+  err "missing plugin marker must exit 1 (exited 0)"
+elif ! grep -q "org.example.kover.gradle.plugin:0.9.9" "$tmp/out"; then
+  err "missing plugin failure must name org.example.kover.gradle.plugin:0.9.9"
+fi
+
+if run_checker bad-floor.xml; then
+  err "absent floor version must exit 1 (exited 0)"
+elif ! grep -q "9.9.9.Final" "$tmp/out"; then
+  err "floor failure must name the version 9.9.9.Final"
+fi
+
+if run_checker markerless-plugin.xml; then :; else
+  err "markerless plugin with version pinned elsewhere must exit 0 (got build-logic pattern wrong): $(head -3 "$tmp/out" | tr '\n' ' ')"
+fi
+
+exit "$fail"

--- a/checks/catalog-metadata-sync.py
+++ b/checks/catalog-metadata-sync.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Fail when the version catalog outruns dependency-verification metadata.
+
+WHY THIS EXISTS (PR #91, and every gradle Dependabot PR before it): Dependabot can edit
+gateway/gradle/libs.versions.toml but cannot run the metadata regeneration, so every catalog bump
+arrives with gradle/verification-metadata.xml still pinning the OLD versions. With
+verify-metadata=true that is a guaranteed red — but it surfaces six minutes into the gradle leg
+of the gate, as a wall of "Dependency verification failed" noise. This check states the same
+fact statically, in under a second, with the remedy attached.
+
+What is checked, per catalog table:
+  [libraries]  every entry carrying a resolvable version must appear in the metadata as a
+               component (group, name, version). Versionless entries (BOM riders) are skipped.
+  [plugins]    checked as their marker artifact: (id, id + ".gradle.plugin", version). A plugin
+               applied by bare id inside build-logic never resolves its marker, so the obligation
+               degrades to version presence (kotlin-serialization is that case today).
+  [versions]   keys referenced by neither table are FLOOR pins (netty-style: declared so the
+               resolver and Dependabot have a line to hold/bump, materialised only as
+               transitives). No (group, name) is derivable statically, so the obligation is
+               presence: at least one metadata component at that version. A floor that matches
+               nothing is either an unregenerated bump or an inert floor that should be dropped —
+               both worth a red.
+
+Transitive drift is out of scope by design: it cannot be seen statically, and the remediation
+below repins transitives and directs anyway. Unparseable catalog shapes are a loud death, never
+a silent skip — a skipped entry is exactly how drift would hide (brain #924).
+
+Usage:
+    python3 checks/catalog-metadata-sync.py [catalog.toml] [verification-metadata.xml]
+"""
+from __future__ import annotations
+
+import sys
+import tomllib
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import NoReturn
+
+ROOT = Path(__file__).resolve().parent.parent
+NS = "{https://schema.gradle.org/dependency-verification}"
+
+REMEDY = """\
+catalog-metadata-sync: gateway/gradle/libs.versions.toml declares versions that
+gradle/verification-metadata.xml does not pin. Regenerate from the gateway directory —
+BOTH passes, the shadowJar license pass fetches poms that `check` alone never resolves:
+
+    ./gradlew --write-verification-metadata sha256 clean check
+    ./gradlew --write-verification-metadata sha256 :app:shadowJar --no-daemon --no-parallel
+
+then commit the regenerated gradle/verification-metadata.xml (precedent: PR #91)."""
+
+
+def die(msg: str) -> NoReturn:
+    print(f"catalog-metadata-sync: {msg}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def version_of(key: str, entry: dict, versions: dict[str, str], used: set[str]) -> str | None:
+    """Resolve an entry's version to a literal, None when legitimately absent, death otherwise."""
+    v = entry.get("version")
+    if v is None:
+        return None
+    if isinstance(v, str):
+        return v
+    if isinstance(v, dict) and isinstance(v.get("ref"), str):
+        ref = v["ref"]
+        if ref not in versions:
+            die(f"{key}: version.ref {ref!r} not in [versions]")
+        used.add(ref)
+        return versions[ref]
+    die(f"{key}: unsupported version shape {v!r} — extend this checker, do not skip")
+
+
+def main() -> int:
+    catalog_path = Path(sys.argv[1]) if len(sys.argv) > 1 else ROOT / "gateway/gradle/libs.versions.toml"
+    metadata_path = Path(sys.argv[2]) if len(sys.argv) > 2 else ROOT / "gateway/gradle/verification-metadata.xml"
+
+    catalog = tomllib.loads(catalog_path.read_text())
+    versions = catalog.get("versions", {})
+    for key, v in versions.items():
+        if not isinstance(v, str):
+            die(f"[versions] {key}: rich version {v!r} — extend this checker, do not skip")
+
+    components: set[tuple[str, str, str]] = set()
+    for c in ET.parse(metadata_path).getroot().iter(f"{NS}component"):
+        components.add((c.get("group", ""), c.get("name", ""), c.get("version", "")))
+    pinned_versions = {v for _, _, v in components}
+
+    used: set[str] = set()
+    missing: list[str] = []
+
+    for key, entry in catalog.get("libraries", {}).items():
+        if isinstance(entry, str):
+            parts = entry.split(":")
+            if len(parts) != 3:
+                die(f"libraries.{key}: unsupported shorthand {entry!r}")
+            group, name, version = parts
+        elif isinstance(entry, dict):
+            module = entry.get("module")
+            if isinstance(module, str) and module.count(":") == 1:
+                group, name = module.split(":")
+            elif isinstance(entry.get("group"), str) and isinstance(entry.get("name"), str):
+                group, name = entry["group"], entry["name"]
+            else:
+                die(f"libraries.{key}: no module/group+name — extend this checker, do not skip")
+            version = version_of(f"libraries.{key}", entry, versions, used)
+            if version is None:
+                continue  # BOM rider: version supplied at resolution time, nothing to compare
+        else:
+            die(f"libraries.{key}: unsupported entry {entry!r}")
+        if (group, name, version) not in components:
+            missing.append(f"libraries.{key}: {group}:{name}:{version} not pinned in metadata")
+
+    for key, entry in catalog.get("plugins", {}).items():
+        if not isinstance(entry, dict) or not isinstance(entry.get("id"), str):
+            die(f"plugins.{key}: unsupported entry {entry!r}")
+        version = version_of(f"plugins.{key}", entry, versions, used)
+        if version is None:
+            continue
+        marker = (entry["id"], entry["id"] + ".gradle.plugin", version)
+        # A plugin requested through the plugins DSL resolves its marker; one applied by bare id
+        # inside build-logic (implementation jar on that classpath) never does, so regeneration
+        # cannot pin a marker for it. Degrade to version presence — an unregenerated bump still
+        # has no component at the new version and stays red.
+        if marker not in components and version not in pinned_versions:
+            missing.append(
+                f"plugins.{key}: {marker[0]}:{marker[1]}:{version} (marker) not pinned, "
+                f"and no component at {version}"
+            )
+
+    for key in versions.keys() - used:
+        if versions[key] not in pinned_versions:
+            missing.append(
+                f"[versions] {key} = \"{versions[key]}\": floor version matches no pinned component "
+                "(unregenerated bump, or an inert floor to drop)"
+            )
+
+    if missing:
+        for line in sorted(missing):
+            print(f"  {line}")
+        print(REMEDY)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/checks/gate.sh
+++ b/checks/gate.sh
@@ -61,6 +61,11 @@ run() { # run <label> <cmd...> — runs the command, records its REAL exit, neve
 }
 
 echo "══ splice gate ══  (JAVA_HOME=$JAVA_HOME)"
+# Dependabot edits the catalog but cannot regenerate verification metadata, so gradle bumps used
+# to arrive red six minutes into the gradle leg (#91). State the same fact statically, first and
+# in under a second, with the regeneration remedy attached. Selftest guards the checker itself.
+run "catalog metadata sync" python3 checks/catalog-metadata-sync.py
+run "catalog metadata selftest" bash checks/catalog-metadata-selftest.sh
 run "gradle clean check" bash -c 'cd gateway && ./gradlew clean check'
 run "ast-grep walls" npm run --silent gate:rules
 run "hook tests"     npm run --silent test:hooks


### PR DESCRIPTION
Builds the check proposed in #91's review thread: Dependabot can edit `gateway/gradle/libs.versions.toml` but cannot regenerate `gradle/verification-metadata.xml`, so every gradle bump arrived red six minutes into the gradle leg. This states the same fact statically, first in the ladder, in under a second, with the regeneration remedy attached.

**What it checks** (`checks/catalog-metadata-sync.py`):
- `[libraries]` with a resolvable version → `(group, name, version)` must be a pinned component; BOM riders skipped
- `[plugins]` → marker artifact `(id, id.gradle.plugin, version)`, degrading to version-presence for build-logic-applied plugins whose marker never resolves (kotlin-serialization today)
- unreferenced `[versions]` keys (netty-style floors) → at least one pinned component at that version
- unparseable catalog shapes die loudly, never silently skip (#924)

**Walls first** (`checks/catalog-metadata-selftest.sh`, wired as a second gate leg): five synthetic fixtures carrying the real metadata xmlns — compliant pass, missing library, missing marker, absent floor, markerless-plugin pass.

**Falsifiable checks run:**
- selftest exit 0 at HEAD ✓
- checker exit 0 against the real catalog + metadata at HEAD ✓
- synthetic Dependabot bump (ktor 3.5.3 in a catalog copy vs real metadata) → exit 1 naming all nine ktor libraries in <1s ✓

Also updates the `checks/gate.sh:65` line reference in `ci.yml` (now :70) shifted by the ladder insertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gu4JpMGEjMSFeCuWxZX6m4