### PR TITLE
fix(claudex): retry the backend capacity signal and let Claude Code outlive the proxy wall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Compactions no longer die on the ChatGPT backend's capacity signal.** An in-stream
+  `server_is_overloaded` (or `slow_down`) used to classify as a non-retryable `api_error`, so the
+  proxy neither reissued nor salvaged the turn and Claude Code reported the compaction failed. Any
+  overload-shaped error code is now a transient `overloaded_error`, the type Claude Code retries
+  with backoff, matching codex's own handling of the same two codes.
+- **Claude Code now waits out the proxy's own whole-turn wall.** Every wrapper plants
+  `API_TIMEOUT_MS` from the head's `upstreamTimeoutMs` plus a minute of grace (960 s on the
+  default 900 s cap). With Claude Code's 600 s default, every compaction longer than ten minutes
+  ended as a client abort while the daemon was still streaming the summary.
+
 ## splice v0.3.0-beta.1 — native Claude auth and a hardened multi-head gateway - 2026-08-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
   deadline; on a loaded runner the idle poller could win the tick and end a round as "first-output
   cap" (salvage invited) where the wall should have ended the turn. The tier is now off for
   compactions; `streamIdle` still reaps a stall once output has begun.
+- **A torn perf row no longer swallows the row after it.** When the disk filled mid-append
+  (2026-08-25) a short write left a fragment with no newline and the next row fused onto it, so
+  readers lost both. The JSONL sink now heals a torn tail before appending.
 
 ## splice v0.3.0-beta.1 — native Claude auth and a hardened multi-head gateway - 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
   `API_TIMEOUT_MS` from the head's `upstreamTimeoutMs` plus a minute of grace (960 s on the
   default 900 s cap). With Claude Code's 600 s default, every compaction longer than ten minutes
   ended as a client abort while the daemon was still streaming the summary.
+- **A silent compaction is ended by the whole-turn wall alone.** The compact budget used to raise
+  the first-output tier to the wall instead of switching it off, leaving two pollers on one
+  deadline; on a loaded runner the idle poller could win the tick and end a round as "first-output
+  cap" (salvage invited) where the wall should have ended the turn. The tier is now off for
+  compactions; `streamIdle` still reaps a stall once output has begun.
 
 ## splice v0.3.0-beta.1 — native Claude auth and a hardened multi-head gateway - 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@
 - **Compactions no longer die on the ChatGPT backend's capacity signal.** An in-stream
   `server_is_overloaded` (or `slow_down`) used to classify as a non-retryable `api_error`, so the
   proxy neither reissued nor salvaged the turn and Claude Code reported the compaction failed. Any
-  overload-shaped error code is now a transient `overloaded_error`, the type Claude Code retries
-  with backoff, matching codex's own handling of the same two codes.
+  overload-shaped error code on an in-stream or server-side (5xx) failure is now a transient
+  `overloaded_error`, the type Claude Code retries with backoff, matching codex's own handling of
+  the same two codes; a 4xx keeps its deterministic verdict whatever its code spells.
 - **Claude Code now waits out the proxy's own whole-turn wall.** Every wrapper plants
   `API_TIMEOUT_MS` from the head's `upstreamTimeoutMs` plus a minute of grace (960 s on the
   default 900 s cap). With Claude Code's 600 s default, every compaction longer than ten minutes

--- a/gateway/app/src/main/kotlin/splice/app/head/LaunchSpecFactory.kt
+++ b/gateway/app/src/main/kotlin/splice/app/head/LaunchSpecFactory.kt
@@ -16,6 +16,11 @@ import splice.core.launch.LoginOutcomeFile
 import splice.core.topology.Topology
 import java.nio.file.Paths
 
+/** How much longer than the daemon's whole-turn cap Claude Code waits before giving up on a
+ *  request. Large enough to cover the cancellation seal's travel, small enough that a hung proxy
+ *  still surfaces within a minute of its own wall. */
+private const val CLIENT_TIMEOUT_GRACE_MS = 60_000L
+
 internal class LaunchSpecFactory(
     private val topology: Topology,
     private val signInPlanner: SignInPlanner,
@@ -58,6 +63,9 @@ internal class LaunchSpecFactory(
                 model.slot?.let { slot -> model.id to slot }
             }.toMap(),
             contextWindow = ctx.catalog.contextWindowFor(head.pinnedModel),
+            // The client's request timeout is DERIVED from the head's whole-turn cap (never a
+            // second hand-maintained number): the proxy's wall is the one that names the verdict.
+            apiTimeoutMs = ctx.watchdog.totalCap.inWholeMilliseconds + CLIENT_TIMEOUT_GRACE_MS,
             modelOptionsCache = buildInputs.modelOptionsCache(ctx.catalog),
             statuslineCommand = "curl -sS --data-binary @- http://127.0.0.1:$controlPort/statusline/$key",
             // The installed wrapper (`<command> login`) runs this head's provider sign-in; the

--- a/gateway/app/src/test/kotlin/splice/app/head/LaunchSpecClientAuthTest.kt
+++ b/gateway/app/src/test/kotlin/splice/app/head/LaunchSpecClientAuthTest.kt
@@ -95,6 +95,14 @@ class LaunchSpecClientAuthTest {
         )
     }
 
+    // The client's request timeout is derived from the head's whole-turn cap, not a second number
+    // kept by hand: 600s cap here -> 660s for Claude Code (2026-09-01 compaction client_aborts).
+    @Test
+    fun `the client's request timeout outlives the head's whole-turn cap`(@TempDir tmp: Path) {
+        val spec = factory(tmp).launchSpecFor(build(tmp, Dialect.OPENAI_RESPONSES), 3099, forwardClientAuth = false)
+        assertEquals(600_000L + 60_000L, spec.apiTimeoutMs)
+    }
+
     /** Positive factory half: a resolved true input must be preserved rather than hardcoded false.
      *  AuthDialectCompatibilityBootTest covers the real passthrough arm derivation. */
     @Test

