### PR TITLE
chore(ci): sync workflow templates from github-operator

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -107,8 +107,15 @@ jobs:
       contents: write # gh pr merge --auto
       pull-requests: write
     steps:
+      # A maintainer pushing to a Dependabot branch (rebase, checksum repin, dist
+      # regeneration) replaces Dependabot's signed commits, and fetch-metadata then
+      # refuses with "PR is not from Dependabot, nothing to do" — exit 1, a red X on
+      # every hand-fixed Dependabot PR (splice#90/#91). That refusal IS this job's
+      # no-op, not a failure: arming stays reserved for verified, untouched Dependabot
+      # heads, and a touched PR is armed by the human who touched it.
       - uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         id: meta
+        continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -116,7 +123,9 @@ jobs:
         # Majors are excluded deliberately: a grouped bump resolves to the highest
         # semver change in the group, so a "stuck" green Dependabot PR is usually
         # a major waiting for a decision, not a broken gate.
-        if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        if: >-
+          steps.meta.outcome == 'success' &&
+          steps.meta.outputs.update-type != 'version-update:semver-major'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -128,8 +137,16 @@ jobs:
             >> "$GITHUB_STEP_SUMMARY"
 
       - name: Explain why a major was left alone
-        if: steps.meta.outputs.update-type == 'version-update:semver-major'
+        if: >-
+          steps.meta.outcome == 'success' &&
+          steps.meta.outputs.update-type == 'version-update:semver-major'
         env:
           UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
         run: |
           echo "Left for a human: ${UPDATE_TYPE} is a major update." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Explain the no-op on a maintainer-touched head
+        if: steps.meta.outcome != 'success'
+        run: |
+          echo "No-op: the head no longer verifies as Dependabot's (a maintainer pushed to the branch). Arm auto-merge manually if wanted." \
+            >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Automated sync of `.github/workflows/dependabot-automerge.yml` from the canonical copy in [torad-labs/github-operator](https://github.com/torad-labs/github-operator/tree/main/templates).

The file is MANAGED — edit the template upstream, not this copy, or the next sync overwrites it. The reusable-workflow ref is pinned to an immutable SHA, so this repo moves forward only when a sync says so.

Opened as a PR rather than pushed directly so it faces this repo's own CI first.