### PR TITLE
build(gateway): drop the dead kotlin-serialization plugin alias

### DIFF
--- a/gateway/gradle/libs.versions.toml
+++ b/gateway/gradle/libs.versions.toml
@@ -53,6 +53,5 @@ junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }


### PR DESCRIPTION
Second loose end from building #96: the `[plugins] kotlin-serialization` catalog alias is referenced nowhere. The plugin is actually applied by bare id inside build-logic's `splice.kotlin-common.gradle.kts` with the implementation jar on that classpath (version rides `libs.versions.kotlin`, which stays). The alias's marker never resolves, so it also carried a permanent version-presence degradation in `catalog-metadata-sync`.

Proof: `./gradlew help` configures clean after removal; `catalog metadata sync` + selftest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gu4JpMGEjMSFeCuWxZX6m4