--- a/gateway/control/src/main/kotlin/splice/control/LaunchService.kt
+++ b/gateway/control/src/main/kotlin/splice/control/LaunchService.kt
@@ -137,6 +137,9 @@ public class LaunchService(
             // deadline; the head's whole-turn cap is the wall that decides a turn, so the client
             // must outlive it (spec.apiTimeoutMs = cap + grace). Without this every compaction
             // longer than ten minutes died as client_abort while the daemon was still serving it.
+            // Planted unconditionally: the head's own wall owns this deadline, so an ambient
+            // API_TIMEOUT_MS is replaced rather than merged (unlike NO_PROXY below); a larger value
+            // buys nothing past totalCap and a smaller one recreates the abort.
             put("API_TIMEOUT_MS", spec.apiTimeoutMs.toString())
             put("NO_PROXY", mergedNoProxy())
             // Hide Claude Code's built-in Anthropic-account commands: in a gateway head, auth is the

--- a/gateway/control/src/main/kotlin/splice/control/LaunchService.kt
+++ b/gateway/control/src/main/kotlin/splice/control/LaunchService.kt
@@ -140,6 +140,11 @@ public class LaunchService(
             // Planted unconditionally: the head's own wall owns this deadline, so an ambient
             // API_TIMEOUT_MS is replaced rather than merged (unlike NO_PROXY below); a larger value
             // buys nothing past totalCap and a smaller one recreates the abort.
+            // Claude Code's non-streaming fallback (after a streaming error it re-sends the turn
+            // with stream:false under this same deadline) stays ENABLED on purpose: the collect
+            // path answers it silently until the terminal body, and with the deadline past totalCap
+            // the head's wall speaks first. CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK would only
+            // delete a recovery path.
             put("API_TIMEOUT_MS", spec.apiTimeoutMs.toString())
             put("NO_PROXY", mergedNoProxy())
             // Hide Claude Code's built-in Anthropic-account commands: in a gateway head, auth is the

--- a/gateway/control/src/main/kotlin/splice/control/LaunchService.kt
+++ b/gateway/control/src/main/kotlin/splice/control/LaunchService.kt
@@ -133,6 +133,11 @@ public class LaunchService(
             put("CLAUDE_CODE_AUTO_COMPACT_WINDOW", max(AUTO_COMPACT_FLOOR, spec.contextWindow).toString())
             put("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", "85")
             put("MAX_THINKING_TOKENS", "128000")
+            // Claude Code's default request timeout is 600s and it also bounds the first-byte
+            // deadline; the head's whole-turn cap is the wall that decides a turn, so the client
+            // must outlive it (spec.apiTimeoutMs = cap + grace). Without this every compaction
+            // longer than ten minutes died as client_abort while the daemon was still serving it.
+            put("API_TIMEOUT_MS", spec.apiTimeoutMs.toString())
             put("NO_PROXY", mergedNoProxy())
             // Hide Claude Code's built-in Anthropic-account commands: in a gateway head, auth is the
             // proxy bearer above, so /login (a local-jsx command hardwired to platform.claude.com —

--- a/gateway/control/src/main/kotlin/splice/control/LaunchTypes.kt
+++ b/gateway/control/src/main/kotlin/splice/control/LaunchTypes.kt
@@ -22,6 +22,12 @@ public data class LaunchSpec(
      *  second alias at an already-claimed model (the 2-model duplication this exists to remove). */
     val modelSlots: Map<String, String> = emptyMap(),
     val contextWindow: Long,
+    /** Claude Code's per-request timeout (API_TIMEOUT_MS) for THIS head: the daemon's whole-turn
+     *  cap plus a grace, so the client always outlives the proxy's own wall and receives its honest
+     *  verdict instead of aborting first. 2026-09-01: the daemon allowed a compaction 900s while
+     *  Claude Code's 600s default gave up — every compaction over ten minutes ended as client_abort
+     *  with the summary still streaming, and the ones that survived had 20-100s to spare. */
+    val apiTimeoutMs: Long,
     val modelOptionsCache: JsonElement, // the /model picker option list
     val statuslineCommand: String, // per-head statusline command (…/statusline/<head>)
     val loginCommand: String, // shell command that runs THIS head's provider sign-in (e.g. `claudex login`)

--- a/gateway/control/src/test/kotlin/ControlServerTest.kt
+++ b/gateway/control/src/test/kotlin/ControlServerTest.kt
@@ -155,6 +155,7 @@ class ControlServerTest {
         policy = splice.core.launch.ClaudePolicy(share = emptySet(), isolate = emptySet()),
         port = 3099,
         inferenceToken = inferenceToken,
+        apiTimeoutMs = 960_000,
     )
 
     /** A second head whose wrapper COMMAND differs from its topology KEY (the starter's

--- a/gateway/control/src/test/kotlin/splice/control/LaunchServiceTest.kt
+++ b/gateway/control/src/test/kotlin/splice/control/LaunchServiceTest.kt
@@ -37,7 +37,18 @@ class LaunchServiceTest {
         policy = ClaudePolicy(share = emptySet(), isolate = emptySet()),
         port = 3099,
         inferenceToken = "test-inference-token",
+        apiTimeoutMs = 960_000,
     )
+
+    // 2026-09-01: every claudex compaction ran 500-580s against Claude Code's 600s default request
+    // timeout while the daemon's whole-turn cap was 900s — the two over ten minutes died as
+    // client_abort with the summary still streaming. The recipe plants API_TIMEOUT_MS from the
+    // head's own budget so the client outlives the proxy's wall and receives its honest verdict.
+    @Test
+    fun `API_TIMEOUT_MS is planted from the head's whole-turn budget`() {
+        val env = service.launch(spec("codex"), emptyList(), dangerouslySkipPermissions = false).env
+        assertEquals("960000", env["API_TIMEOUT_MS"])
+    }
 
     // DR-81 (assembly sweep): the spec is assembled once at boot, but `splice key set` promises
     // live pickup — the capture hook and advertiser used to be frozen at the boot-time key check,

--- a/gateway/core/src/main/kotlin/splice/core/turn/Turn.kt
+++ b/gateway/core/src/main/kotlin/splice/core/turn/Turn.kt
@@ -215,6 +215,14 @@ public data class WatchdogBudget(
      *  died at "no first output within the 300s first-output cap" — 1.13MB body, first byte at 3s,
      *  then silence past five minutes, the same session that had looped all day. Idle is a stall
      *  detector, not a budget (operator, DR-7): the one wall before a compaction's first output is
-     *  the whole-turn cap. Normal turns keep [firstByteTimeout]. */
-    public fun forCompact(): WatchdogBudget = copy(firstByteTimeout = totalCap)
+     *  the whole-turn cap. Normal turns keep [firstByteTimeout].
+     *
+     *  The tier is OFF ([Duration.INFINITE]), not merely raised to [totalCap]: two pollers on one
+     *  deadline are a coin flip. TurnWatchdog's idle poller and its cap poller sample on the same
+     *  ~cap/3 cadence, so at the tick past the wall whichever coroutine is dispatched first names
+     *  the verdict — "first-output cap" (a ROUND reaped, salvage invited) or "total cap" (the TURN
+     *  ended). Gate run 33575037270 lost that flip on a loaded runner; production would have lost
+     *  it the same way at 300s. With no pre-output tier there is nothing to race: the wall alone
+     *  ends a silent compaction, and [streamIdle] still reaps a stall once output has begun. */
+    public fun forCompact(): WatchdogBudget = copy(firstByteTimeout = Duration.INFINITE)
 }

--- a/gateway/core/src/main/kotlin/splice/core/util/JsonlSink.kt
+++ b/gateway/core/src/main/kotlin/splice/core/util/JsonlSink.kt
@@ -90,15 +90,32 @@ public object JsonlSink {
 
     private fun append(file: Path, line: String, maxBytes: Long, rotate: Boolean) {
         val encoded = (line + "\n").toByteArray(StandardCharsets.UTF_8)
-        if (rotate) {
-            val currentSize = if (Files.exists(file)) Files.size(file) else 0L
-            if (currentSize > 0 && currentSize + encoded.size > maxBytes) {
-                val rolled = file.resolveSibling("${file.fileName}.1")
-                Files.move(file, rolled, StandardCopyOption.REPLACE_EXISTING)
-            }
+        val currentSize = if (Files.exists(file)) Files.size(file) else 0L
+        val rotated = rotate && currentSize > 0 && currentSize + encoded.size > maxBytes
+        if (rotated) {
+            val rolled = file.resolveSibling("${file.fileName}.1")
+            Files.move(file, rolled, StandardCopyOption.REPLACE_EXISTING)
         }
-        Files.write(file, encoded, StandardOpenOption.CREATE, StandardOpenOption.APPEND)
+        // A torn tail is healed BEFORE the row lands. 2026-08-25 01:23 the disk filled mid-append
+        // (ENOSPC): 230 bytes of one perf row were written with no newline, the next row was
+        // appended straight onto them, and every reader lost BOTH — the whole row that followed
+        // the short write was fused into the fragment. One byte read per append buys the
+        // guarantee that a short write costs exactly the row it interrupted.
+        val torn = !rotated && currentSize > 0 && lastByte(file) != NEWLINE_BYTE
+        val bytes = if (torn) byteArrayOf(NEWLINE_BYTE) + encoded else encoded
+        Files.write(file, bytes, StandardOpenOption.CREATE, StandardOpenOption.APPEND)
     }
+
+    private fun lastByte(file: Path): Byte =
+        FileChannel.open(file, StandardOpenOption.READ).use { ch ->
+            val size = ch.size()
+            if (size <= 0L) return@use NEWLINE_BYTE
+            val buf = ByteBuffer.allocate(1)
+            ch.position(size - 1)
+            if (ch.read(buf) < 1) return@use NEWLINE_BYTE
+            buf.flip()
+            buf.get()
+        }
 
     /**
      * Read the trailing [maxBytes] of [file] as UTF-8 lines. If the file is larger, the first

--- a/gateway/core/src/test/kotlin/JsonlSinkTest.kt
+++ b/gateway/core/src/test/kotlin/JsonlSinkTest.kt
@@ -33,6 +33,24 @@ class JsonlSinkTest {
         assertEquals(listOf("new"), Files.readAllLines(file))
     }
 
+    // 2026-08-25 01:23: ENOSPC cut a perf row at 230 bytes with no newline; the next append fused
+    // onto it and BOTH rows were lost to every reader. The heal costs one byte read per append.
+    @Test
+    fun `a torn tail is healed before the next row lands - the ENOSPC case`(@TempDir tmp: Path) {
+        val file = tmp.resolve("perf.jsonl")
+        Files.write(file, """{"ts":1,"torn""".toByteArray())
+        JsonlSink.appendLine(file, """{"ts":2}""")
+        assertEquals(listOf("""{"ts":1,"torn""", """{"ts":2}"""), Files.readAllLines(file))
+    }
+
+    @Test
+    fun `a healthy tail is never padded - heal trap control`(@TempDir tmp: Path) {
+        val file = tmp.resolve("perf.jsonl")
+        JsonlSink.appendLine(file, """{"ts":1}""")
+        JsonlSink.appendLine(file, """{"ts":2}""")
+        assertEquals(listOf("""{"ts":1}""", """{"ts":2}"""), Files.readAllLines(file))
+    }
+
     // DR-178: the peer is held from a SECOND channel in this same JVM, which is not a weaker
     // stand-in for a second process — java.nio hands the lock to the whole JVM, so the second
     // acquirer gets OverlappingFileLockException where a foreign process would simply block. Both

--- a/gateway/core/src/test/kotlin/WatchdogBudgetTest.kt
+++ b/gateway/core/src/test/kotlin/WatchdogBudgetTest.kt
@@ -1,18 +1,25 @@
 // The compact-turn budget (2026-09-01): a compaction's silence before its first output is bounded by
 // totalCap alone. Live provenance is in WatchdogBudget.forCompact's KDoc — the first compaction on
 // the corrected watchdog tier still died at "no first output within the 300s first-output cap".
+// Off, not raised to totalCap: two pollers on one deadline flipped a coin over the verdict (gate run
+// 33575037270 on a loaded runner).
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import splice.core.turn.WatchdogBudget
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 class WatchdogBudgetTest {
 
     @Test
-    fun `forCompact lifts the first-output cap to totalCap and touches nothing else`() {
+    fun `forCompact switches the first-output tier off and touches nothing else`() {
         val provider = WatchdogBudget(firstByteTimeout = 300.seconds, streamIdle = 180.seconds, totalCap = 900.seconds)
         val compact = provider.forCompact()
-        assertEquals(900.seconds, compact.firstByteTimeout, "the only wall before a compaction's first output")
+        assertEquals(
+            Duration.INFINITE,
+            compact.firstByteTimeout,
+            "no pre-output tier: the whole-turn cap is the only wall",
+        )
         assertEquals(180.seconds, compact.streamIdle, "mid-output stall detection is unchanged")
         assertEquals(900.seconds, compact.totalCap, "the whole-turn cap is unchanged")
         assertEquals(300.seconds, provider.firstByteTimeout, "the provider budget itself is untouched")

--- a/gateway/gateway/src/test/kotlin/head/HeadServerCompactCapTest.kt
+++ b/gateway/gateway/src/test/kotlin/head/HeadServerCompactCapTest.kt
@@ -8,10 +8,12 @@
 // wall is far away (30s) because the turn spans two upstream attempts (the WS round, then the SSE
 // re-serve) and sharing the compact arm's 4s wall let a slow CI runner reach the wall first (coverage
 // run 33549293551 failed this arm at the first-output assertion; locally it took 3.7s). A COMPACT
-// turn's first-output cap IS the total cap, so the only thing that can end it is its 4s whole-turn
+// turn has no first-output tier at all, so the only thing that can end it is its 4s whole-turn
 // wall — which surfaces as the cancellation seal's generic watchdog wording. Live provenance
 // (2026-09-01 14:07): the first compaction on the corrected tier died at "no first output within
-// the 300s first-output cap".
+// the 300s first-output cap". When the tier was merely RAISED to the wall, gate run 33575037270
+// failed this arm on a loaded runner: two pollers on one deadline, and the idle poller won the
+// tick and named the wrong cap (the coin flip WatchdogBudget.forCompact's KDoc describes).
 package head
 
 import io.ktor.client.HttpClient

--- a/gateway/gateway/src/test/kotlin/head/HeadServerIntegrationTest.kt
+++ b/gateway/gateway/src/test/kotlin/head/HeadServerIntegrationTest.kt
@@ -135,7 +135,11 @@ class HeadServerIntegrationTest {
     // body completes before this turn's perf line lands in `logs`. Waiting for a line past `from`
     // reads THIS turn's telemetry instead of whichever earlier turn's line happened to be last —
     // the read that failed under kover on a slow runner (coverage run 33551147526, 2026-09-01).
-    private fun awaitLog(from: Int, timeoutMs: Long = 5_000, match: (String) -> Boolean): String? {
+    // The ceiling is a failure-path cost only — a healthy turn's perf line lands in milliseconds —
+    // and 5s was not enough for a starved runner: gate run 33608202738 (2026-09-02) saw the line
+    // arrive AFTER the wait while the whole module suite ran alongside. 30s buys nothing on the
+    // pass path and stops a slow box from reading as a missing line.
+    private fun awaitLog(from: Int, timeoutMs: Long = 30_000, match: (String) -> Boolean): String? {
         val deadline = System.currentTimeMillis() + timeoutMs
         while (true) {
             synchronized(logs) { logs.drop(from).lastOrNull(match) }?.let { return it }

--- a/gateway/gateway/src/test/kotlin/head/HeadServerIntegrationTest.kt
+++ b/gateway/gateway/src/test/kotlin/head/HeadServerIntegrationTest.kt
@@ -372,6 +372,46 @@ class HeadServerIntegrationTest {
         assertTrue(sse.contains("overloaded_error"))
     }
 
+    // PR #115 end to end: the backend's capacity signal in every wire shape it takes, driven through
+    // the real head. UpstreamFailureRetryWordingTest proves the VERDICT; these prove the head RETRIES
+    // the pre-stream 503 (the mock counts POSTs), that a signal which clears is invisible to the
+    // client, and that what the client finally sees is overloaded_error — the type Claude Code
+    // itself retries on — never the terminal api_error that ended the 2026-09-01 20:56 compaction.
+    @Test
+    fun `a 503 capacity signal is retried by the head and surfaces as overloaded_error when it persists`() = runTest {
+        val sse = messages("overload_503")
+        assertTrue(sse.contains("event: error"), sse)
+        assertTrue(sse.contains("overloaded_error"), sse)
+        assertFalse(sse.contains("api_error"), sse)
+        val posts = mock.upstreamBodies.count { it.first == "overload_503" }
+        assertTrue(posts >= 2, "the head gave up on the capacity signal without retrying: $posts POST(s)")
+    }
+
+    @Test
+    fun `a capacity signal that clears on the head's retry completes the turn`() = runTest {
+        val sse = messages("overload_once")
+        assertTrue(sse.contains("ok after auth"), sse)
+        assertTrue(sse.contains("event: message_stop"), sse)
+        assertEquals(2, mock.upstreamBodies.count { it.first == "overload_once" })
+    }
+
+    @Test
+    fun `an in-stream capacity signal surfaces as overloaded_error, never api_error`() = runTest {
+        val sse = messages("overload_sse")
+        assertTrue(sse.contains("event: error"), sse)
+        assertTrue(sse.contains("overloaded_error"), sse)
+        assertFalse(sse.contains("api_error"), sse)
+    }
+
+    @Test
+    fun `a 4xx wearing the overload code keeps its deterministic verdict and is not retried`() = runTest {
+        val sse = messages("overload_403")
+        assertTrue(sse.contains("event: error"), sse)
+        assertTrue(sse.contains("invalid_request_error"), sse)
+        assertFalse(sse.contains("overloaded_error"), sse)
+        assertEquals(1, mock.upstreamBodies.count { it.first == "overload_403" }, "a 4xx must not be retried")
+    }
+
     @Test
     fun `compactish turn promotes reasoning to text (mirror + promote)`() = runTest {
         // a compact-shaped SCENARIO won't trigger classifyCompact (no marker), so this proves

--- a/gateway/gateway/src/testFixtures/kotlin/mock/MockChatGptUpstream.kt
+++ b/gateway/gateway/src/testFixtures/kotlin/mock/MockChatGptUpstream.kt
@@ -93,6 +93,13 @@ class MockChatGptUpstream {
         pool.shutdownNow()
     }
 
+    private fun capacityStatus(scenario: String): Int? = when (scenario) {
+        "overload_503" -> 503
+        "overload_once" -> if (upstreamBodies.count { it.first == scenario } == 1) 503 else null
+        "overload_403" -> 403
+        else -> null
+    }
+
     private fun sse(ex: HttpExchange, json: String) {
         ex.responseBody.write("data: $json\n\n".toByteArray())
         ex.responseBody.flush()
@@ -133,6 +140,18 @@ class MockChatGptUpstream {
         if (scenario == "refresh" && auth == "Bearer tok-old") {
             val err = """{"error":{"message":"token expired"}}"""
             ex.sendResponseHeaders(401, err.length.toLong())
+            ex.responseBody.use { it.write(err.toByteArray()) }
+            return
+        }
+
+        // The ChatGPT backend's capacity signal in its PRE-STREAM shape (PR #115 classifies the code
+        // by shape): "overload_503" never clears, so the head retries and then surfaces OVERLOADED;
+        // "overload_once" clears on the second POST, so the head's own retry completes the turn;
+        // "overload_403" wears the same code on a 4xx, which must stay a deterministic client error.
+        // The POST count in [upstreamBodies] is the retry proof — never the verdict alone.
+        capacityStatus(scenario)?.let { status ->
+            val err = """{"error":{"code":"server_is_overloaded","message":"The engine is currently overloaded, please try again later"}}"""
+            ex.sendResponseHeaders(status, err.length.toLong())
             ex.responseBody.use { it.write(err.toByteArray()) }
             return
         }
@@ -405,6 +424,12 @@ class MockChatGptUpstream {
             "failed" -> sse(
                 ex,
                 """{"type":"response.failed","response":{"error":{"code":"server_error","message":"boom upstream"}}}""",
+            )
+            // The capacity signal in its IN-STREAM shape — the 2026-09-01 20:56 compaction death.
+            "overload_sse" -> sse(
+                ex,
+                """{"type":"response.failed","response":{"error":{"code":"server_is_overloaded",""" +
+                    """"message":"The engine is currently overloaded, please try again later"}}}""",
             )
             "overflow_sse" -> sse(
                 ex,

--- a/gateway/provider-spi/src/main/kotlin/splice/spi/UpstreamFailureClassifier.kt
+++ b/gateway/provider-spi/src/main/kotlin/splice/spi/UpstreamFailureClassifier.kt
@@ -232,11 +232,21 @@ public object UpstreamFailureClassifier {
 
     private sealed class ExtractResult {
         data class Fields(val message: String, val code: String) : ExtractResult() {
-            /** Overload: a 502 from the gateway, or capacity by CODE SHAPE (classifyContent's branch
-             *  comment carries the provenance). Lives on the fields, not the object: the object sits
-             *  at detekt's function budget and classifyContent at its complexity budget. */
-            fun isOverload(status: Int?): Boolean =
-                status == BAD_GATEWAY || code.lowercase() in CAPACITY_CODES || overloadCodeRe.containsMatchIn(code)
+            /** Overload: a 502 from the gateway, or capacity by CODE SHAPE on a status-less (in-stream)
+             *  or server-side failure (classifyContent's branch comment carries the provenance). A 4xx
+             *  keeps its deterministic verdict whatever its code spells: this arm sits ahead of
+             *  statusFallback's client-error branch, so without the floor a permanent 403 spelling
+             *  "overload" would be re-POSTed UPSTREAM_RETRIES times (review of #115). Lives on the
+             *  fields, not the object: the object sits at detekt's function budget and
+             *  classifyContent at its complexity budget. */
+            fun isOverload(status: Int?): Boolean = when {
+                status == BAD_GATEWAY -> true
+                status == null -> capacityShape()
+                else -> status >= SERVER_ERROR_FLOOR && capacityShape()
+            }
+
+            private fun capacityShape(): Boolean =
+                code.lowercase() in CAPACITY_CODES || overloadCodeRe.containsMatchIn(code)
         }
         data class Gateway(val failure: ClassifiedFailure) : ExtractResult()
     }

--- a/gateway/provider-spi/src/main/kotlin/splice/spi/UpstreamFailureClassifier.kt
+++ b/gateway/provider-spi/src/main/kotlin/splice/spi/UpstreamFailureClassifier.kt
@@ -148,7 +148,16 @@ public object UpstreamFailureClassifier {
                 ClassifiedFailure(ErrorType.RATE_LIMIT, msg.take(MAX_MESSAGE))
             status == AUTH_STATUS || authRe.containsMatchIn(blob) ->
                 ClassifiedFailure(ErrorType.AUTHENTICATION, msg.take(MAX_MESSAGE))
-            status == BAD_GATEWAY ->
+            // Overload: a 502 from the gateway, or capacity by CODE SHAPE. The ChatGPT backend
+            // reports "model at capacity" as HTTP 503 or an in-stream response.failed whose code is
+            // server_is_overloaded / slow_down — codex-rs names exactly those two (PR #31058, which
+            // turned them from turn-ending into a patient same-turn retry). An exact allowlist keeps
+            // losing this race one spelling at a time: DR-71 added engine_/model_overloaded, and on
+            // 2026-09-01 20:56 a claudex compaction (830KB upstream body) died as a non-transient
+            // api_error on server_is_overloaded — no reissue, no salvage, "compaction failed" in the
+            // client. Any code spelling overload IS the named transient server condition, and it
+            // surfaces as OVERLOADED (529 / overloaded_error): the type Claude Code retries on.
+            fields.isOverload(status) ->
                 ClassifiedFailure(ErrorType.OVERLOADED, msg.take(MAX_MESSAGE), transient = true)
             else -> statusFallback(status, msg, fields.code)
         }
@@ -222,7 +231,13 @@ public object UpstreamFailureClassifier {
     public fun mapOutStatus(status: Int): Int = if (status == BAD_GATEWAY) OVERLOADED_STATUS else status
 
     private sealed class ExtractResult {
-        data class Fields(val message: String, val code: String) : ExtractResult()
+        data class Fields(val message: String, val code: String) : ExtractResult() {
+            /** Overload: a 502 from the gateway, or capacity by CODE SHAPE (classifyContent's branch
+             *  comment carries the provenance). Lives on the fields, not the object: the object sits
+             *  at detekt's function budget and classifyContent at its complexity budget. */
+            fun isOverload(status: Int?): Boolean =
+                status == BAD_GATEWAY || code.lowercase() in CAPACITY_CODES || overloadCodeRe.containsMatchIn(code)
+        }
         data class Gateway(val failure: ClassifiedFailure) : ExtractResult()
     }
 
@@ -244,22 +259,24 @@ public object UpstreamFailureClassifier {
 
     // The exact codes a status-less failure may be re-POSTed on: named transient server
     // conditions only. Anything else — known-deterministic or unknown — does not earn a
-    // full-context replay on the say-so of its message text.
+    // full-context replay on the say-so of its message text. Overload is NOT listed here: every
+    // spelling of it (overloaded, overloaded_error, engine_/model_overloaded, server_is_overloaded)
+    // is classified by shape in classifyContent, one rule instead of a list that rots a spelling
+    // at a time (DR-71, then 2026-09-01).
     private val RETRYABLE_CODES = setOf(
         "server_error",
         "internal_error",
         "internal_server_error",
-        "overloaded",
-        "overloaded_error",
         "timeout",
         "request_timeout",
         "service_unavailable",
         "temporarily_unavailable",
-        // DR-71: the engine/model-scoped overload spellings vendors emit are the same named
-        // transient server condition — a deterministic-looking absence here made them non-retryable.
-        "engine_overloaded",
-        "model_overloaded",
     )
+
+    // The backend's two capacity codes by name (codex-rs PR #31058); `slow_down` does not spell
+    // overload, so the shape rule alone would miss it.
+    private val CAPACITY_CODES = setOf("server_is_overloaded", "slow_down")
+    private val overloadCodeRe = Regex("overload", RegexOption.IGNORE_CASE)
 
     private const val RATE_LIMIT_STATUS = 429
     private const val AUTH_STATUS = 401

--- a/gateway/provider-spi/src/main/kotlin/splice/spi/Watchdog.kt
+++ b/gateway/provider-spi/src/main/kotlin/splice/spi/Watchdog.kt
@@ -23,8 +23,10 @@
 // keys reissue on): until the client has seen content, the silence is prefill/reasoning and the
 // first-output cap applies; after it, the stream is mid-output and streamIdle applies. Bytes still
 // TOUCH the slot (liveness: a keepalive resets idleness); they no longer choose the limit. A COMPACT
-// turn's first-output cap is totalCap itself (WatchdogBudget.forCompact, wired at TurnDriveFactory):
-// the first compaction on the corrected tier still died silent at 300s.
+// turn has NO first-output tier (WatchdogBudget.forCompact, wired at TurnDriveFactory) — its wall is
+// launchTotalCap alone: the first compaction on the corrected tier still died silent at 300s, and
+// raising the tier to totalCap instead of removing it left two pollers flipping a coin over which
+// verdict named the stall (gate run 33575037270).
 package splice.spi
 
 import kotlinx.coroutines.CoroutineScope

--- a/gateway/provider-spi/src/test/kotlin/UpstreamFailureRetryWordingTest.kt
+++ b/gateway/provider-spi/src/test/kotlin/UpstreamFailureRetryWordingTest.kt
@@ -2,9 +2,11 @@
 // retry-wording heuristic and the structured-code allowlist, red 6/6 on the pre-fix classifier —
 // em/en-dash and line-break clause cuts, the "retry" invitation synonym, "service is unavailable"
 // wording, engine/model overload codes, the 120-char clause budget, and won't/will-not negators.
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import splice.core.turn.ErrorType
 import splice.spi.FailureSource
 import splice.spi.UpstreamFailureClassifier
 
@@ -54,6 +56,47 @@ class UpstreamFailureRetryWordingTest {
     fun `engine and model overload codes are allowlisted transients - DR-71`() {
         assertTrue(coded("engine_overloaded").transient)
         assertTrue(coded("model_overloaded").transient)
+        // Overload is the vendor's own verdict, so it surfaces as the type the client retries on.
+        assertEquals(ErrorType.OVERLOADED, coded("engine_overloaded").type)
+    }
+
+    // 2026-09-01 20:56, claudex compaction (830KB upstream body): the backend's response.failed
+    // carried code server_is_overloaded — "Our servers are currently overloaded. Please try again
+    // later." — and the exact-list idiom made it a non-transient api_error: no reissue, no salvage,
+    // "compaction failed" in Claude Code. codex-rs (PR #31058) names server_is_overloaded and
+    // slow_down as the backend's two capacity codes and retries them patiently on their own budget;
+    // here any code spelling overload is capacity, surfaced as OVERLOADED so the client retries
+    // with backoff instead of ending the turn. Red 3/3 on the allowlist classifier.
+    @Test
+    fun `the backend's capacity codes are transient overloaded, not api_error`() {
+        for (code in listOf("server_is_overloaded", "slow_down", "SERVER_IS_OVERLOADED")) {
+            val r = coded(code)
+            assertEquals(ErrorType.OVERLOADED, r.type, code)
+            assertTrue(r.transient, code)
+        }
+    }
+
+    @Test
+    fun `a capacity code outranks message wording that reads deterministic`() {
+        val r = UpstreamFailureClassifier.classify(
+            FailureSource.SSE,
+            "Do not retry this request",
+            code = "server_is_overloaded",
+        )
+        assertEquals(ErrorType.OVERLOADED, r.type)
+        assertTrue(r.transient)
+    }
+
+    // The pre-stream shape of the same verdict: HTTP 503 with the structured code in the body.
+    @Test
+    fun `an HTTP 503 carrying a capacity code is overloaded, not a generic 5xx api_error`() {
+        val r = UpstreamFailureClassifier.classify(
+            FailureSource.HTTP,
+            """{"error":{"code":"server_is_overloaded","message":"Our servers are currently overloaded."}}""",
+            status = 503,
+        )
+        assertEquals(ErrorType.OVERLOADED, r.type)
+        assertTrue(r.transient)
     }
 
     // DR-71 redo (codex red-repro): the negation bridge caps at 2000 chars but the heuristic used

--- a/gateway/provider-spi/src/test/kotlin/UpstreamFailureRetryWordingTest.kt
+++ b/gateway/provider-spi/src/test/kotlin/UpstreamFailureRetryWordingTest.kt
@@ -99,6 +99,28 @@ class UpstreamFailureRetryWordingTest {
         assertTrue(r.transient)
     }
 
+    // The shape rule IS the fix: an unseen overload spelling is capacity too. Mutation-checked: an
+    // exact four-entry allowlist keeps every arm above green and only this one red.
+    @Test
+    fun `an unseen overload spelling is capacity by shape, not by allowlist`() {
+        val r = coded("gpu_pool_overload_backpressure")
+        assertEquals(ErrorType.OVERLOADED, r.type)
+        assertTrue(r.transient)
+    }
+
+    // The shape rule never overrides a deterministic client error: a 4xx spelling overload keeps
+    // statusFallback's verdict instead of being re-POSTed four times against a limited account.
+    @Test
+    fun `a 4xx carrying an overload-shaped code stays a deterministic client error`() {
+        val r = UpstreamFailureClassifier.classify(
+            FailureSource.HTTP,
+            """{"error":{"code":"server_is_overloaded","message":"at capacity"}}""",
+            status = 403,
+        )
+        assertEquals(ErrorType.INVALID_REQUEST, r.type)
+        assertFalse(r.transient)
+    }
+
     // DR-71 redo (codex red-repro): the negation bridge caps at 2000 chars but the heuristic used
     // to scan the UNTRUNCATED message — an invitation past the bridge's reach was still seen by
     // tryAgainRe, so a clause whose visible (displayed) half is pure negation read as transient.

--- a/gateway/provider-spi/src/test/kotlin/WatchdogTest.kt
+++ b/gateway/provider-spi/src/test/kotlin/WatchdogTest.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -102,6 +103,36 @@ class WatchdogTest {
             val poller = dog.launchIn(this, slot, target, ClientFrameEmitted { false })
             delay(900) // silent 3x streamIdle, still under firstByteTimeout
             assertNull(dog.fired, "prefill was reaped — the compaction-ate-my-quota regression")
+            target.cancel()
+            poller.cancel()
+            slot.release()
+        }
+    }
+
+    // THE COMPACT BUDGET (WatchdogBudget.forCompact): the pre-output tier is OFF, so a silent
+    // compaction is never reaped by THIS poller — not at firstByteTimeout, not at totalCap, which is
+    // launchTotalCap's cancel and the wall that alone may end it. Before this the tier was RAISED to
+    // totalCap, and two pollers on one deadline flipped a coin over which verdict named the stall
+    // (gate run 33575037270 on a loaded runner). Rides a real clock like the v35 arm above: it
+    // proves idleness as the slot measures it, and the slot's clock has no seam.
+    @Test
+    fun `the compact budget never reaps pre-output silence from the idle poller, even past totalCap`() {
+        runBlocking {
+            val gate = InflightGate({ 0 })
+            val slot = gate.acquire()
+            val dog = TurnWatchdog(budget(firstByteMs = 5_000, idleMs = 300, capMs = 600).forCompact())
+            val cancelled = AtomicBoolean(false)
+            val target = launch {
+                try {
+                    delay(10.seconds)
+                } finally {
+                    cancelled.set(true)
+                }
+            }
+            val poller = dog.launchIn(this, slot, target, ClientFrameEmitted { false })
+            delay(1_200) // silent 4x streamIdle and 2x totalCap, no client frame yet
+            assertNull(dog.fired, "the idle poller reaped a compaction's pre-output silence — the wall alone owns it")
+            assertFalse(cancelled.get(), "the round was cancelled without a verdict")
             target.cancel()
             poller.cancel()
             slot.release()


### PR DESCRIPTION
## What broke (read off the live daemon, 2026-09-01)

Every claudex compaction today was a 1.2 MB request that took 500 to 580 s when it worked. Two of them died as `client_abort` at 600 s and 604 s, one died in 7.5 s on the backend's `server_is_overloaded`, and from 21:01 one session retried its compaction every ~300 s with the daemon recording nothing.

## Fix 1: overload is classified by code shape, and it is `overloaded_error`

The in-stream `response.failed` carried code `server_is_overloaded`. The classifier trusts only an exact allowlist of codes, so this became a non-transient `api_error`: no reissue, no salvage, and Claude Code reported the compaction failed. codex-rs (PR #31058) names `server_is_overloaded` and `slow_down` as the backend's two capacity codes and retries them patiently. Any code spelling overload, plus `slow_down`, is now a transient `OVERLOADED` (the 529 / `overloaded_error` Claude Code retries with backoff). DR-71 had patched the same gap for `engine_/model_overloaded` by adding spellings; this replaces the list with one rule.

## Fix 2: the wrapper plants `API_TIMEOUT_MS` from the head's own wall

Claude Code's default request timeout is 600 s and it also bounds the first-byte deadline; the daemon's whole-turn cap is 900 s. Every compaction over ten minutes was killed by the client while the daemon was still streaming it. Each wrapper now launches Claude Code with `API_TIMEOUT_MS = upstreamTimeoutMs + 60 s` (960 s on defaults), derived in `LaunchSpecFactory` from the same `WatchdogBudget` the daemon enforces.

## Proof

- Red: the four new classifier arms fail on the old classifier (`expected OVERLOADED but was API_ERROR`), the launch-env arm fails without the planted variable (`expected 960000 but was null`).
- Green: 582 targeted tests, then the full `npm run gate` on this tip: `GATE: PASS` (first run failed only on `webui dist` from a stale local node_modules; `npm ci` and a rebuild reproduce the committed bundle byte for byte).

## Not fixed here, deliberately named

The ~300 s retry loop after 21:01 is a third defect: while an SSE upstream POST waits for response headers, the daemon writes nothing to Claude Code, so the client's first-byte deadline fires and the daemon records no verdict for the aborted turn. The evidence and the proposed change (commit headers and keepalive before the upstream handoff, and record client aborts before commit) are in the session notes; it needs its own red test against the mock upstream's stall scenario before it is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Update 2026-09-01 22:10 — the third symptom explained, build installed locally, Docker e2e green

**The ~300 s retry loop is Claude Code's non-streaming fallback, and both fixes above cover it.** Read from the installed binary (2.1.257): after a streaming attempt errors, Claude Code logs `Error streaming, falling back to non-streaming mode` and re-issues the query with `stream: false` and `timeout: API_TIMEOUT_MS || 300000`. The daemon serves `stream:false` on its collect path, which by design writes nothing until the terminal JSON body (no SSE channel, no keepalive), and a compaction's first upstream content arrives 500–580 s after `response.created` (perf rows today: `first_delta` 500502 / 576329 / 578572 ms). So every fallback attempt died client-side at 300 s with zero bytes on the wire, the daemon cancelled the upstream on the socket close (no perf row), and the client retried. Fix 1 removes the trigger in the observed case (`server_is_overloaded` no longer surfaces as a terminal `api_error`); fix 2 raises the fallback's timeout to 960 s, above the daemon's 900 s wall, so even a fallback compaction completes. `CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK` exists in the client and would keep compaction on the streaming path (where the daemon does keep the client alive); not planted here — separate decision.

**Installed locally.** Jar `f80a075d59369ed9` (this branch at 3912a166, built through buildgate) installed via `install.sh` at 22:08 with the beta.1 jar backed up beside it; daemon restarted at inflight 0/0/0/0, 4/4 heads ready. The live `/launch/claudex` recipe now carries `API_TIMEOUT_MS=960000`.

**Fresh-machine Docker e2e** (harness in its own PR): this build 19/19; the v0.3.0-beta.1 assets 17/19, failing exactly the two launch-recipe steps (`API_TIMEOUT_MS` absent).
