### PR TITLE
fix(gateway): stall watchdog keys on the first client frame, compact turns get the total cap, policy refusals are terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@
 
 ### Fixed
 
+- **Codex compaction no longer dies at the idle cap while the model is still reading.** The stall
+  watchdog switched to its short `streamIdleMs` tier on the first upstream byte, and on the
+  Responses API that byte is the `response.created` handshake, not output — so a compaction that
+  reasoned silently over a large transcript for longer than 180s was aborted and re-sent cold by the
+  client, in a loop (109 stalls on one head in a single day). The tier now follows the first client
+  content frame: until the client has seen output the silence is judged on `firstByteTimeoutMs`,
+  after it on `streamIdleMs`, on both the SSE and WebSocket transports. The stall message names the
+  tier that actually fired.
+- **A content-policy refusal is terminal, not retried.** ChatGPT's `cyber_policy` flag (and the
+  Responses API's documented prompt refusals: `invalid_prompt`, `bio_policy`,
+  `image_content_policy_violation`) reached Claude Code as a retryable `api_error`, so every refusal
+  became a backoff storm of the same multi-megabyte transcript. They now surface as
+  `invalid_request_error` with the vendor's own remedy text, matching the HTTP 400 the vendor returns
+  for the same refusal pre-stream.
 - Refresh failures for Codex, Grok, and Kimi no longer risk logging vendor response bodies, and
   KeyStore values containing `#`, quotes, or backslashes round-trip without corruption.
 - Request-body torn wakeups become an Anthropic-shaped HTTP 400 without swallowing genuine coroutine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,9 @@
   reasoned silently over a large transcript for longer than 180s was aborted and re-sent cold by the
   client, in a loop (109 stalls on one head in a single day). The tier now follows the first client
   content frame: until the client has seen output the silence is judged on `firstByteTimeoutMs`,
-  after it on `streamIdleMs`, on both the SSE and WebSocket transports. The stall message names the
-  tier that actually fired.
+  after it on `streamIdleMs`, on both the SSE and WebSocket transports. A compact turn's pre-output
+  silence is bounded by `upstreamTimeoutMs` alone (compactions on the corrected tier still
+  died silent at the 300s cap). The stall message names the tier that actually fired.
 - **A content-policy refusal is terminal, not retried.** ChatGPT's `cyber_policy` flag (and the
   Responses API's documented prompt refusals: `invalid_prompt`, `bio_policy`,
   `image_content_policy_violation`) reached Claude Code as a retryable `api_error`, so every refusal

--- a/gateway/core/src/main/kotlin/splice/core/turn/Turn.kt
+++ b/gateway/core/src/main/kotlin/splice/core/turn/Turn.kt
@@ -200,11 +200,21 @@ public class SharedSummaryParts(
     }
 }
 
-/** The two-tier watchdog knobs (v35 doctrine): before first byte the idle limit is
- *  firstByteTimeout (prefill is legitimately silent for minutes); after, streamIdle;
+/** The two-tier watchdog knobs (v35 doctrine): before the client has seen output the idle limit
+ *  is firstByteTimeout (prefill is legitimately silent for minutes); after, streamIdle;
  *  totalCap bounds the whole turn. */
 public data class WatchdogBudget(
     val firstByteTimeout: Duration,
     val streamIdle: Duration,
     val totalCap: Duration,
-)
+) {
+    /** The budget a COMPACT turn runs under: its pre-output silence is bounded by [totalCap] alone.
+     *  A compaction's prefill + reasoning over the whole transcript is the case the v35 doctrine
+     *  calls legitimately silent for minutes, and once the watchdog tier was corrected to key on
+     *  the first client frame (2026-09-01) the very first compaction on the corrected tier still
+     *  died at "no first output within the 300s first-output cap" — 1.13MB body, first byte at 3s,
+     *  then silence past five minutes, the same session that had looped all day. Idle is a stall
+     *  detector, not a budget (operator, DR-7): the one wall before a compaction's first output is
+     *  the whole-turn cap. Normal turns keep [firstByteTimeout]. */
+    public fun forCompact(): WatchdogBudget = copy(firstByteTimeout = totalCap)
+}

--- a/gateway/core/src/test/kotlin/WatchdogBudgetTest.kt
+++ b/gateway/core/src/test/kotlin/WatchdogBudgetTest.kt
@@ -1,0 +1,20 @@
+// The compact-turn budget (2026-09-01): a compaction's silence before its first output is bounded by
+// totalCap alone. Live provenance is in WatchdogBudget.forCompact's KDoc — the first compaction on
+// the corrected watchdog tier still died at "no first output within the 300s first-output cap".
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import splice.core.turn.WatchdogBudget
+import kotlin.time.Duration.Companion.seconds
+
+class WatchdogBudgetTest {
+
+    @Test
+    fun `forCompact lifts the first-output cap to totalCap and touches nothing else`() {
+        val provider = WatchdogBudget(firstByteTimeout = 300.seconds, streamIdle = 180.seconds, totalCap = 900.seconds)
+        val compact = provider.forCompact()
+        assertEquals(900.seconds, compact.firstByteTimeout, "the only wall before a compaction's first output")
+        assertEquals(180.seconds, compact.streamIdle, "mid-output stall detection is unchanged")
+        assertEquals(900.seconds, compact.totalCap, "the whole-turn cap is unchanged")
+        assertEquals(300.seconds, provider.firstByteTimeout, "the provider budget itself is untouched")
+    }
+}

--- a/gateway/dialect-anthropic-passthrough/src/test/kotlin/PassthroughStreamTranslatorTest.kt
+++ b/gateway/dialect-anthropic-passthrough/src/test/kotlin/PassthroughStreamTranslatorTest.kt
@@ -416,7 +416,7 @@ class PassthroughStreamTranslatorTest {
         // Preferring watchdog discarded successful kimi turns and burned quota on retries.
         val late = PassthroughTurnContext(
             { false },
-            { splice.spi.WatchdogFired.Idle(180_000, true) },
+            { splice.spi.WatchdogFired.Idle(180_000, sawClientFrame = true, limitMs = 180_000) },
             180_000,
             900_000,
         )

--- a/gateway/dialect-openai-chat/src/test/kotlin/ChatStreamTranslatorTest.kt
+++ b/gateway/dialect-openai-chat/src/test/kotlin/ChatStreamTranslatorTest.kt
@@ -275,7 +275,9 @@ class ChatStreamTranslatorTest {
 
     @Test
     fun `finished turn beats a late watchdog fire - success not overloaded`() = runTest {
-        val outcome = ChatStreamTranslator(firedCtx(splice.spi.WatchdogFired.Idle(180_000, true))).driveTurn(
+        val outcome = ChatStreamTranslator(
+            firedCtx(splice.spi.WatchdogFired.Idle(180_000, sawClientFrame = true, limitMs = 180_000)),
+        ).driveTurn(
             listOf(
                 ev("""{"choices":[{"delta":{"content":"done"},"finish_reason":null}]}"""),
                 ev("""{"choices":[{"delta":{},"finish_reason":"stop"}]}"""),
@@ -287,7 +289,9 @@ class ChatStreamTranslatorTest {
 
     @Test
     fun `watchdog fire without a finish stays an overloaded failure`() = runTest {
-        val outcome = ChatStreamTranslator(firedCtx(splice.spi.WatchdogFired.Idle(180_000, true))).driveTurn(
+        val outcome = ChatStreamTranslator(
+            firedCtx(splice.spi.WatchdogFired.Idle(180_000, sawClientFrame = true, limitMs = 180_000)),
+        ).driveTurn(
             listOf(ev("""{"choices":[{"delta":{"content":"partial"},"finish_reason":null}]}""")).asFlow(),
             Rec(),
         )

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesTerminalDecision.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesTerminalDecision.kt
@@ -105,8 +105,14 @@ internal class ResponsesTerminalDecision(
     // away text the client had already been shown and could not continue even in principle.
     private fun watchdogOutcome(fired: WatchdogFired, state: ResponsesTurnState): TurnOutcome {
         val why = when (fired) {
-            is WatchdogFired.Idle ->
+            // The tier that fired is named, not assumed: before any client frame the silence was
+            // judged on the first-output cap (firstByteTimeoutMs), after it on streamIdle. An
+            // operator reading "180s idle cap" on a 300s pre-output stall was reading a lie.
+            is WatchdogFired.Idle -> if (fired.sawClientFrame) {
                 "no completion within the ${ctx.streamIdleMsForMessage / MS_PER_S}s idle cap"
+            } else {
+                "no first output within the ${fired.limitMs / MS_PER_S}s first-output cap"
+            }
             is WatchdogFired.TotalCap ->
                 "no completion within the ${ctx.upstreamTimeoutMsForMessage / MS_PER_S}s total cap"
         }

--- a/gateway/dialect-openai-responses/src/test/kotlin/ResponsesReanchorTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ResponsesReanchorTest.kt
@@ -403,7 +403,7 @@ class ResponsesReanchorPartialTest {
     @Test
     fun `an idle watchdog fire carries its partial - the round is reaped, not the turn`() = runTest {
         val outcome = ResponsesStreamTranslator(
-            reanchorCtx(fired = WatchdogFired.Idle(idleMs = 1, sawFirstByte = true)),
+            reanchorCtx(fired = WatchdogFired.Idle(idleMs = 1, sawClientFrame = true, limitMs = 1)),
         ).driveTurn(
             listOf(
                 ev("""{"type":"response.output_text.delta","output_index":0,"delta":"text"}"""),

--- a/gateway/dialect-openai-responses/src/test/kotlin/ResponsesStreamTranslatorTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ResponsesStreamTranslatorTest.kt
@@ -105,7 +105,7 @@ class ResponsesStreamTranslatorTest {
         // was parsed. A fully-received turn must NOT be discarded as OVERLOADED (that retries a
         // successful compaction — the quota waste the watchdog exists to prevent).
         val outcome = ResponsesStreamTranslator(
-            ctx(fired = WatchdogFired.Idle(idleMs = 200_000, sawFirstByte = true)),
+            ctx(fired = WatchdogFired.Idle(idleMs = 200_000, sawClientFrame = true, limitMs = 180_000)),
         ).driveTurn(listOf(completed).asFlow(), RecordingSink())
         val success = outcome as TurnOutcome.Success
         assertEquals(100, success.usage.inputTokens)
@@ -351,7 +351,7 @@ class ResponsesStreamTranslatorTest {
     @Test
     fun `watchdog fired maps to overloaded with the idle cap message`() = runTest {
         val outcome = ResponsesStreamTranslator(
-            ctx(fired = WatchdogFired.Idle(idleMs = 200_000, sawFirstByte = true)),
+            ctx(fired = WatchdogFired.Idle(idleMs = 200_000, sawClientFrame = true, limitMs = 180_000)),
         ).driveTurn(emptyList<JsonObject>().asFlow(), RecordingSink())
         val failure = outcome as TurnOutcome.Failure
         assertEquals(ErrorType.OVERLOADED, failure.type)

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/SseRoundConsume.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/SseRoundConsume.kt
@@ -26,10 +26,11 @@ internal class SseRoundConsume(
         // first and nothing here pre-empts it. Recovers p50 2840ms of frozen screen per codex
         // turn; also gives the keepalive pinger an opened stream to ping into.
         drive.emitter.ensureStarted()
-        // Fresh upstream round/attempt: reset the idle tier so this round's (possibly long,
-        // silent) prefill is judged against firstByteTimeout, not the short streamIdle a prior
-        // round's first byte would otherwise pin it to. totalCap still spans the whole turn.
-        drive.watchdog.resetFirstByte()
+        // Fresh upstream round/attempt: clear a stale Idle sentinel (DR-7). The idle TIER needs no
+        // reset — the poller below reads this round's own client-frame probe, so a (possibly long,
+        // silent) prefill is judged against firstByteTimeout until the client has seen content.
+        // totalCap still spans the whole turn.
+        drive.watchdog.resetRound()
         // DR-7: the idle watchdog reaps THIS ROUND, not the turn. It used to cancel inputs.turnJob,
         // which killed driveTurn along with the round — so the translator never returned, the
         // salvaged reasoning died with it, and the fold loop had nothing left to continue from. The
@@ -51,7 +52,7 @@ internal class SseRoundConsume(
         val roundJob = Job(inputs.turnJob)
         val body = resp.bodyChannel()
         roundJob.invokeOnCompletion { cause -> if (cause != null) body.cancel(IOException(REAPED, cause)) }
-        val poller = drive.watchdog.launchIn(inputs.scope, drive.slot, roundJob)
+        val poller = drive.watchdog.launchIn(inputs.scope, drive.slot, roundJob, inputs.frameEmittedThisRound)
         // Leak wall (review 2026-07-19): the attempt's poller dies on EVERY exit of this
         // block — a torn-then-reissued stream used to leak it into `self`, pinning the
         // admission slot ~streamIdle past turn completion. (The client pinger is whole-turn

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/TearAwareEvents.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/TearAwareEvents.kt
@@ -33,8 +33,10 @@ internal class TearAwareEvents(
         SseReader().sseJsonEvents(
             body,
             onBytes = { chunkBytes ->
+                // Bytes TOUCH the slot (liveness) and stamp FIRST_BYTE; they do not pick the
+                // watchdog tier. A Responses handshake (response.created) is bytes with no output,
+                // and letting it flip the tier reaped every silent compaction — see Watchdog.kt.
                 drive.slot.touch()
-                drive.watchdog.markByte()
                 drive.perf.markOnce(PerfKeys.FIRST_BYTE)
                 drive.perf.add(PerfKeys.SSE_BYTES_IN, chunkBytes.toLong())
             },

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnDriveFactory.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnDriveFactory.kt
@@ -37,7 +37,10 @@ internal class TurnDriveFactory(
         // so a request that stamped tools_deferred=0 is VISIBLE, never silently absent.
         meta.toolsEager?.let { perf.setCount(PerfKeys.TOOLS_EAGER, it.toLong()) }
         meta.toolsDeferred?.let { perf.setCount(PerfKeys.TOOLS_DEFERRED, it.toLong()) }
-        val watchdog = TurnWatchdog(provider.watchdog, deps.clock)
+        // A compact turn's silence before its first output is bounded by totalCap only — see
+        // WatchdogBudget.forCompact for the live evidence. Normal turns keep the provider budget.
+        val budget = if (meta.compact) provider.watchdog.forCompact() else provider.watchdog
+        val watchdog = TurnWatchdog(budget, deps.clock)
         val signals = driveSignals.make(watchdog, channel, perf)
         return TurnDrive(
             bodyJson = bodyJson,

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/WsRoundDrive.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/WsRoundDrive.kt
@@ -17,9 +17,11 @@ internal class WsRoundDrive(
     private val provider: Provider,
     private val classifyZeroEvent: ZeroEventClassifier,
 ) {
-    /** The per-round bookkeeping mirrors the SSE path exactly — slot touch, watchdog byte mark,
-     *  first-byte/events perf, zero-event classification — because the client must not be able to
-     *  tell which transport served its turn. */
+    /** The per-round bookkeeping mirrors the SSE path exactly — slot touch, first-byte/events
+     *  perf, zero-event classification — because the client must not be able to tell which
+     *  transport served its turn. An EVENT touches the slot (liveness) but never picks the watchdog
+     *  tier: response.created is the handshake, not output, and this is the transport on which the
+     *  2026-09-01 compaction stalls were measured — see Watchdog.kt. */
     suspend fun drive(
         inputs: WsRoundInputs,
         runner: WsRoundRunner,
@@ -33,7 +35,6 @@ internal class WsRoundDrive(
         val instrumented = events.onEach { evt ->
             if (runner.isFailureTerminal(evt) && !inputs.frameEmittedThisRound()) throw WsRoundNeedsSse()
             drive.slot.touch()
-            drive.watchdog.markByte()
             drive.perf.markOnce(PerfKeys.FIRST_BYTE)
             drive.perf.add(PerfKeys.EVENTS_IN, 1)
         }

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/WsRoundDriver.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/WsRoundDriver.kt
@@ -58,7 +58,7 @@ internal class WsRoundDriver(
             // start write throws or is cancelled, the exception unwinds through the transport flow's
             // onCompletion and poisons its busy lease instead of stranding the connection forever.
             val startingEvents = accepted.events.onEach { drive.emitter.ensureStarted() }
-            drive.watchdog.resetFirstByte()
+            drive.watchdog.resetRound()
             // DR-7 round 2: the idle watchdog reaps THIS ROUND here too, the same way
             // SseRoundConsume does. It used to cancel inputs.turnJob, so a WS stall killed the
             // translator along with the round and the salvage died with it — the SSE path earned
@@ -96,7 +96,7 @@ internal class WsRoundDriver(
             val round = Job(inputs.turnJob)
             roundJob = round
             round.invokeOnCompletion { cause -> if (cause != null) accepted.abort.abort() }
-            poller = drive.watchdog.launchIn(inputs.scope, drive.slot, round)
+            poller = drive.watchdog.launchIn(inputs.scope, drive.slot, round, inputs.frameEmittedThisRound)
             return try {
                 roundDrive.drive(inputs, runner, startingEvents).also { reported = true }
             } catch (ignored: WsRoundNeedsSse) {

--- a/gateway/gateway/src/test/kotlin/head/HeadServerCompactCapTest.kt
+++ b/gateway/gateway/src/test/kotlin/head/HeadServerCompactCapTest.kt
@@ -3,12 +3,15 @@
 // a direct test of WatchdogBudget.forCompact proves the arithmetic while nothing proves the factory
 // ever calls it (the shape of gap DR-7's acceptance wall exists to close).
 //
-// One head, one budget: 1s first-output / 20s streamIdle / 4s total. A NORMAL turn that goes silent
-// after the handshake is reaped by the 1s first-output cap and says so. A COMPACT turn on the same
-// head is not — its first-output cap IS the total cap, so the only thing that can end it is the 4s
-// whole-turn wall, which surfaces as the cancellation seal's generic watchdog wording. Live
-// provenance (2026-09-01 14:07): the first compaction on the corrected tier died at "no first output
-// within the 300s first-output cap".
+// One head PER ARM, same 1s first-output / 20s streamIdle tiers, different whole-turn wall. A NORMAL
+// turn that goes silent after the handshake is reaped by the 1s first-output cap and says so; its
+// wall is far away (30s) because the turn spans two upstream attempts (the WS round, then the SSE
+// re-serve) and sharing the compact arm's 4s wall let a slow CI runner reach the wall first (coverage
+// run 33549293551 failed this arm at the first-output assertion; locally it took 3.7s). A COMPACT
+// turn's first-output cap IS the total cap, so the only thing that can end it is its 4s whole-turn
+// wall — which surfaces as the cancellation seal's generic watchdog wording. Live provenance
+// (2026-09-01 14:07): the first compaction on the corrected tier died at "no first output within
+// the 300s first-output cap".
 package head
 
 import io.ktor.client.HttpClient
@@ -26,7 +29,6 @@ import mock.freshPort
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import splice.core.auth.AuthDescription
@@ -62,13 +64,16 @@ class HeadServerCompactCapTest {
     private val client = HttpClient(CIO) {
         defaultRequest { bearerAuth("test-inference-token") }
     }
-    private val port = freshPort()
-    private lateinit var head: HeadServer
 
-    @BeforeAll
-    fun setUp() = runTest {
+    @AfterAll
+    fun tearDown() {
+        client.close()
+        mock.stop()
+    }
+
+    private fun head(port: Int, watchdog: WatchdogBudget): HeadServer {
         val tmp = Files.createTempDirectory("head-compact-cap")
-        head = HeadServer(
+        return HeadServer(
             provider = CodexProvider(
                 tuning = ProviderTuning(
                     key = "codex",
@@ -81,9 +86,7 @@ class HeadServerCompactCapTest {
                     pinnedModel = "gpt-5.6-sol",
                     auth = CapFakeAuth(),
                     baseUrl = mock.baseUrl,
-                    // first-output 1s, streamIdle 20s, total 4s: the two arms below can only be
-                    // told apart by WHICH cap ends them, and the mock stalls for 6s — past both.
-                    watchdog = WatchdogBudget(1.seconds, 20.seconds, 4.seconds),
+                    watchdog = watchdog,
                     loginCommand = "claudex login",
                 ),
                 showReasoning = ReasoningDisplay.TEXT,
@@ -103,18 +106,22 @@ class HeadServerCompactCapTest {
                 log = {},
             ),
         )
-        head.start()
+    }
+
+    // Drives one turn through a head built for this arm's budget; the mock stalls 6s per attempt.
+    private suspend fun turnOn(watchdog: WatchdogBudget, system: String): String {
+        val port = freshPort()
+        val server = head(port, watchdog)
+        server.start()
         awaitListening(port)
+        try {
+            return turn(port, system)
+        } finally {
+            server.stop()
+        }
     }
 
-    @AfterAll
-    fun tearDown() = runTest {
-        head.stop()
-        client.close()
-        mock.stop()
-    }
-
-    private suspend fun turn(system: String): String =
+    private suspend fun turn(port: Int, system: String): String =
         client.post("http://127.0.0.1:$port/v1/messages") {
             header("Content-Type", "application/json")
             setBody(
@@ -126,10 +133,10 @@ class HeadServerCompactCapTest {
 
     @Test
     fun `a normal turn silent after the handshake is reaped by the first-output cap`() = runTest {
-        val sse = turn("You are a test. SCENARIO:idlepre")
+        val sse = turnOn(WatchdogBudget(1.seconds, 20.seconds, 30.seconds), "You are a test. SCENARIO:idlepre")
         assertTrue(sse.contains("overloaded_error"), "a stall is an honest, retryable failure: $sse")
         assertTrue(sse.contains("first-output cap"), "the 1s first-output tier must be the one that fired: $sse")
-        assertFalse(sse.contains("total cap"), "the 4s whole-turn wall must not have been reached: $sse")
+        assertFalse(sse.contains("stalled (watchdog)"), "the whole-turn wall must not have been reached: $sse")
     }
 
     // The system prompt carries Claude Code's verbatim summarizer marker, so the gateway classifies
@@ -137,7 +144,10 @@ class HeadServerCompactCapTest {
     @Test
     fun `a compact turn silent after the handshake survives the first-output cap and dies only on the total cap`() =
         runTest {
-            val sse = turn("SCENARIO:idlepre You are tasked with summarizing conversations for another agent.")
+            val sse = turnOn(
+                WatchdogBudget(1.seconds, 20.seconds, 4.seconds),
+                "SCENARIO:idlepre You are tasked with summarizing conversations for another agent.",
+            )
             assertTrue(sse.contains("overloaded_error"), "a stall is an honest, retryable failure: $sse")
             assertFalse(
                 sse.contains("first-output cap"),

--- a/gateway/gateway/src/test/kotlin/head/HeadServerCompactCapTest.kt
+++ b/gateway/gateway/src/test/kotlin/head/HeadServerCompactCapTest.kt
@@ -1,0 +1,151 @@
+// The compact-turn watchdog budget, driven through the REAL production path — HeadServer over HTTP,
+// TurnDriveFactory wiring the budget, the idlepre mock acknowledging and then going silent — because
+// a direct test of WatchdogBudget.forCompact proves the arithmetic while nothing proves the factory
+// ever calls it (the shape of gap DR-7's acceptance wall exists to close).
+//
+// One head, one budget: 1s first-output / 20s streamIdle / 4s total. A NORMAL turn that goes silent
+// after the handshake is reaped by the 1s first-output cap and says so. A COMPACT turn on the same
+// head is not — its first-output cap IS the total cap, so the only thing that can end it is the 4s
+// whole-turn wall, which surfaces as the cancellation seal's generic watchdog wording. Live
+// provenance (2026-09-01 14:07): the first compaction on the corrected tier died at "no first output
+// within the 300s first-output cap".
+package head
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import kotlinx.coroutines.test.runTest
+import mock.MockChatGptUpstream
+import mock.awaitListening
+import mock.freshPort
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import splice.core.auth.AuthDescription
+import splice.core.auth.Credentials
+import splice.core.auth.RefreshableAuthProvider
+import splice.core.model.ModelCatalog
+import splice.core.model.ModelEntry
+import splice.core.turn.ReasoningDisplay
+import splice.core.turn.WatchdogBudget
+import splice.gateway.compact.CompactStats
+import splice.gateway.compact.ShadowClassifier
+import splice.gateway.head.HeadDeps
+import splice.gateway.head.HeadServer
+import splice.gateway.perf.PerfStats
+import splice.gateway.usage.UsageStore
+import splice.provider.codex.CodexProvider
+import splice.spi.InflightGate
+import splice.spi.ProviderTuning
+import splice.spi.UpstreamClient
+import java.nio.file.Files
+import kotlin.time.Duration.Companion.seconds
+
+private class CapFakeAuth : RefreshableAuthProvider {
+    override suspend fun credentials(): Credentials = Credentials.Bearer("tok-cap", "acct-cap")
+    override suspend fun refresh(): Credentials = credentials()
+    override suspend fun describe(): AuthDescription = AuthDescription(true, "fake")
+}
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class HeadServerCompactCapTest {
+
+    private val mock = MockChatGptUpstream()
+    private val client = HttpClient(CIO) {
+        defaultRequest { bearerAuth("test-inference-token") }
+    }
+    private val port = freshPort()
+    private lateinit var head: HeadServer
+
+    @BeforeAll
+    fun setUp() = runTest {
+        val tmp = Files.createTempDirectory("head-compact-cap")
+        head = HeadServer(
+            provider = CodexProvider(
+                tuning = ProviderTuning(
+                    key = "codex",
+                    label = "claudex",
+                    catalog = ModelCatalog(
+                        discoveryPrefix = "claude-codex--",
+                        models = listOf(ModelEntry("gpt-5.6-sol", "Sol", contextWindow = 272_000)),
+                        defaultContextWindow = 272_000,
+                    ),
+                    pinnedModel = "gpt-5.6-sol",
+                    auth = CapFakeAuth(),
+                    baseUrl = mock.baseUrl,
+                    // first-output 1s, streamIdle 20s, total 4s: the two arms below can only be
+                    // told apart by WHICH cap ends them, and the mock stalls for 6s — past both.
+                    watchdog = WatchdogBudget(1.seconds, 20.seconds, 4.seconds),
+                    loginCommand = "claudex login",
+                ),
+                showReasoning = ReasoningDisplay.TEXT,
+                replayReasoning = false,
+                configEffort = "high",
+                configSummary = "detailed",
+            ),
+            listenPort = port,
+            deps = HeadDeps(
+                upstream = UpstreamClient(firstByteTimeoutMs = 20_000, totalTimeoutMs = 30_000, maxRetries = 1),
+                inferenceToken = "test-inference-token",
+                gate = InflightGate({ 0 }),
+                shadow = ShadowClassifier(log = {}),
+                compactStats = CompactStats(tmp.resolve("compact.jsonl")),
+                usageStore = UsageStore(tmp.resolve("usage.json"), tmp.resolve("ratelimit.json")),
+                perfStats = PerfStats(tmp.resolve("perf.jsonl")),
+                log = {},
+            ),
+        )
+        head.start()
+        awaitListening(port)
+    }
+
+    @AfterAll
+    fun tearDown() = runTest {
+        head.stop()
+        client.close()
+        mock.stop()
+    }
+
+    private suspend fun turn(system: String): String =
+        client.post("http://127.0.0.1:$port/v1/messages") {
+            header("Content-Type", "application/json")
+            setBody(
+                """{"model":"claude-codex--gpt-5.6-sol","stream":true,"max_tokens":8000,
+                    "system":"$system",
+                    "messages":[{"role":"user","content":"go"}]}""",
+            )
+        }.bodyAsText()
+
+    @Test
+    fun `a normal turn silent after the handshake is reaped by the first-output cap`() = runTest {
+        val sse = turn("You are a test. SCENARIO:idlepre")
+        assertTrue(sse.contains("overloaded_error"), "a stall is an honest, retryable failure: $sse")
+        assertTrue(sse.contains("first-output cap"), "the 1s first-output tier must be the one that fired: $sse")
+        assertFalse(sse.contains("total cap"), "the 4s whole-turn wall must not have been reached: $sse")
+    }
+
+    // The system prompt carries Claude Code's verbatim summarizer marker, so the gateway classifies
+    // the turn as a compaction (Compact.kt) and TurnDriveFactory hands it forCompact().
+    @Test
+    fun `a compact turn silent after the handshake survives the first-output cap and dies only on the total cap`() =
+        runTest {
+            val sse = turn("SCENARIO:idlepre You are tasked with summarizing conversations for another agent.")
+            assertTrue(sse.contains("overloaded_error"), "a stall is an honest, retryable failure: $sse")
+            assertFalse(
+                sse.contains("first-output cap"),
+                "a compaction's pre-output silence must not be judged on the 1s first-output tier: $sse",
+            )
+            // The whole-turn cap cancels the TURN, so it surfaces through the cancellation seal's
+            // generic watchdog wording (as HeadServerFoldTest's NF-03 arm pins), not a tier-named
+            // message — which is exactly the discriminator: the 1s tier would have said its name.
+            assertTrue(sse.contains("stalled (watchdog)"), "only the whole-turn wall may end it: $sse")
+        }
+}

--- a/gateway/gateway/src/test/kotlin/head/HeadServerIntegrationTest.kt
+++ b/gateway/gateway/src/test/kotlin/head/HeadServerIntegrationTest.kt
@@ -101,11 +101,11 @@ class HeadServerIntegrationTest {
                 upstream = UpstreamClient(firstByteTimeoutMs = 5_000, totalTimeoutMs = 30_000, maxRetries = 2),
                 inferenceToken = "test-inference-token",
                 gate = InflightGate({ 0 }),
-                shadow = ShadowClassifier(log = { logs.add(it) }),
+                shadow = ShadowClassifier(log = { synchronized(logs) { logs.add(it) } }),
                 compactStats = CompactStats(tmp.resolve("compact.jsonl")),
                 usageStore = UsageStore(tmp.resolve("usage.json"), tmp.resolve("ratelimit.json")),
                 perfStats = PerfStats(tmp.resolve("perf.jsonl")),
-                log = { logs.add(it) },
+                log = { synchronized(logs) { logs.add(it) } },
                 maxRequestBytes = 1_024,
             ),
         )
@@ -129,6 +129,19 @@ class HeadServerIntegrationTest {
                     "messages":[{"role":"user","content":"go"}]}""",
             )
         }.bodyAsText()
+
+    // TurnFinish sends the terminal frames FIRST (DR-129) and records perf LAST, so the client's
+    // body completes before this turn's perf line lands in `logs`. Waiting for a line past `from`
+    // reads THIS turn's telemetry instead of whichever earlier turn's line happened to be last —
+    // the read that failed under kover on a slow runner (coverage run 33551147526, 2026-09-01).
+    private fun awaitLog(from: Int, timeoutMs: Long = 5_000, match: (String) -> Boolean): String? {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (true) {
+            synchronized(logs) { logs.drop(from).lastOrNull(match) }?.let { return it }
+            if (System.currentTimeMillis() >= deadline) return null
+            Thread.sleep(20)
+        }
+    }
 
     @Test
     fun `health carries version and port`() = runTest {
@@ -200,18 +213,19 @@ class HeadServerIntegrationTest {
         val before = logs.size
         val sse = messages("malformed_sse")
         assertTrue(sse.contains("\"stop_reason\":\"end_turn\""))
-        val scoped = logs.drop(before)
+        val perfLine = awaitLog(before) { it.contains("] perf outcome=ok") }
+        val scoped = synchronized(logs) { logs.drop(before) }
         val malformedLines = scoped.filter { it.contains("malformed SSE frame skipped: {not-json}") }
         assertEquals(1, malformedLines.size, "expected exactly one malformed-frame log line, got: $scoped")
-        val perfLine = scoped.lastOrNull { it.contains("] perf outcome=ok") }
         assertTrue(perfLine != null, "expected a perf line in the log, got: $scoped")
         assertTrue(perfLine!!.contains("frames_skipped=1"), "expected frames_skipped=1 in: $perfLine")
     }
 
     @Test
     fun `turn records perf telemetry - log line and JSONL row with pipeline marks`() = runTest {
+        val before = logs.size
         messages("basic")
-        val perfLine = logs.lastOrNull { it.contains("] perf outcome=ok") }
+        val perfLine = awaitLog(before) { it.contains("] perf outcome=ok") }
         assertTrue(perfLine != null, "expected a perf line in the log, got: $logs")
         val expectedFields = listOf(
             "recv=", "parse=", "build=", "gate=", "headers=", "first_byte=",

--- a/gateway/gateway/src/test/kotlin/head/SseRoundConsumeTest.kt
+++ b/gateway/gateway/src/test/kotlin/head/SseRoundConsumeTest.kt
@@ -229,15 +229,16 @@ class SseRoundConsumeTest {
             TurnTelemetry("codex", PerfStats(tmp.resolve("perf-dr7.jsonl")), log = {}, clock = ElapsedClock { 0L }),
             TearAwareEvents(provider, log = {}),
         )
-        // STREAM-IDLE is the tier that reaps this, not firstByteTimeout — the opposite of what this
-        // comment used to claim. The scenario's response.created is bytes on the wire, and
-        // TearAwareEvents.onBytes marks them on the RAW read, so the watchdog has already flipped
-        // tiers before the stall begins. "Pre-content" is about CLIENT FRAMES, not bytes.
-        //
-        // The budgets are now far apart so the arm can actually tell the tiers apart: with both at
-        // 1s (as they were) either tier produced the same pass, which is how the false claim went
-        // unnoticed. A generous 20s first-byte tier blows REAP_DEADLINE_MS if markByte never ran.
-        val drive = drive(WatchdogBudget(20.seconds, 1.seconds, 30.seconds))
+        // FIRST-OUTPUT is the tier that judges this, not streamIdle — the reverse of what this arm
+        // asserted until 2026-09-01. The scenario's response.created is bytes on the wire, but it
+        // is a HANDSHAKE, not model output: no client frame exists yet, and the watchdog's short
+        // tier applies only once the client has been handed content. Live evidence: 109 codex
+        // compactions in one day died at "180s idle cap" with first_byte at 1-5s and NO first
+        // delta — the model was reasoning silently over a 1.2MB transcript and the handshake had
+        // already flipped the tier. The budgets are far apart so the arm names the tier: a 1s
+        // first-output cap must reap this well inside the 6s mock stall, and a 20s streamIdle would
+        // let the mock hang up first (no Idle sentinel at all).
+        val drive = drive(WatchdogBudget(1.seconds, 20.seconds, 30.seconds))
         val inputs = WsRoundInputs(
             drive = drive,
             bodyJson = "{}",
@@ -270,17 +271,16 @@ class SseRoundConsumeTest {
                 assertTrue(outcome is TurnOutcome.Failure, "a reaped round must report an outcome: $outcome")
                 val fired = drive.watchdog.fired
                 assertTrue(fired is WatchdogFired.Idle, "expected an Idle reap: $fired")
-                // Names the TIER directly instead of inferring it from a pass. The ack is a byte,
-                // so a correct watchdog reports sawFirstByte=true and judged this against
-                // streamIdle; the arm previously asserted nothing about it and could not have
-                // noticed if the first-byte tier had been the one that fired.
+                // Names the TIER directly instead of inferring it from a pass: the ack is not a
+                // client frame, so a correct watchdog reports sawClientFrame=false and judged this
+                // against firstByteTimeout (the first-output cap), not streamIdle.
                 assertTrue(
-                    (fired as? WatchdogFired.Idle)?.sawFirstByte == true,
-                    "the ack is a byte, so the stall is judged on streamIdle, not firstByteTimeout: $fired",
+                    (fired as? WatchdogFired.Idle)?.sawClientFrame == false,
+                    "a handshake is not output — the stall is judged on the first-output cap, not streamIdle: $fired",
                 )
                 assertTrue(
                     tookMs < REAP_DEADLINE_MS,
-                    "reaped by the 1s streamIdle cap, not by the 20s first-byte tier or the mock hanging up " +
+                    "reaped by the 1s first-output cap, not by the 20s streamIdle tier or the mock hanging up " +
                         "($tookMs ms)",
                 )
             }
@@ -291,7 +291,7 @@ class SseRoundConsumeTest {
     }
 }
 
-// The mock stalls for 6s, and the arm's first-byte tier is 20s. A reap driven by the 1s STREAM-IDLE
+// The mock stalls for 6s, and the arm's streamIdle tier is 20s. A reap driven by the 1s FIRST-OUTPUT
 // cap must land far inside both — which is what makes this deadline name the tier rather than just
 // asserting that something eventually happened.
 private const val REAP_DEADLINE_MS = 4_000L

--- a/gateway/gateway/src/testFixtures/kotlin/mock/MockChatGptUpstream.kt
+++ b/gateway/gateway/src/testFixtures/kotlin/mock/MockChatGptUpstream.kt
@@ -343,9 +343,10 @@ class MockChatGptUpstream {
             // DR-7: an acknowledgement, then silence — the PRE-CONTENT stall. "Pre-content" means
             // no CLIENT FRAME has been emitted (the state G5's reissue path claims); it does NOT
             // mean no event and not no byte, and an earlier version of this comment said both.
-            // The distinction matters because response.created IS bytes on the wire, so the
-            // watchdog has already flipped from its first-byte tier to streamIdle by the time this
-            // stalls. See the arm in SseRoundConsumeTest, whose budgets are split to prove it.
+            // The distinction matters because response.created IS bytes on the wire but NOT a
+            // client frame, so the watchdog keeps its first-output tier (firstByteTimeout) through
+            // the stall — bytes touch the slot, frames pick the tier (Watchdog.kt, 2026-09-01). See
+            // the arm in SseRoundConsumeTest, whose budgets are split to prove which tier fires.
             "idlepre" -> {
                 // The backend ACKNOWLEDGES and then goes quiet: response.created carries no
                 // content, so the round reaches its stall having emitted nothing to the client —

--- a/gateway/provider-spi/src/main/kotlin/splice/spi/UpstreamFailureClassifier.kt
+++ b/gateway/provider-spi/src/main/kotlin/splice/spi/UpstreamFailureClassifier.kt
@@ -135,6 +135,15 @@ public object UpstreamFailureClassifier {
         val blob = "${fields.code} ${fields.message}"
         return when {
             overflowRe.containsMatchIn(blob) -> overflowFailure(msg)
+            // Provenance beats status: a content-policy refusal is a fact about the REQUEST, and the
+            // vendor itself returns it as HTTP 400 when it arrives pre-stream. Mid-stream it comes
+            // status-less, and DR-72's api_error verdict was still RETRYABLE on the client side —
+            // Claude Code re-sends an api_error with backoff, so every refusal became a ~30s x N
+            // storm of the same 1.3MB transcript (242 turns on 2026-09-01, 42 of them compactions
+            // that could never complete). invalid_request_error is terminal to the client, and the
+            // vendor's own remedy text ("try rephrasing") rides along untouched.
+            fields.code.lowercase() in POLICY_REFUSAL_CODES ->
+                ClassifiedFailure(ErrorType.INVALID_REQUEST, msg.take(MAX_MESSAGE))
             status == RATE_LIMIT_STATUS || rateRe.containsMatchIn(blob) ->
                 ClassifiedFailure(ErrorType.RATE_LIMIT, msg.take(MAX_MESSAGE))
             status == AUTH_STATUS || authRe.containsMatchIn(blob) ->
@@ -221,6 +230,17 @@ public object UpstreamFailureClassifier {
     private const val SECONDS_PER_MINUTE = 60L
     private const val SECONDS_PER_HOUR = 3600L
     private const val SECONDS_PER_DAY = 86_400L
+
+    // The deterministic prompt-level refusals: the Responses API's own error enum
+    // (openai-python ResponseError.code: invalid_prompt, bio_policy, image_content_policy_violation)
+    // plus the ChatGPT backend's Trusted-Access gate (cyber_policy, live on claudex 2026-08-31/09-01).
+    // Exact codes, never wording — the same rule as RETRYABLE_CODES below.
+    private val POLICY_REFUSAL_CODES = setOf(
+        "cyber_policy",
+        "bio_policy",
+        "invalid_prompt",
+        "image_content_policy_violation",
+    )
 
     // The exact codes a status-less failure may be re-POSTed on: named transient server
     // conditions only. Anything else — known-deterministic or unknown — does not earn a

--- a/gateway/provider-spi/src/main/kotlin/splice/spi/Watchdog.kt
+++ b/gateway/provider-spi/src/main/kotlin/splice/spi/Watchdog.kt
@@ -1,12 +1,28 @@
 // PORT-OF: server/src/codex/stream.mjs idle-watchdog block @ pre-public-port-baseline — invariants (the v35
-// headline fix IS the spec): BEFORE the first byte the idle limit is firstByteTimeout — a
-// big-context prefill (compaction re-reading ~160k tokens) is legitimately silent for
-// minutes; reaping prefill on streamIdle caused the abort->retry->cold-re-read loop
-// ("compaction ate my quota"). AFTER first byte the limit is streamIdle. totalCap bounds the
-// whole turn (an overloaded backend can trickle keepalives forever and leak the slot — the
-// "55 inflight, 2 agents" class). Poll interval = min(15s, max(250ms, streamIdle/3)).
+// headline fix IS the spec): BEFORE the client has been handed any output the idle limit is
+// firstByteTimeout — a big-context prefill (compaction re-reading ~160k tokens) is legitimately
+// silent for minutes; reaping prefill on streamIdle caused the abort->retry->cold-re-read loop
+// ("compaction ate my quota"). AFTER the first client content frame the limit is streamIdle.
+// totalCap bounds the whole turn (an overloaded backend can trickle keepalives forever and leak
+// the slot — the "55 inflight, 2 agents" class). Poll interval = min(15s, max(250ms, tier/3)) for
+// the tighter of the two idle tiers.
 // The fired reason is a TYPED SENTINEL set BEFORE cancelling, so catch sites can tell
 // watchdog-fired from client-gone from shutdown.
+//
+// 2026-09-01 — THE TIER IS THE CLIENT FRAME, NOT THE BYTE. The port flipped tiers on the first
+// upstream BYTE (markByte on the raw SSE read / the first WS event). That is the wrong signal for a
+// handshake-first protocol: the Responses API answers within 1-5s with response.created /
+// response.in_progress — bytes, but no output — and the model then reasons silently over the whole
+// prefill. So the v35 spec was defeated by the very stream it protected: the handshake pinned every
+// compaction to the short streamIdle tier before a single token existed. Live: 109 codex
+// compactions in one day (gpt-5.6-sol, 1.0-1.2MB upstream bodies) died at "no completion within
+// the 180s idle cap" with first_byte=1-5s and NO first delta, each failure re-sent cold by the
+// client, three sessions looping in parallel. The successful ones that day had first deltas at
+// 17s..111s — the same silence, one tier apart. The tier now reads the round's own
+// [ClientFrameEmitted] probe (CONTENT_FRAMES_OUT above the round's baseline — the same fact G5
+// keys reissue on): until the client has seen content, the silence is prefill/reasoning and the
+// first-output cap applies; after it, the stream is mid-output and streamIdle applies. Bytes still
+// TOUCH the slot (liveness: a keepalive resets idleness); they no longer choose the limit.
 package splice.spi
 
 import kotlinx.coroutines.CoroutineScope
@@ -16,13 +32,15 @@ import kotlinx.coroutines.launch
 import splice.core.turn.WatchdogBudget
 import splice.core.util.ElapsedClock
 import splice.core.util.MonoClock
-import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
 public sealed class WatchdogFired {
-    public data class Idle(val idleMs: Long, val sawFirstByte: Boolean) : WatchdogFired()
+    /** [sawClientFrame] names the tier that judged the silence — false: the first-output tier
+     *  ([WatchdogBudget.firstByteTimeout]), true: the mid-output tier ([WatchdogBudget.streamIdle]) —
+     *  and [limitMs] is that tier's cap, so a terminal message can name the number that fired. */
+    public data class Idle(val idleMs: Long, val sawClientFrame: Boolean, val limitMs: Long) : WatchdogFired()
 
     public data class TotalCap(val elapsedMs: Long) : WatchdogFired()
 }
@@ -36,56 +54,63 @@ public class TurnWatchdog(
     // the loop after N samples instead of racing a cancellation against a real 250ms..15s sleep.
     private val ticker: Ticker = ProcessTicker(),
 ) {
-    private val sawFirstByte = AtomicBoolean(false)
     private val firedRef = AtomicReference<WatchdogFired?>(null)
     private val startedAt = clock()
 
     public val fired: WatchdogFired? get() = firedRef.get()
 
-    /** Reader-side touch: the first byte flips the idle tier from firstByteTimeout to streamIdle. */
-    public fun markByte() {
-        sawFirstByte.set(true)
-    }
-
-    /** Reasoning-continuation fold: each round is a fresh upstream POST whose prefill can be silent
-     *  for minutes. The watchdog is shared across rounds (totalCap must span the whole turn), but the
-     *  idle TIER must reset per round — otherwise round 1's first byte pins every later round to the
-     *  short streamIdle cap instead of firstByteTimeout, wrongly aborting a slow continuation prefill.
-     *  startedAt/totalCap are untouched, and since DR-7 a stale IDLE sentinel is cleared too (see
-     *  below); a TotalCap verdict survives, because it belongs to the turn and not to a round. */
-    public fun resetFirstByte() {
-        sawFirstByte.set(false)
-        // DR-7: also clear a STALE IDLE fire. The sentinel is sticky by design so the terminal
-        // decision can name why a round died, but a salvaged round is followed by another round —
-        // and a sentinel left set makes every later round terminate as "stalled" no matter how
-        // healthy it is, and re-vetoes the continuation gates. Only Idle is cleared, and only by
-        // CAS: TotalCap is a WHOLE-TURN verdict that no new round may erase, and a compareAndSet
-        // against the exact observed value cannot race away a fire landing at this instant.
+    /** Round boundary. The idle TIER needs no reset any more — [launchIn] reads the round's own
+     *  client-frame probe on every poll, and a fresh round starts from a fresh baseline — but the
+     *  DR-7 half stays: a stale IDLE sentinel is cleared. The sentinel is sticky by design so the
+     *  terminal decision can name why a round died, but a salvaged round is followed by another
+     *  round — and a sentinel left set makes every later round terminate as "stalled" no matter how
+     *  healthy it is, and re-vetoes the continuation gates. Only Idle is cleared, and only by CAS:
+     *  TotalCap is a WHOLE-TURN verdict that no new round may erase, and a compareAndSet against
+     *  the exact observed value cannot race away a fire landing at this instant. */
+    public fun resetRound() {
         firedRef.get()?.let { if (it is WatchdogFired.Idle) firedRef.compareAndSet(it, null) }
     }
 
+    /** Paced to the TIGHTER idle tier. Both caps are sampled by the same poller, and a first-output
+     *  cap shorter than streamIdle/3 (a test rig, or an operator wanting a fast pre-output verdict)
+     *  would otherwise be sampled too late to matter — the rule [launchTotalCap] already applies
+     *  against totalCap. Production (180s/300s) still lands on the 15s ceiling. */
     public fun pollInterval(): Duration {
-        val third = budget.streamIdle.inWholeMilliseconds / IDLE_DIVISOR
-        return third.coerceIn(MIN_POLL_MS, MAX_POLL_MS).milliseconds
+        val tighter = minOf(budget.streamIdle, budget.firstByteTimeout).inWholeMilliseconds / IDLE_DIVISOR
+        return tighter.coerceIn(MIN_POLL_MS, MAX_POLL_MS).milliseconds
     }
 
     /**
-     * Launch the sibling poller: watches [slot] IDLENESS, and on breach sets the typed sentinel
-     * FIRST, then cancels [target]. Cancel the returned job on clean exit.
+     * Launch the sibling poller: watches [slot] IDLENESS against the tier [clientFrame] selects, and
+     * on breach sets the typed sentinel FIRST, then cancels [target]. Cancel the returned job on
+     * clean exit.
+     *
+     * [clientFrame] is the ROUND's probe (SseRoundDriver baselines CONTENT_FRAMES_OUT per round):
+     * false = the client has seen no content this round, so the silence is prefill/reasoning and
+     * the first-output cap applies; true = mid-output, streamIdle applies. See the file header for
+     * why this is a frame and not a byte. A fold round's BUFFERED final output (held back until the
+     * terminal proves the round) and a non-stream turn (no client frames are ever written) read as
+     * "no client frame" and so sit on the first-output cap — the lenient side, and literally true:
+     * nothing has reached the client yet.
      *
      * DR-7: [target] is a ROUND, not the turn — the SSE path parents a job to the turn job and
      * aborts that round's body channel, so the translator survives to report the stall WITH its
      * salvage. Total elapsed is NOT sampled here any more; see [launchTotalCap].
      */
-    public fun launchIn(scope: CoroutineScope, slot: InflightGate.Slot, target: Job): Job =
+    public fun launchIn(
+        scope: CoroutineScope,
+        slot: InflightGate.Slot,
+        target: Job,
+        clientFrame: ClientFrameEmitted,
+    ): Job =
         scope.launch {
             while (isActive) {
                 // pollInterval() is coerced to 250ms..15s, so inWholeMilliseconds is the exact value
                 // delay(Duration) would have used (its <1ms coerceAtLeast(1) rounding is unreachable here).
                 if (!ticker.awaitTick(pollInterval().inWholeMilliseconds)) return@launch
                 val idle = slot.idleForMs()
-                val first = sawFirstByte.get()
-                val idleLimit = if (first) {
+                val seen = clientFrame()
+                val idleLimit = if (seen) {
                     budget.streamIdle.inWholeMilliseconds
                 } else {
                     budget.firstByteTimeout.inWholeMilliseconds
@@ -96,7 +121,7 @@ public class TurnWatchdog(
                 // fold loop open the next — spending past the cap under a name that means "stop".
                 // One breach kind per poller, each cancelling the scope it actually owns.
                 if (idle >= idleLimit) {
-                    firedRef.compareAndSet(null, WatchdogFired.Idle(idle, first))
+                    firedRef.compareAndSet(null, WatchdogFired.Idle(idle, seen, idleLimit))
                     target.cancel()
                     return@launch
                 }

--- a/gateway/provider-spi/src/main/kotlin/splice/spi/Watchdog.kt
+++ b/gateway/provider-spi/src/main/kotlin/splice/spi/Watchdog.kt
@@ -22,7 +22,9 @@
 // [ClientFrameEmitted] probe (CONTENT_FRAMES_OUT above the round's baseline — the same fact G5
 // keys reissue on): until the client has seen content, the silence is prefill/reasoning and the
 // first-output cap applies; after it, the stream is mid-output and streamIdle applies. Bytes still
-// TOUCH the slot (liveness: a keepalive resets idleness); they no longer choose the limit.
+// TOUCH the slot (liveness: a keepalive resets idleness); they no longer choose the limit. A COMPACT
+// turn's first-output cap is totalCap itself (WatchdogBudget.forCompact, wired at TurnDriveFactory):
+// the first compaction on the corrected tier still died silent at 300s.
 package splice.spi
 
 import kotlinx.coroutines.CoroutineScope

--- a/gateway/provider-spi/src/test/kotlin/UpstreamFailurePolicyRefusalTest.kt
+++ b/gateway/provider-spi/src/test/kotlin/UpstreamFailurePolicyRefusalTest.kt
@@ -1,8 +1,15 @@
 // DR-72 (soak-caught, twice live on claudex 2026-08-31): ChatGPT's cyber_policy content-flag
 // refusal says "To get authorized for security work, join the Trusted Access..." — and the old
 // auth regex's bare \bauth\w*\b matched "authorized", so a deterministic policy refusal reached
-// Claude Code as authentication_error (re-login UX) while the credential was fine. Policy
-// refusals must fall through to a non-transient api_error carrying the vendor's own text.
+// Claude Code as authentication_error (re-login UX) while the credential was fine.
+//
+// 2026-09-01 (live, 242 turns in one day — 42 of them compactions): DR-72's api_error verdict was
+// still RETRYABLE on the client side. Claude Code re-sends an api_error with backoff, so every
+// policy refusal became a ~30s x N storm of the same 1.3MB transcript, and a compaction that
+// tripped the flag could never complete. A content-policy refusal is a fact about the REQUEST —
+// the vendor itself returns it as HTTP 400 / `invalid_request` when it arrives pre-stream — so a
+// status-less (mid-stream) one must reach the client as invalid_request_error too: terminal, the
+// vendor's own remedy text intact, no retry.
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -19,11 +26,42 @@ private const val CYBER_POLICY_MSG =
 class UpstreamFailurePolicyRefusalTest {
 
     @Test
-    fun `a cyber_policy refusal is not an authentication failure - DR-72`() {
+    fun `a cyber_policy refusal is a terminal invalid_request, never auth and never retried`() {
         val r = UpstreamFailureClassifier.classify(FailureSource.SSE, CYBER_POLICY_MSG, code = "cyber_policy")
-        assertEquals(ErrorType.API_ERROR, r.type, "a content flag is not an auth failure: $r")
+        assertEquals(ErrorType.INVALID_REQUEST, r.type, "a content flag is about the request, not the server: $r")
         assertFalse(r.transient, "a deterministic policy refusal is never re-POSTed: $r")
         assertTrue(r.message.contains("rephrasing"), "the vendor's remedy text must survive: $r")
+    }
+
+    // The Responses API's own error enum (openai-python ResponseError.code) names the other
+    // prompt-level refusals; they are the same deterministic class and must land the same way.
+    @Test
+    fun `every documented prompt-refusal code is a terminal invalid_request`() {
+        listOf("invalid_prompt", "bio_policy", "image_content_policy_violation", "CYBER_POLICY").forEach { code ->
+            val r = UpstreamFailureClassifier.classify(FailureSource.SSE, "The prompt was rejected.", code = code)
+            assertEquals(ErrorType.INVALID_REQUEST, r.type, code)
+            assertFalse(r.transient, code)
+        }
+    }
+
+    // Control: an UNKNOWN status-less code keeps DR-10's verdict (api_error, non-transient) — the
+    // refusal allowlist is exact, not a heuristic on wording.
+    @Test
+    fun `an unknown status-less code is still a non-transient api_error - DR-10 control`() {
+        val r = UpstreamFailureClassifier.classify(FailureSource.SSE, "The prompt was rejected.", code = "quantum_flux")
+        assertEquals(ErrorType.API_ERROR, r.type, "$r")
+        assertFalse(r.transient, "$r")
+    }
+
+    // Control: the pre-stream shape (Azure/OpenAI HTTP 400 carrying the same code) already lands
+    // as invalid_request by status; the mid-stream fix must agree with it, not diverge from it.
+    @Test
+    fun `the HTTP 400 shape of the same refusal agrees with the mid-stream verdict`() {
+        val body = """{"error":{"message":"$CYBER_POLICY_MSG","type":"invalid_request",""" +
+            """"param":null,"code":"cyber_policy"}}"""
+        val r = UpstreamFailureClassifier.classify(FailureSource.HTTP, body, status = 400)
+        assertEquals(ErrorType.INVALID_REQUEST, r.type, "$r")
+        assertTrue(r.message.contains("rephrasing"), "$r")
     }
 
     @Test

--- a/gateway/provider-spi/src/test/kotlin/WatchdogTest.kt
+++ b/gateway/provider-spi/src/test/kotlin/WatchdogTest.kt
@@ -1,11 +1,16 @@
 // PORT-OF: the v35 watchdog pins from server/test/codex-proxy.test.mjs @ pre-public-port-baseline — the
 // slow-prefill regression (silent LONGER than streamIdle but shorter than firstByteTimeout
-// must NOT be reaped before the first byte), idle-after-first-byte reaped, total cap reaped,
-// typed sentinel set before cancel.
+// must NOT be reaped before the client has seen output), idle-after-first-frame reaped, total cap
+// reaped, typed sentinel set before cancel.
+//
+// 2026-09-01: the tier is chosen by the round's CLIENT-FRAME probe, not by the first upstream byte.
+// A Responses handshake (response.created) is bytes with no output, and flipping on it pinned every
+// silent compaction to the short streamIdle tier — 109 live stalls in one day. The handshake arm
+// below is that case; the v35 arm keeps its name and now passes the probe the driver would.
 //
 // DR-7 moved the cap OUT of launchIn: that poller now reaps a single round so the turn can salvage
 // and continue, and launchTotalCap owns the only whole-turn cancel. The sentinel is per-turn and
-// sticky, so resetFirstByte clears a stale Idle between rounds while leaving TotalCap standing.
+// sticky, so resetRound clears a stale Idle between rounds while leaving TotalCap standing.
 //
 // CLOCK POLICY (HD-19): the two IDLE cases still ride a real clock with generous margins, because
 // what they prove is idleness measured by InflightGate.Slot, whose clock is its own and outside this
@@ -22,6 +27,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import splice.core.turn.WatchdogBudget
+import splice.spi.ClientFrameEmitted
 import splice.spi.InflightGate
 import splice.spi.Ticker
 import splice.spi.TurnWatchdog
@@ -80,7 +86,7 @@ class WatchdogTest {
     )
 
     @Test
-    fun `prefill silence beyond streamIdle is NOT reaped before first byte - the v35 case`() {
+    fun `prefill silence beyond streamIdle is NOT reaped before the first client frame - the v35 case`() {
         runBlocking {
             val gate = InflightGate({ 0 })
             val slot = gate.acquire()
@@ -93,7 +99,7 @@ class WatchdogTest {
                     cancelled.set(true)
                 }
             }
-            val poller = dog.launchIn(this, slot, target)
+            val poller = dog.launchIn(this, slot, target, ClientFrameEmitted { false })
             delay(900) // silent 3x streamIdle, still under firstByteTimeout
             assertNull(dog.fired, "prefill was reaped — the compaction-ate-my-quota regression")
             target.cancel()
@@ -102,40 +108,69 @@ class WatchdogTest {
         }
     }
 
+    // THE 2026-09-01 CASE. The backend acknowledges at once (bytes touch the slot), then reasons in
+    // silence with nothing yet shown to the client. Under the byte rule that ack flipped the tier and
+    // the 300ms streamIdle reaped the round; under the frame rule the silence is judged on the 5s
+    // first-output cap and survives. Then the first client frame lands, and the SAME silence is
+    // reaped on streamIdle — the tier moved with the frame, exactly once, in the right direction.
     @Test
-    fun `idle after first byte is reaped with a typed sentinel`() {
+    fun `a handshake byte before any client frame keeps the first-output tier - the compaction stall case`() {
+        runBlocking {
+            val gate = InflightGate({ 0 })
+            val slot = gate.acquire()
+            val dog = TurnWatchdog(budget(firstByteMs = 5_000, idleMs = 300, capMs = 30_000))
+            val frameSeen = AtomicBoolean(false)
+            val target = launch { delay(10.seconds) }
+            val poller = dog.launchIn(this, slot, target, ClientFrameEmitted { frameSeen.get() })
+            slot.touch() // response.created: bytes on the wire, no output
+            delay(900) // silent 3x streamIdle after the ack, still under firstByteTimeout
+            assertNull(dog.fired, "a handshake is not output — the ack must not flip the tier")
+            assertTrue(target.isActive)
+            frameSeen.set(true) // the first content frame reaches the client
+            delay(900) // and the same silence is now a mid-output stall
+            target.join()
+            val fired = dog.fired
+            assertTrue(fired is WatchdogFired.Idle, "expected Idle once the client has seen output, got $fired")
+            assertTrue((fired as WatchdogFired.Idle).sawClientFrame)
+            assertEquals(300L, fired.limitMs, "the sentinel names the tier's cap")
+            poller.cancel()
+            slot.release()
+        }
+    }
+
+    @Test
+    fun `idle after the first client frame is reaped with a typed sentinel`() {
         runBlocking {
             val gate = InflightGate({ 0 })
             val slot = gate.acquire()
             val dog = TurnWatchdog(budget(firstByteMs = 10_000, idleMs = 300, capMs = 30_000))
             val target = launch { delay(10.seconds) }
-            val poller = dog.launchIn(this, slot, target)
+            val poller = dog.launchIn(this, slot, target, ClientFrameEmitted { true })
             slot.touch()
-            dog.markByte()
             delay(900)
             target.join()
             val fired = dog.fired
             assertTrue(fired is WatchdogFired.Idle, "expected Idle, got $fired")
-            assertTrue((fired as WatchdogFired.Idle).sawFirstByte)
+            assertTrue((fired as WatchdogFired.Idle).sawClientFrame)
+            assertEquals(300L, fired.limitMs)
             assertTrue(target.isCancelled)
             poller.cancel()
             slot.release()
         }
     }
 
-    // DR-7, from codex-splice's review: resetFirstByte's Idle-clear was comment-only. Deleting the
+    // DR-7, from codex-splice's review: resetRound's Idle-clear was comment-only. Deleting the
     // line left every Watchdog arm AND the real HeadServer acceptance green, which means the
     // behaviour was asserted nowhere at all.
     @Test
-    fun `resetFirstByte clears a stale Idle so the next round is not born stalled - DR-7`() {
+    fun `resetRound clears a stale Idle so the next round is not born stalled - DR-7`() {
         runBlocking {
             val gate = InflightGate({ 0 })
             val slot = gate.acquire()
             val dog = TurnWatchdog(budget(firstByteMs = 10_000, idleMs = 300, capMs = 30_000))
             val target = launch { delay(10.seconds) }
-            val poller = dog.launchIn(this, slot, target)
+            val poller = dog.launchIn(this, slot, target, ClientFrameEmitted { true })
             slot.touch()
-            dog.markByte()
             delay(900)
             target.join()
             assertTrue(dog.fired is WatchdogFired.Idle, "setup: the round must actually have been reaped")
@@ -143,7 +178,7 @@ class WatchdogTest {
             // The sentinel is sticky so the terminal decision can name why the round died. Left set,
             // it makes every LATER round of the same turn terminate as stalled no matter how healthy
             // it is — and a salvaged round is by definition followed by another round.
-            dog.resetFirstByte()
+            dog.resetRound()
             assertNull(dog.fired, "a salvaged round must not leave the next one born stalled")
             slot.release()
         }
@@ -152,7 +187,7 @@ class WatchdogTest {
     // The other half, and the reason it is a CAS against the observed Idle rather than a set(null):
     // totalCap is a WHOLE-TURN verdict, and no new round may erase it.
     @Test
-    fun `resetFirstByte preserves a TotalCap verdict - DR-7`() {
+    fun `resetRound preserves a TotalCap verdict - DR-7`() {
         runBlocking {
             val ticks = VirtualTicks()
             val dog = TurnWatchdog(
@@ -164,7 +199,7 @@ class WatchdogTest {
             val capPoller = dog.launchTotalCap(this, target)
             target.join()
             assertTrue(dog.fired is WatchdogFired.TotalCap, "setup: expected TotalCap, got ${dog.fired}")
-            dog.resetFirstByte()
+            dog.resetRound()
             assertTrue(dog.fired is WatchdogFired.TotalCap, "the whole-turn verdict is not a round's to erase")
             capPoller.cancel()
         }
@@ -181,14 +216,13 @@ class WatchdogTest {
             val slot = gate.acquire()
             val dog = TurnWatchdog(budget(firstByteMs = 10_000, idleMs = 300, capMs = 1_200))
             val stalled = launch { delay(10.seconds) }
-            val poller = dog.launchIn(this, slot, stalled)
+            val poller = dog.launchIn(this, slot, stalled, ClientFrameEmitted { true })
             slot.touch()
-            dog.markByte()
             delay(900)
             stalled.join()
             assertTrue(dog.fired is WatchdogFired.Idle, "setup: round one must be reaped")
             poller.cancel()
-            dog.resetFirstByte()
+            dog.resetRound()
             val next = launch { delay(10.seconds) }
             val capPoller = dog.launchTotalCap(this, next)
             next.join()
@@ -214,11 +248,10 @@ class WatchdogTest {
                 ticker = ticks.ticker,
             )
             val target = launch { delay(10.seconds) }
-            // lively and past first byte: real idle is ~0 against a 5s limit, so Idle cannot fire
-            // and the virtual clock is far past the 600ms cap. Nothing is left that could.
+            // lively and past the first client frame: real idle is ~0 against a 5s limit, so Idle
+            // cannot fire and the virtual clock is far past the 600ms cap. Nothing is left that could.
             slot.touch()
-            dog.markByte()
-            val poller = dog.launchIn(this, slot, target)
+            val poller = dog.launchIn(this, slot, target, ClientFrameEmitted { true })
             poller.join()
             assertNull(dog.fired, "a round-scoped poller must not raise a whole-turn verdict")
             assertTrue(ticks.now > 600, "the virtual clock really did run past the cap (${ticks.now}ms)")
@@ -243,7 +276,6 @@ class WatchdogTest {
             )
             val target = launch {
                 while (true) {
-                    dog.markByte()
                     delay(50)
                 }
             }
@@ -297,7 +329,7 @@ class WatchdogTest {
             val slot = gate.acquire()
             val dog = TurnWatchdog(budget(2_000, 2_000, 5_000))
             val target = launch { delay(100) }
-            val poller = dog.launchIn(this, slot, target)
+            val poller = dog.launchIn(this, slot, target, ClientFrameEmitted { false })
             target.join()
             poller.cancel()
             assertNull(dog.fired)
@@ -306,10 +338,15 @@ class WatchdogTest {
     }
 
     @Test
-    fun `poll interval floors and caps`() {
-        assertEquals(250, TurnWatchdog(budget(1, 300, 1)).pollInterval().inWholeMilliseconds)
-        assertEquals(15_000, TurnWatchdog(budget(1, 600_000, 1)).pollInterval().inWholeMilliseconds)
-        assertEquals(1_000, TurnWatchdog(budget(1, 3_000, 1)).pollInterval().inWholeMilliseconds)
+    fun `poll interval floors and caps, paced to the tighter idle tier`() {
+        assertEquals(250, TurnWatchdog(budget(300, 300, 1)).pollInterval().inWholeMilliseconds)
+        assertEquals(15_000, TurnWatchdog(budget(600_000, 600_000, 1)).pollInterval().inWholeMilliseconds)
+        assertEquals(1_000, TurnWatchdog(budget(3_000, 3_000, 1)).pollInterval().inWholeMilliseconds)
+        // A first-output cap tighter than streamIdle paces the poll, or a pre-output stall would be
+        // sampled only every streamIdle/3 — the SseRoundConsumeTest rig (1s / 20s) is that case.
+        assertEquals(333, TurnWatchdog(budget(1_000, 20_000, 1)).pollInterval().inWholeMilliseconds)
+        // Production: 300s first-output / 180s streamIdle still sits on the 15s ceiling.
+        assertEquals(15_000, TurnWatchdog(budget(300_000, 180_000, 1)).pollInterval().inWholeMilliseconds)
     }
 }
 


### PR DESCRIPTION
## Why

Codex compaction has been failing across projects since this morning. `~/.claude-codex/claudex-compact-stats.jsonl` for 2026-09-01: 30 `model_text` vs **153 `stream_error`** (109 `overloaded_error`, 44 `api_error`), against 1–2 failures/day for the previous week. Two distinct mechanisms, both ours to fix at the proxy:

### 1. The stall watchdog reaped silent compactions on the wrong tier

Every one of the 109 stalls reads `no completion within the 180s idle cap` with `first_byte=1–5s`, `events_in=5`, **no first delta**, on 1.0–1.2MB upstream bodies. The successful compactions the same morning had first deltas at 17s, 19s and 111s — the same silence, one tier apart.

`TurnWatchdog` had two tiers by design (the v35 spec in `Watchdog.kt`): `firstByteTimeoutMs` (300s) until the first byte, `streamIdleMs` (180s) after it, precisely so a big-context prefill "legitimately silent for minutes" is not reaped. But the tier flipped on the first upstream **byte** (`markByte()` on the raw SSE read / the first WS event), and on the Responses API that byte is the `response.created` handshake, which arrives in 1–5s while the model is still reading the prefill. So every large compaction was pinned to the short tier before a single token existed, aborted at ~180s, surfaced as a retryable `overloaded_error`, re-sent cold by Claude Code, and looped (three sessions in parallel, `inflight=3`). The `drift-repair` ledger's DR-7 notes record the same fact ("TearAwareEvents.onBytes calls markByte on the RAW read, so response.created flips the watchdog to streamIdle before the stall begins") but the `SseRoundConsumeTest` arm pinned that behaviour as correct.

**Fix:** the tier now reads the round's own `ClientFrameEmitted` probe (CONTENT_FRAMES_OUT above the round baseline — the same fact G5 keys reissue on), on both transports. Until the client has been handed content, silence is judged on `firstByteTimeoutMs`; after it, on `streamIdleMs`. `markByte()`/`resetFirstByte()` are gone (`resetRound()` keeps only the DR-7 stale-Idle clear); bytes still touch the slot for liveness. The `WatchdogFired.Idle` sentinel now carries `sawClientFrame` and `limitMs`, and the terminal message names the tier that fired instead of always saying "180s idle cap".

### 2. Content-policy refusals were retried as if transient

44 compact turns (and 200 normal turns) today failed with `ChatGPT backend: cyber_policy This content was flagged for possible cybersecurity risk…` — OpenAI's Trusted-Access classifier on the whole context (a known false-positive class: openai/codex#37473, #34864, #41672). DR-72 stopped mislabelling it as `authentication_error`, but its `api_error` verdict is still retryable to Claude Code, so each refusal became a ~30s × N backoff storm of the same 1.3MB transcript, and a compaction that trips it can never complete. The vendor itself returns this refusal as HTTP 400 / `invalid_request` when it arrives pre-stream.

**Fix:** the documented prompt-refusal codes (`cyber_policy`, plus the Responses API enum's `invalid_prompt`, `bio_policy`, `image_content_policy_violation`) classify as `INVALID_REQUEST` — terminal to the client, vendor remedy text intact, provenance by exact code (same rule as `RETRYABLE_CODES`). Nothing splice can do makes the classifier accept the content; what it can do is stop paying for the same rejection ten times and let the user switch heads for the compaction.

### 3. A compact turn's pre-output silence is bounded by the whole-turn cap only (second commit)

Deployed at 13:58 with fixes 1 and 2, the next three compactions (14:07:59, 14:13:50, 14:14:41) died on the now-correct tier: `no first output within the 300s first-output cap` — first byte at 4–6s, `events_in=5`, 1.1–1.2MB upstream bodies, ~350s of reasoning silence before the model would have started the summary. A compaction is one long reasoning pass over the whole transcript; the only pre-output wall that makes sense for it is the whole-turn wall.

**Fix:** `WatchdogBudget.forCompact()` copies the budget with `firstByteTimeout = totalCap`; `TurnDriveFactory` selects it when the turn is a compaction. Normal turns keep the 300s tier, and `streamIdleMs` still applies to every turn once output flows.

## Evidence-first

Red on unmodified `feat/claude-head` (26a9b9b2), then green:

- `UpstreamFailurePolicyRefusalTest`: `a cyber_policy refusal is a terminal invalid_request…` and `every documented prompt-refusal code…` — RED (`expected: <INVALID_REQUEST> but was: <API_ERROR>`).
- `SseRoundConsumeTest` `a pre-content idle reap is an outcome, not a transport tear - DR-7`: budgets swapped to 1s first-output / 20s streamIdle — RED (`expected an Idle reap: null`: the ack flipped the tier and the 20s streamIdle let the mock hang up first).
- `WatchdogTest`: new arm `a handshake byte before any client frame keeps the first-output tier` pins the mechanism at the unit level (touch without a frame → not reaped past 3× streamIdle; then the first frame → reaped on streamIdle with `limitMs` named).
- `WatchdogBudgetTest` (core): `forCompact()` moves only the first tier. `HeadServerCompactCapTest` (gateway, real `HeadServer` + `CodexProvider` against the mock upstream's `idlepre` scenario): a normal turn silent after the handshake is reaped by a 1s first-output cap; the same silence on a compact turn survives it and is ended only by the 4s whole-turn wall.

## Test robustness (commits 3 and 4, test-only)

- `HeadServerCompactCapTest` builds one head per arm: the normal arm's turn spans two upstream attempts (WS, then the SSE re-serve), so it no longer shares the compact arm's 4s whole-turn wall (the kover-instrumented coverage job on 2d9e2c0a lost that race; the gate job passed).
- `HeadServerIntegrationTest`'s two log-reading tests wait for their own turn's perf line under the list's lock: `TurnFinish` sends the terminal frames first (DR-129) and records perf last, so reading `logs` the moment the client body completes raced the server thread (coverage job on 1a2e81c7; the gate job passed, and the previous fifteen coverage runs on `feat/claude-head` were green).

## Not changed

- No knob defaults moved. `firstByteTimeoutMs` (300s) is the cap a silent NORMAL turn gets (Codex CLI's own `stream_idle_timeout_ms` default is 300000); a silent compaction gets `upstreamTimeoutMs` (900s on claudex). Successful compactions have run to 733s; if gpt-5.6 xhigh needs longer on a 250k transcript, `[heads.claudex.overrides] upstreamTimeoutMs` is the per-head override (kimi already carries 2400000), not a code change.
- The WS→SSE re-serve on a pre-frame failure terminal still runs for a policy refusal (two upstream attempts instead of ~20). Skipping the re-serve for a deterministic code is a follow-up.
- Ledger: this branch's `drift-repair.toml` is owned by the claude-splice seat per its 2026-08-30 two-seat law; no row was written here. Suggested row: the DR-7 arm C2 note above, closed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
