### PR TITLE
test(e2e): fresh-machine Docker e2e (install → doctor → heads → real wrapper → uninstall)

### DIFF
--- a/checks/e2e/README.md
+++ b/checks/e2e/README.md
@@ -90,6 +90,32 @@ your own `claude` login). Every other head tier 2 drives spends an OAuth subscri
 gating this one alone would single out a cost that is already universal. The spend is announced
 per head at dispatch instead. Use `--tier 1` if you do not want it.
 
+## Fresh-machine e2e (Docker)
+
+`npm run e2e:docker` proves a build on a **new machine**: a Docker image with only the
+prerequisites (Java 21, Node 24, python3, curl, bash, Claude Code) and an empty unprivileged
+HOME, run with `--network none`. Inside, `checks/e2e/docker/inside.sh` brings up two mock
+upstreams (the migration oracle's vendored ChatGPT-backend mock for `openai-responses`, a
+minimal `openai-chat` mock), writes a two-head topology, installs from artifacts through the
+real `install.sh` (checksum → `init` → `install --all` → `doctor`), cold-starts the daemon, drives
+`stream_probe.py` and `count_tokens` through every head, runs the **real** Claude Code wrapper
+(`claudex -p …`, `claude-mockchat -p …`) against the head, then `restart` / `logs` / `status` /
+`uninstall`. No vendor, no quota, no network: every byte the daemon or the wrapper moves goes to
+the in-container mocks or the step fails.
+
+```bash
+npm run e2e:docker                                     # build this checkout, prove it
+bash checks/e2e/docker/run.sh --release v0.3.0-beta.1  # prove a published release's assets
+bash checks/e2e/docker/run.sh --jar P --shim P         # prove any prebuilt pair
+bash checks/e2e/docker/run.sh --no-build               # reuse the image
+```
+
+Each run writes `checks/e2e/receipts/docker-<stamp>.json` (per-step verdict, seconds, evidence)
+and exits non-zero on any failed step; a failed step never stops the run, so later steps stay
+evidence. The image pins Claude Code to the host's `claude --version` (override with
+`SPLICE_E2E_CLAUDE_VERSION`). Run it before `npm run promote`: a release that has not passed here has
+not been installed anywhere.
+
 ## Debugging a failure
 
 `E2E_KEEP_TMUX=1` keeps the tmux session and scratch dir; attach with

--- a/checks/e2e/docker/Dockerfile
+++ b/checks/e2e/docker/Dockerfile
@@ -7,16 +7,24 @@
 # the wrapper move goes to the two in-container mock upstreams, or the run fails.
 FROM eclipse-temurin:21-jre-noble
 
-ARG CLAUDE_CODE_VERSION=latest
+# Every input is pinned so two builds a month apart prove the same machine (review of #116):
+# Node from the official tarball, verified against its published sha256; Claude Code at an exact
+# version (run.sh overrides it with the host's, when one is discoverable).
+ARG NODE_VERSION=24.20.0
+ARG NODE_SHA256=2f2c0da162318f0de47665410c7c8c2ed3d36c8f3105de4bbc61176c70a7cbf2
+ARG CLAUDE_CODE_VERSION=2.1.257
 # The unprivileged user's uid — run.sh passes the host's so the bind-mounted /out and /artifacts
 # are readable/writable on both sides (the noble base already owns uid 1000 as `ubuntu`).
 ARG UID=1000
 
-# iproute2 gives `ss` for the socket assertions; procps gives `pgrep` for the daemon assertions.
+# iproute2 gives `ss` for the socket assertions; procps gives `pgrep` for the daemon assertions;
+# xz-utils unpacks the Node tarball.
 RUN apt-get update \
- && apt-get install -y --no-install-recommends ca-certificates curl bash python3 iproute2 procps gnupg \
- && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
- && apt-get install -y --no-install-recommends nodejs \
+ && apt-get install -y --no-install-recommends ca-certificates curl bash python3 iproute2 procps xz-utils \
+ && curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" -o /tmp/node.tar.xz \
+ && echo "${NODE_SHA256}  /tmp/node.tar.xz" | sha256sum -c - \
+ && tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1 --exclude='*/CHANGELOG.md' --exclude='*/README.md' --exclude='*/LICENSE' \
+ && rm /tmp/node.tar.xz \
  && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
  && npm cache clean --force \
  && rm -rf /var/lib/apt/lists/*

--- a/checks/e2e/docker/Dockerfile
+++ b/checks/e2e/docker/Dockerfile
@@ -1,0 +1,30 @@
+# checks/e2e/docker/Dockerfile — a NEW MACHINE for the fresh-install e2e.
+#
+# Nothing splice-specific is baked in: the image is the prerequisite set the README asks a new
+# operator to have (Java 21+, Node 24, python3, curl, bash, Claude Code on PATH) and an unprivileged
+# user with an empty HOME. The release artifacts and the checkout are mounted at run time, so the
+# same image proves any build. The container runs with --network none: every byte the daemon and
+# the wrapper move goes to the two in-container mock upstreams, or the run fails.
+FROM eclipse-temurin:21-jre-noble
+
+ARG CLAUDE_CODE_VERSION=latest
+# The unprivileged user's uid — run.sh passes the host's so the bind-mounted /out and /artifacts
+# are readable/writable on both sides (the noble base already owns uid 1000 as `ubuntu`).
+ARG UID=1000
+
+# iproute2 gives `ss` for the socket assertions; procps gives `pgrep` for the daemon assertions.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl bash python3 iproute2 procps gnupg \
+ && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+ && npm cache clean --force \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN (userdel -r ubuntu 2>/dev/null || true) && useradd -m -u "${UID}" -s /bin/bash tester \
+ && mkdir -p /out && chown tester:tester /out
+
+USER tester
+WORKDIR /home/tester
+ENV HOME=/home/tester
+ENV PATH="/home/tester/.local/bin:${PATH}"

--- a/checks/e2e/docker/inside.sh
+++ b/checks/e2e/docker/inside.sh
@@ -19,6 +19,7 @@ OUT="${OUT:-/out}"
 CONTROL_PORT=3096
 CODEX_HEAD_PORT=3099
 CHAT_HEAD_PORT=3101
+CHAT2_HEAD_PORT=3105
 RECEIPT="$OUT/receipt.json"
 STEPS_FILE="$(mktemp)"
 FAILED=0
@@ -108,7 +109,7 @@ echo "fresh-machine e2e: user=$(id -un) home=$HOME artifacts=$ARTIFACTS"
 start_mocks() {
   nohup node "$REPO/checks/e2e/docker/mock_codex.mjs" "$REPO" 0 > "$OUT/mock_codex.out" 2> "$OUT/mock_codex.err" &
   echo $! > "$OUT/mock_codex.pid"
-  nohup python3 "$REPO/checks/e2e/docker/mock_chat.py" 0 > "$OUT/mock_chat.out" 2> "$OUT/mock_chat.err" &
+  MOCK_CHAT_HOLD_S=45 nohup python3 "$REPO/checks/e2e/docker/mock_chat.py" 0 > "$OUT/mock_chat.out" 2> "$OUT/mock_chat.err" &
   echo $! > "$OUT/mock_chat.pid"
   for _ in $(seq 1 50); do
     [ -s "$OUT/mock_codex.out" ] && [ -s "$OUT/mock_chat.out" ] && break
@@ -156,6 +157,18 @@ id = "mock-chat"
 label = "Chat (mock)"
 context_window = 128000
 
+# A second chat head on the SAME mock with its own window: the per-head contract check and the
+# cross-head ListAgents proof need two heads whose every turn the harness controls.
+[providers.mockchat2]
+dialect = "openai-chat"
+base_url = "http://127.0.0.1:$CHAT_MOCK_PORT"
+auth = { kind = "api-key", env = "MOCK_CHAT_API_KEY" }
+
+[[providers.mockchat2.models]]
+id = "mock-chat-2"
+label = "Chat 2 (mock)"
+context_window = 64000
+
 [heads.claudex]
 provider = "codex"
 port = $CODEX_HEAD_PORT
@@ -171,6 +184,14 @@ discovery_prefix = "claude-mockchat--"
 pinned_model = "mock-chat"
 [heads.mockchat.claude]
 command = "claude-mockchat"
+
+[heads.mockchat2]
+provider = "mockchat2"
+port = $CHAT2_HEAD_PORT
+discovery_prefix = "claude-mockchat2--"
+pinned_model = "mock-chat-2"
+[heads.mockchat2.claude]
+command = "claude-mockchat2"
 EOF
   cat "$HOME/.config/splice/splice.toml"
 }
@@ -205,6 +226,7 @@ install_step() {
   [ -x "$HOME/.local/bin/splice" ] || { echo "splice command not linked"; return 1; }
   [ -x "$HOME/.local/bin/claudex" ] || { echo "claudex wrapper not linked"; return 1; }
   [ -x "$HOME/.local/bin/claude-mockchat" ] || { echo "claude-mockchat wrapper not linked"; return 1; }
+  [ -x "$HOME/.local/bin/claude-mockchat2" ] || { echo "claude-mockchat2 wrapper not linked"; return 1; }
   ls -l "$HOME/.local/bin/"
   splice version
 }
@@ -226,7 +248,7 @@ step "doctor: prerequisites ✓, no ✗ anywhere" doctor_prereqs
 cold_start() {
   splice restart </dev/null || return 1
   wait_health 60 || return 1
-  ss -ltn | grep -E ":($CONTROL_PORT|$CODEX_HEAD_PORT|$CHAT_HEAD_PORT) " || { echo "head ports not listening"; return 1; }
+  ss -ltn | grep -E ":($CONTROL_PORT|$CODEX_HEAD_PORT|$CHAT_HEAD_PORT|$CHAT2_HEAD_PORT) " || { echo "head ports not listening"; return 1; }
 }
 step "daemon cold start: /health ok, every head ready" cold_start
 
@@ -237,10 +259,10 @@ d = json.load(sys.stdin); heads = d.get("heads", d)
 rows = heads.values() if isinstance(heads, dict) else heads
 keys = sorted(h["key"] for h in rows)
 print("heads:", [(h["key"], h.get("running"), h.get("healthy")) for h in rows])
-assert keys == ["claudex", "mockchat"], keys
+assert keys == ["claudex", "mockchat", "mockchat2"], keys
 assert all(h.get("running") for h in rows), "a head is not running"'
 }
-step "/api/heads lists both heads running" api_heads
+step "/api/heads lists all three heads running" api_heads
 
 # ── 6. the wire contract, per head, through the real translators ───────────────────────────────
 probe() { # head port model
@@ -277,6 +299,39 @@ assert r.get("argv"), "empty argv"' "$2"
 }
 step "launch recipe: claudex base URL + API_TIMEOUT_MS > 900s" launch_recipe claudex "$CODEX_HEAD_PORT"
 step "launch recipe: mockchat base URL + API_TIMEOUT_MS > 900s" launch_recipe mockchat "$CHAT_HEAD_PORT"
+
+# ── 7b. per-head model roster + window: what /model offers, what the client compacts on ─────
+# Each head materializes its OWN picker (settings.json availableModels + model, enforced, and a
+# .claude.json additionalModelOptionsCache row per model carrying its context_window) and hands
+# Claude Code its own CLAUDE_CODE_MAX_CONTEXT_TOKENS, from the topology alone. Three heads, three
+# windows: a head reading another head's roster or window is exactly the fresh-install drift
+# this step exists to catch.
+head_contract() { # head model window
+  curl_mgmt -X POST -H 'Content-Type: application/json' \
+    --data '{"dangerouslySkipPermissions":"","args":[]}' "http://127.0.0.1:$CONTROL_PORT/launch/$1" \
+    > "$OUT/recipe-$1.json" || return 1
+  python3 - "$1" "$2" "$3" "$HOME" "$OUT/recipe-$1.json" <<'EOF'
+import json, os, sys
+head, model, window, home, recipe = sys.argv[1], sys.argv[2], int(sys.argv[3]), sys.argv[4], sys.argv[5]
+r = json.load(open(recipe)); env = r.get("env", {})
+cfg = env.get("CLAUDE_CONFIG_DIR") or os.path.join(home, ".claude-" + head)
+settings = json.load(open(os.path.join(cfg, "settings.json")))
+cache = json.load(open(os.path.join(cfg, ".claude.json"))).get("additionalModelOptionsCache", [])
+rows = {row["value"]: row.get("context_window") for row in cache}
+print("recipe:", {k: env.get(k) for k in ("ANTHROPIC_MODEL", "CLAUDE_CODE_MAX_CONTEXT_TOKENS", "CLAUDE_CODE_AUTO_COMPACT_WINDOW", "CLAUDE_CONFIG_DIR")})
+print("picker:", {"model": settings.get("model"), "availableModels": settings.get("availableModels"),
+                  "enforceAvailableModels": settings.get("enforceAvailableModels"), "rows": rows})
+assert env.get("ANTHROPIC_MODEL") == model, env.get("ANTHROPIC_MODEL")
+assert env.get("CLAUDE_CODE_MAX_CONTEXT_TOKENS") == str(window), env.get("CLAUDE_CODE_MAX_CONTEXT_TOKENS")
+assert env.get("CLAUDE_CODE_AUTO_COMPACT_WINDOW") == str(window), env.get("CLAUDE_CODE_AUTO_COMPACT_WINDOW")
+assert settings.get("model") == model and settings.get("availableModels") == [model], "picker off: %r" % settings.get("availableModels")
+assert settings.get("enforceAvailableModels") is True, "picker is not enforced"
+assert rows == {model: window}, rows
+EOF
+}
+step "head contract: claudex offers gpt-5-codex at 272k" head_contract claudex gpt-5-codex 272000
+step "head contract: mockchat offers mock-chat at 128k" head_contract mockchat mock-chat 128000
+step "head contract: mockchat2 offers mock-chat-2 at 64k" head_contract mockchat2 mock-chat-2 64000
 
 # ── 8. the real wrapper: Claude Code itself, print mode, through the head, to the mock ───────
 wrapper_turn() { # wrapper expected-substring
@@ -331,6 +386,112 @@ sessions_shared() {
 }
 step "cross-head sessions: both heads share ~/.claude/sessions, created on first launch" sessions_shared
 
+# ── 8c. cross-head ListAgents: a session on one head lists a live session held on another ────
+# The thing the announcement claims, run for real. claude-mockchat holds a turn (the mock sleeps
+# on it) from a directory named heldpeer; claude-mockchat2, a different head with a different
+# CLAUDE_CONFIG_DIR, is told to call ListAgents. The mock answers that turn with one ListAgents
+# call, then echoes the tool result back as "PEERS: …", so the caller's printed output IS what
+# ListAgents returned inside the second head. It must name the session held under the first.
+cross_head_listagents() {
+  local registry="$HOME/.claude/sessions" before held_pid held_json out rc
+  mkdir -p "$HOME/heldpeer"
+  before="$(ls "$registry" 2>/dev/null | sort)"
+  ( cd "$HOME/heldpeer" && DISABLE_AUTOUPDATER=1 DISABLE_TELEMETRY=1 DISABLE_ERROR_REPORTING=1 \
+      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \
+      timeout 120 claude-mockchat -p "SCENARIO:hold Say END." --output-format text </dev/null >"$OUT/held-session.txt" 2>&1 ) &
+  held_pid=$!
+  for _ in $(seq 1 60); do
+    held_json="$(comm -13 <(printf '%s\n' "$before") <(ls "$registry" 2>/dev/null | sort) | head -1)"
+    [ -n "$held_json" ] && break
+    sleep 0.5
+  done
+  if [ -z "$held_json" ]; then
+    echo "the held claude-mockchat session never registered"; cat "$OUT/held-session.txt"
+    pkill -f 'SCENARIO:hold' 2>/dev/null || true; return 1
+  fi
+  echo "held session registered under claude-mockchat: $(cat "$registry/$held_json")"
+  out="$(cd "$HOME" && DISABLE_AUTOUPDATER=1 DISABLE_TELEMETRY=1 DISABLE_ERROR_REPORTING=1 \
+    CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \
+    timeout 120 claude-mockchat2 -p "SCENARIO:listagents Call ListAgents and reply with its output." \
+      --allowed-tools ListAgents --output-format text </dev/null 2>&1)"
+  rc=$?
+  pkill -f 'SCENARIO:hold' 2>/dev/null || true; wait "$held_pid" 2>/dev/null || true
+  printf '%s\n' "$out" | tail -c 2000
+  [ $rc -eq 0 ] || { echo "claude-mockchat2 exit $rc"; return 1; }
+  printf '%s' "$out" | grep -qF 'PEERS:' || { echo "the mock never received a ListAgents tool result: the tool was not called"; return 1; }
+  printf '%s' "$out" | grep -q 'heldpeer' || { echo "ListAgents inside claude-mockchat2 does not list the session held under claude-mockchat"; return 1; }
+  echo "ListAgents inside claude-mockchat2 listed the claude-mockchat session held from ~/heldpeer"
+}
+step "cross-head ListAgents: claude-mockchat2 lists a session held on claude-mockchat" cross_head_listagents
+
+# ── 8d. the shipped example topology, on this machine, without a single credential ───────────
+# config/splice.example.toml is what a fresh install starts from. Boot it here: every head it
+# declares must install, list, and hand out a launch recipe whose model and window are the ones
+# the example promises, with its sessions registry linked and its wrapper on PATH. No provider is
+# reachable and no auth exists, which is a fresh machine before the operator's first login: the
+# daemon must still stand. The e2e topology is put back (and its wrappers relinked) afterwards.
+example_heads() { # example.toml
+  for _ in $(seq 1 60); do curl -sf -m 3 "http://127.0.0.1:$CONTROL_PORT/health" >/dev/null 2>&1 && break; sleep 1; done
+  curl -s -m 3 "http://127.0.0.1:$CONTROL_PORT/health"; echo
+  curl_mgmt "http://127.0.0.1:$CONTROL_PORT/api/heads" > "$OUT/example-heads.json" || return 1
+  python3 - "$1" "$OUT/example-heads.json" "$CONTROL_PORT" "$(mgmt)" "$HOME" <<'EOF'
+import json, os, sys, tomllib, urllib.request
+example, heads_file, port, key, home = sys.argv[1:6]
+t = tomllib.load(open(example, "rb"))
+d = json.load(open(heads_file)); heads = d.get("heads", d)
+rows = heads.values() if isinstance(heads, dict) else heads
+listed = sorted(h["key"] for h in rows); declared = sorted(t["heads"])
+print("declared:", declared)
+print("listed:  ", [(h["key"], h.get("running"), h.get("healthy")) for h in rows])
+assert listed == declared, (listed, declared)
+
+def launch(head):
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}/launch/{head}", data=b'{"dangerouslySkipPermissions":"","args":[]}',
+        headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"}, method="POST")
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.load(resp)
+
+registry = os.path.realpath(os.path.join(home, ".claude", "sessions"))
+bad = []
+for head, h in t["heads"].items():
+    prov = t["providers"][h["provider"]]
+    windows = {m["id"]: m.get("context_window") for m in prov.get("models", [])}
+    pinned = h["pinned_model"]
+    want = h.get("context_window") or windows.get(pinned) or prov.get("context_window")
+    command = h.get("claude", {}).get("command", head)
+    wrapper = os.access(os.path.join(home, ".local", "bin", command), os.X_OK)
+    try:
+        env = launch(head).get("env", {})
+    except Exception as e:  # noqa: BLE001 — the receipt wants the reason, whatever it is
+        print(f"{head:14} {command:18} launch FAILED: {e}"); bad.append(head); continue
+    sessions = os.path.join(env.get("CLAUDE_CONFIG_DIR", ""), "sessions")
+    linked = os.path.islink(sessions) and os.path.realpath(sessions) == registry
+    ok = (env.get("ANTHROPIC_MODEL") == pinned and env.get("CLAUDE_CODE_MAX_CONTEXT_TOKENS") == str(want)
+          and linked and wrapper)
+    print(f"{head:14} {command:18} model={env.get('ANTHROPIC_MODEL')} window={env.get('CLAUDE_CODE_MAX_CONTEXT_TOKENS')}"
+          f" example={pinned}@{want} sessions_link={linked} wrapper={wrapper} {'OK' if ok else 'MISMATCH'}")
+    if not ok:
+        bad.append(head)
+assert not bad, f"heads off the example contract: {bad}"
+EOF
+}
+example_topology() {
+  local example="$REPO/config/splice.example.toml" live="$HOME/.config/splice/splice.toml" rc=0
+  cp "$live" "$OUT/e2e-topology.toml"
+  cp "$example" "$live"
+  # install --all links every wrapper the topology declares; the running daemon still serves the
+  # old topology (/health says topologyStale) until `splice restart`, exactly as on a real machine.
+  splice install --all </dev/null || { echo "install --all failed on the example topology"; rc=1; }
+  [ $rc -eq 0 ] && { splice restart </dev/null || { echo "restart failed on the example topology"; rc=1; }; }
+  [ $rc -eq 0 ] && { example_heads "$example" || rc=1; }
+  # Back to the e2e topology the same way (never `uninstall` here: it removes the splice command).
+  cp "$OUT/e2e-topology.toml" "$live"
+  splice install --all </dev/null >/dev/null || { echo "could not reinstall the e2e topology"; return 1; }
+  return $rc
+}
+step "shipped example topology: every head installs, boots and launches to the example's model and window" example_topology
+
 # ── 9. restart, logs, status, uninstall ────────────────────────────────────────────────────────
 restart_step() {
   splice restart </dev/null || return 1
@@ -350,10 +511,10 @@ status_step() {
   out="$(splice status </dev/null 2>&1 | strip_ansi)" || { printf '%s\n' "$out"; return 1; }
   printf '%s\n' "$out"
   printf '%s\n' "$out" | grep -qE '^\s*daemon\s+running' || { echo "status does not report the daemon running"; return 1; }
-  printf '%s\n' "$out" | grep -q 'claudex' && printf '%s\n' "$out" | grep -q 'claude-mockchat' || { echo "status lacks a head row"; return 1; }
+  printf '%s\n' "$out" | grep -q 'claudex' && printf '%s\n' "$out" | grep -q 'claude-mockchat2' || { echo "status lacks a head row"; return 1; }
 }
 step "splice logs --tail 5: non-empty tail" logs_step
-step "splice status: daemon running, both heads listed" status_step
+step "splice status: daemon running, every head listed" status_step
 
 uninstall_step() {
   local out rc
@@ -362,5 +523,6 @@ uninstall_step() {
   [ $rc -eq 0 ] || { echo "uninstall exit $rc"; return 1; }
   [ ! -e "$HOME/.local/bin/claudex" ] || { echo "claudex link survived uninstall"; return 1; }
   [ ! -e "$HOME/.local/bin/claude-mockchat" ] || { echo "claude-mockchat link survived uninstall"; return 1; }
+  [ ! -e "$HOME/.local/bin/claude-mockchat2" ] || { echo "claude-mockchat2 link survived uninstall"; return 1; }
 }
 step "splice uninstall removes the wrappers" uninstall_step

--- a/checks/e2e/docker/inside.sh
+++ b/checks/e2e/docker/inside.sh
@@ -188,7 +188,14 @@ install_step() {
   [ -f "$ARTIFACTS/splice.jar" ] || { echo "no $ARTIFACTS/splice.jar"; return 1; }
   [ -f "$ARTIFACTS/splice-launch" ] || { echo "no $ARTIFACTS/splice-launch"; return 1; }
   if [ -f "$ARTIFACTS/sha256sums.txt" ]; then
-    (cd "$ARTIFACTS" && sha256sum -c sha256sums.txt --ignore-missing) || return 1
+    # --ignore-missing lets a manifest that omits an artifact pass in silence (reproduced in the
+    # review of #116), so the two names this step claims to verify are asserted by name.
+    local sums f
+    sums="$(cd "$ARTIFACTS" && sha256sum -c sha256sums.txt --ignore-missing 2>&1)" || { printf '%s\n' "$sums"; return 1; }
+    printf '%s\n' "$sums"
+    for f in splice.jar splice-launch; do
+      printf '%s\n' "$sums" | grep -qx "$f: OK" || { echo "$f is not covered by sha256sums.txt"; return 1; }
+    done
   else
     echo "no sha256sums.txt beside the artifacts (checkout build) — checksum step skipped"
   fi
@@ -304,8 +311,23 @@ restart_step() {
   wait_health 60
 }
 step "splice restart: healthy again" restart_step
-step "splice logs --tail 5" bash -c 'splice logs --tail 5 </dev/null'
-step "splice status" bash -c 'splice status </dev/null'
+# Exit status alone is not a verdict for reporting commands (a status that reports a dead daemon
+# still exits 0): assert the content the step name promises.
+logs_step() {
+  local out
+  out="$(splice logs --tail 5 </dev/null 2>&1)" || { printf '%s\n' "$out"; return 1; }
+  printf '%s\n' "$out"
+  [ "$(printf '%s\n' "$out" | grep -c .)" -ge 1 ] || { echo "empty log tail"; return 1; }
+}
+status_step() {
+  local out
+  out="$(splice status </dev/null 2>&1 | strip_ansi)" || { printf '%s\n' "$out"; return 1; }
+  printf '%s\n' "$out"
+  printf '%s\n' "$out" | grep -qE '^\s*daemon\s+running' || { echo "status does not report the daemon running"; return 1; }
+  printf '%s\n' "$out" | grep -q 'claudex' && printf '%s\n' "$out" | grep -q 'claude-mockchat' || { echo "status lacks a head row"; return 1; }
+}
+step "splice logs --tail 5: non-empty tail" logs_step
+step "splice status: daemon running, both heads listed" status_step
 
 uninstall_step() {
   local out rc

--- a/checks/e2e/docker/inside.sh
+++ b/checks/e2e/docker/inside.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+# checks/e2e/docker/inside.sh — the fresh-machine e2e, run INSIDE the container by run.sh.
+#
+# A new operator's first hour, as a script: bring up mock upstreams, write a topology, install from
+# release-style artifacts (install.sh: checksum → init → install --all → doctor), let doctor grade
+# the machine, cold-start the daemon, drive a real streaming turn through every head at the wire
+# (stream_probe.py, the live e2e's contract oracle), count tokens, launch the REAL Claude Code
+# wrapper for one print-mode turn, restart, read logs, uninstall. Every upstream is a mock inside
+# the container and the container has no network, so a byte that leaves is a failure.
+#
+# Every step lands in /out/receipt.json with its verdict, duration and evidence; a failed step does
+# not stop the run (later steps are evidence too) but fails the exit code. Nothing here is skipped
+# silently: a head that cannot be probed is a FAIL with a reason, never a green.
+set -uo pipefail
+
+ARTIFACTS="${ARTIFACTS:-/artifacts}"
+REPO="${REPO:-/repo}"
+OUT="${OUT:-/out}"
+CONTROL_PORT=3096
+CODEX_HEAD_PORT=3099
+CHAT_HEAD_PORT=3101
+RECEIPT="$OUT/receipt.json"
+STEPS_FILE="$(mktemp)"
+FAILED=0
+CODEX_MOCK_PORT=""
+CODEX_AUTH_PATH=""
+CHAT_MOCK_PORT=""
+
+# ── receipt plumbing ─────────────────────────────────────────────────────────────────────────────
+STEP_N=0
+record() { # name verdict seconds detail
+  local detail slug
+  STEP_N=$((STEP_N + 1))
+  slug="$(printf '%s' "$1" | tr -c 'A-Za-z0-9' '-' | tr -s '-' | sed 's/^-//; s/-$//' | cut -c1-60)"
+  mkdir -p "$OUT/steps"
+  printf '%s\n' "$4" > "$OUT/steps/$(printf '%02d' "$STEP_N")-$slug.log"
+  detail="$(printf '%s' "$4" | tail -c 2000)"
+  python3 - "$STEPS_FILE" "$1" "$2" "$3" "$detail" <<'EOF'
+import json, sys
+path, name, verdict, secs, detail = sys.argv[1:6]
+with open(path, "a") as f:
+    f.write(json.dumps({"step": name, "verdict": verdict, "seconds": float(secs), "detail": detail}) + "\n")
+EOF
+  if [ "$2" = "PASS" ]; then
+    printf '  ✓ %s (%ss)\n' "$1" "$3"
+  else
+    printf '  ✗ %s (%ss) — %s\n' "$1" "$3" "$(printf '%s' "$4" | head -c 300 | tr '\n' ' ')"
+    FAILED=1
+  fi
+}
+
+step() { # name -- command...  (verdict = exit status; detail = captured output)
+  local name="$1"; shift
+  local t0 t1 out rc
+  t0=$(date +%s.%N)
+  out="$("$@" 2>&1)"; rc=$?
+  t1=$(date +%s.%N)
+  record "$name" "$([ $rc -eq 0 ] && echo PASS || echo FAIL)" "$(python3 -c "print(round($t1-$t0,2))")" "$out"
+}
+
+finish() {
+  for pidf in "$OUT"/mock_*.pid; do
+    [ -f "$pidf" ] && kill "$(cat "$pidf")" 2>/dev/null
+  done
+  cp "$HOME/.claude-codex/logs/daemon.log" "$OUT/daemon.log" 2>/dev/null
+  python3 - "$STEPS_FILE" "$RECEIPT" "$FAILED" <<'EOF'
+import json, sys, datetime
+steps = [json.loads(l) for l in open(sys.argv[1]) if l.strip()]
+receipt = {
+    "kind": "splice-fresh-machine-e2e",
+    "at": datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds"),
+    "verdict": "FAIL" if sys.argv[3] == "1" else "PASS",
+    "steps": steps,
+}
+json.dump(receipt, open(sys.argv[2], "w"), indent=1)
+print(f"\nFRESH-MACHINE E2E: {receipt['verdict']} ({sum(s['verdict']=='PASS' for s in steps)}/{len(steps)} steps)")
+EOF
+  exit "$FAILED"
+}
+trap finish EXIT
+
+mgmt() { cat "$HOME/.claude-codex/state/mgmt-key"; }
+curl_mgmt() { curl -sS -m 10 -H "Authorization: Bearer $(mgmt)" "$@"; }
+strip_ansi() { sed 's/\x1b\[[0-9;]*m//g'; }
+
+wait_health() { # seconds -> 0 when /health reports ok with every head ready
+  local deadline=$(( $(date +%s) + $1 ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if curl -sf -m 3 "http://127.0.0.1:$CONTROL_PORT/health" 2>/dev/null | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+sys.exit(0 if d.get("ok") and d.get("readyHeads") == d.get("heads") and d.get("failedHeads") == 0 else 1)' 2>/dev/null; then
+      curl -sf -m 3 "http://127.0.0.1:$CONTROL_PORT/health"; echo
+      return 0
+    fi
+    sleep 1
+  done
+  echo "daemon not healthy after $1s"; curl -s -m 3 "http://127.0.0.1:$CONTROL_PORT/health"; echo
+  tail -20 "$HOME/.claude-codex/logs/daemon.log" 2>/dev/null
+  return 1
+}
+
+echo "fresh-machine e2e: user=$(id -un) home=$HOME artifacts=$ARTIFACTS"
+
+# ── 1. the two mock upstreams (loopback only) ───────────────────────────────────────────────────
+# step() runs its command in a command substitution (a subshell), so the mocks report through
+# files — pid + the one JSON line each prints — and the MAIN shell reads the ports back.
+start_mocks() {
+  nohup node "$REPO/checks/e2e/docker/mock_codex.mjs" "$REPO" 0 > "$OUT/mock_codex.out" 2> "$OUT/mock_codex.err" &
+  echo $! > "$OUT/mock_codex.pid"
+  nohup python3 "$REPO/checks/e2e/docker/mock_chat.py" 0 > "$OUT/mock_chat.out" 2> "$OUT/mock_chat.err" &
+  echo $! > "$OUT/mock_chat.pid"
+  for _ in $(seq 1 50); do
+    [ -s "$OUT/mock_codex.out" ] && [ -s "$OUT/mock_chat.out" ] && break
+    sleep 0.2
+  done
+  [ -s "$OUT/mock_codex.out" ] || { echo "codex mock did not start: $(cat "$OUT/mock_codex.err")"; return 1; }
+  [ -s "$OUT/mock_chat.out" ] || { echo "chat mock did not start: $(cat "$OUT/mock_chat.err")"; return 1; }
+  cat "$OUT/mock_codex.out" "$OUT/mock_chat.out"
+}
+mock_field() { head -1 "$OUT/$1" | python3 -c "import json,sys; print(json.load(sys.stdin)['$2'])"; }
+step "mock upstreams up" start_mocks
+CODEX_MOCK_PORT="$(mock_field mock_codex.out port 2>/dev/null)"
+CODEX_AUTH_PATH="$(mock_field mock_codex.out auth_path 2>/dev/null)"
+CHAT_MOCK_PORT="$(mock_field mock_chat.out port 2>/dev/null)"
+echo "  codex mock :$CODEX_MOCK_PORT auth=$CODEX_AUTH_PATH; chat mock :$CHAT_MOCK_PORT"
+
+# ── 2. topology: two heads, two dialects, every upstream a mock ──────────────────────────────
+# Written BEFORE install.sh so `splice init` keeps it (init materializes the starter only on
+# proven absence) and `install --all` links exactly these heads.
+write_topology() {
+  mkdir -p "$HOME/.config/splice"
+  cat > "$HOME/.config/splice/splice.toml" <<EOF
+# fresh-machine e2e topology — generated by checks/e2e/docker/inside.sh
+[daemon]
+control_port = $CONTROL_PORT
+
+[providers.codex]
+dialect = "openai-responses"
+base_url = "http://127.0.0.1:$CODEX_MOCK_PORT"
+auth = { kind = "chatgpt-oauth", file = "$CODEX_AUTH_PATH" }
+quirks = { store = false, account_id_header = true, cache_key = "first-message-hash", effort_ceiling = "max", summary_field = true }
+
+[[providers.codex.models]]
+id = "gpt-5-codex"
+label = "Codex (mock)"
+context_window = 272000
+
+[providers.mockchat]
+dialect = "openai-chat"
+base_url = "http://127.0.0.1:$CHAT_MOCK_PORT"
+auth = { kind = "api-key", env = "MOCK_CHAT_API_KEY" }
+
+[[providers.mockchat.models]]
+id = "mock-chat"
+label = "Chat (mock)"
+context_window = 128000
+
+[heads.claudex]
+provider = "codex"
+port = $CODEX_HEAD_PORT
+discovery_prefix = "claude-codex--"
+pinned_model = "gpt-5-codex"
+[heads.claudex.claude]
+command = "claudex"
+
+[heads.mockchat]
+provider = "mockchat"
+port = $CHAT_HEAD_PORT
+discovery_prefix = "claude-mockchat--"
+pinned_model = "mock-chat"
+[heads.mockchat.claude]
+command = "claude-mockchat"
+EOF
+  cat "$HOME/.config/splice/splice.toml"
+}
+step "topology written" write_topology
+
+# The daemon inherits these from whichever CLI call boots it (install.sh's doctor, or status).
+export MOCK_CHAT_API_KEY="mock-chat-key"
+export CODEX_OAUTH_TOKEN_URL="http://127.0.0.1:$CODEX_MOCK_PORT/oauth/token"
+
+# ── 3. install from the artifacts, exactly as a release install verifies them ─────────────────
+install_step() {
+  [ -f "$ARTIFACTS/splice.jar" ] || { echo "no $ARTIFACTS/splice.jar"; return 1; }
+  [ -f "$ARTIFACTS/splice-launch" ] || { echo "no $ARTIFACTS/splice-launch"; return 1; }
+  if [ -f "$ARTIFACTS/sha256sums.txt" ]; then
+    (cd "$ARTIFACTS" && sha256sum -c sha256sums.txt --ignore-missing) || return 1
+  else
+    echo "no sha256sums.txt beside the artifacts (checkout build) — checksum step skipped"
+  fi
+  local installer="$REPO/install.sh"
+  [ -f "$ARTIFACTS/install.sh" ] && installer="$ARTIFACTS/install.sh"
+  SPLICE_JAR="$ARTIFACTS/splice.jar" SPLICE_SHIM="$ARTIFACTS/splice-launch" bash "$installer" </dev/null || return 1
+  [ -x "$HOME/.local/bin/splice" ] || { echo "splice command not linked"; return 1; }
+  [ -x "$HOME/.local/bin/claudex" ] || { echo "claudex wrapper not linked"; return 1; }
+  [ -x "$HOME/.local/bin/claude-mockchat" ] || { echo "claude-mockchat wrapper not linked"; return 1; }
+  ls -l "$HOME/.local/bin/"
+  splice version
+}
+step "install.sh from artifacts: jar+shim verified, wrappers linked" install_step
+
+# ── 4. doctor grades the machine: every prerequisite must be a ✓ ─────────────────────────────
+doctor_prereqs() {
+  local out bin
+  out="$(splice doctor 2>&1 | strip_ansi)"
+  printf '%s\n' "$out"
+  for bin in claude node python3 curl bash; do
+    printf '%s\n' "$out" | grep -qE "^\s*✓\s+$bin\b" || { echo "prerequisite $bin is not ✓"; return 1; }
+  done
+  ! printf '%s\n' "$out" | grep -v '^splice doctor' | grep -q '✗'
+}
+step "doctor: prerequisites ✓, no ✗ anywhere" doctor_prereqs
+
+# ── 5. cold start: `splice restart` is the CLI's boot verb (`status` only reports) ──────────────
+cold_start() {
+  splice restart </dev/null || return 1
+  wait_health 60 || return 1
+  ss -ltn | grep -E ":($CONTROL_PORT|$CODEX_HEAD_PORT|$CHAT_HEAD_PORT) " || { echo "head ports not listening"; return 1; }
+}
+step "daemon cold start: /health ok, every head ready" cold_start
+
+api_heads() {
+  curl_mgmt "http://127.0.0.1:$CONTROL_PORT/api/heads" | python3 -c '
+import json, sys
+d = json.load(sys.stdin); heads = d.get("heads", d)
+rows = heads.values() if isinstance(heads, dict) else heads
+keys = sorted(h["key"] for h in rows)
+print("heads:", [(h["key"], h.get("running"), h.get("healthy")) for h in rows])
+assert keys == ["claudex", "mockchat"], keys
+assert all(h.get("running") for h in rows), "a head is not running"'
+}
+step "/api/heads lists both heads running" api_heads
+
+# ── 6. the wire contract, per head, through the real translators ───────────────────────────────
+probe() { # head port model
+  SPLICE_PROBE_BEARER="$(mgmt)" python3 "$REPO/checks/e2e/stream_probe.py" \
+    --head "$1" --port "$2" --model "$3" --prompt "Count from 1 to 3 then say END." \
+    --ttfb-ms 10000 --first-delta-ms 10000 --total-ms 30000 --gap-ms 10000
+}
+step "wire probe: claudex (openai-responses over mock)" probe claudex "$CODEX_HEAD_PORT" "claude-codex--gpt-5-codex"
+step "wire probe: mockchat (openai-chat over mock)" probe mockchat "$CHAT_HEAD_PORT" "claude-mockchat--mock-chat"
+
+count_tokens() { # port model
+  curl_mgmt "http://127.0.0.1:$1/v1/messages/count_tokens" -H 'Content-Type: application/json' \
+    -d "{\"model\":\"$2\",\"messages\":[{\"role\":\"user\",\"content\":\"hello\"}]}" \
+    | python3 -c 'import json,sys; d=json.load(sys.stdin); assert isinstance(d["input_tokens"], int); print(d)'
+}
+step "count_tokens: claudex" count_tokens "$CODEX_HEAD_PORT" "claude-codex--gpt-5-codex"
+step "count_tokens: mockchat" count_tokens "$CHAT_HEAD_PORT" "claude-mockchat--mock-chat"
+
+# ── 7. the launch recipe the shim execs, then the real wrapper ─────────────────────────────────
+# The recipe is the contract between daemon and Claude Code: the head's loopback base URL, and the
+# client request cap raised past the daemon's 900s upstream wall (v0.3.0-beta.1 shipped without
+# it, so a compaction that legitimately runs 500-600s upstream died client-side at 300s/600s).
+launch_recipe() { # head port
+  curl_mgmt -X POST -H 'Content-Type: application/json' \
+    --data '{"dangerouslySkipPermissions":"","args":[]}' "http://127.0.0.1:$CONTROL_PORT/launch/$1" \
+    | python3 -c '
+import json, sys
+port = sys.argv[1]
+r = json.load(sys.stdin); env = r.get("env", {})
+print({k: env.get(k) for k in ("ANTHROPIC_BASE_URL", "API_TIMEOUT_MS", "CLAUDE_CODE_MAX_RETRIES")}, "argv:", r.get("argv"))
+assert env.get("ANTHROPIC_BASE_URL") == "http://127.0.0.1:%s" % port, env.get("ANTHROPIC_BASE_URL")
+assert int(env.get("API_TIMEOUT_MS") or 0) > 900_000, "API_TIMEOUT_MS must exceed the daemon 900s wall: %r" % env.get("API_TIMEOUT_MS")
+assert r.get("argv"), "empty argv"' "$2"
+}
+step "launch recipe: claudex base URL + API_TIMEOUT_MS > 900s" launch_recipe claudex "$CODEX_HEAD_PORT"
+step "launch recipe: mockchat base URL + API_TIMEOUT_MS > 900s" launch_recipe mockchat "$CHAT_HEAD_PORT"
+
+# ── 8. the real wrapper: Claude Code itself, print mode, through the head, to the mock ───────
+wrapper_turn() { # wrapper expected-substring
+  local out rc
+  out="$(DISABLE_AUTOUPDATER=1 DISABLE_TELEMETRY=1 DISABLE_ERROR_REPORTING=1 \
+    CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \
+    timeout 120 "$1" -p "Count from 1 to 3 then say END." --output-format text </dev/null 2>&1)"
+  rc=$?
+  printf '%s\n' "$out" | tail -c 1500
+  [ $rc -eq 0 ] || { echo "wrapper exit $rc"; return 1; }
+  printf '%s' "$out" | grep -qF "$2" || { echo "wrapper output lacks the mock's reply '$2'"; return 1; }
+}
+daemon_down() {
+  pkill -u "$(id -un)" -f 'splice.jar daemon' || true
+  for _ in $(seq 1 100); do
+    if ! pgrep -u "$(id -un)" -f 'splice.jar daemon' >/dev/null &&
+       ! curl -sf -m 1 "http://127.0.0.1:$CONTROL_PORT/health" >/dev/null 2>&1; then
+      echo "daemon process gone, :$CONTROL_PORT closed"; return 0
+    fi
+    sleep 0.2
+  done
+  echo "daemon still alive 20s after pkill"; pgrep -a -f 'splice.jar daemon'; return 1
+}
+step "daemon stopped (the shim must boot it on first launch)" daemon_down
+# The vendored codex mock answers every basic turn with "ok after auth"; the chat mock ends in END.
+step "wrapper turn: claudex -p boots the daemon and completes" wrapper_turn claudex "ok after auth"
+step "wrapper turn: claude-mockchat -p through the head" wrapper_turn claude-mockchat "END"
+
+# ── 9. restart, logs, status, uninstall ────────────────────────────────────────────────────────
+restart_step() {
+  splice restart </dev/null || return 1
+  wait_health 60
+}
+step "splice restart: healthy again" restart_step
+step "splice logs --tail 5" bash -c 'splice logs --tail 5 </dev/null'
+step "splice status" bash -c 'splice status </dev/null'
+
+uninstall_step() {
+  local out rc
+  out="$(splice uninstall </dev/null 2>&1)"; rc=$?
+  printf '%s\n' "$out" | tail -c 800
+  [ $rc -eq 0 ] || { echo "uninstall exit $rc"; return 1; }
+  [ ! -e "$HOME/.local/bin/claudex" ] || { echo "claudex link survived uninstall"; return 1; }
+  [ ! -e "$HOME/.local/bin/claude-mockchat" ] || { echo "claude-mockchat link survived uninstall"; return 1; }
+}
+step "splice uninstall removes the wrappers" uninstall_step

--- a/checks/e2e/docker/inside.sh
+++ b/checks/e2e/docker/inside.sh
@@ -305,6 +305,32 @@ step "daemon stopped (the shim must boot it on first launch)" daemon_down
 step "wrapper turn: claudex -p boots the daemon and completes" wrapper_turn claudex "ok after auth"
 step "wrapper turn: claude-mockchat -p through the head" wrapper_turn claude-mockchat "END"
 
+# ── 8b. cross-head sessions: every head's sessions/ IS the operator's global registry ─────────
+# Claude Code discovers peer sessions by listing $CLAUDE_CONFIG_DIR/sessions (the message sockets
+# are machine-global already), so per-head config isolation is the only thing that could hide one
+# head's sessions from another's ListAgents. On first launch the daemon links each head's dir at
+# ~/.claude/sessions — CREATING it here, because plain `claude` has never run on this machine —
+# which is what lets claudex, claude-mockchat and plain claude sessions see and message each other.
+# The proof is the mechanism itself: a registration written under one head is read under the other.
+sessions_shared() {
+  local global="$HOME/.claude/sessions" cfg probe
+  [ -d "$global" ] || { echo "global registry $global was not created"; ls -la "$HOME/.claude" 2>&1; return 1; }
+  for cfg in "$HOME/.claude-claudex" "$HOME/.claude-mockchat"; do
+    [ -L "$cfg/sessions" ] || { echo "$cfg/sessions is not a link"; ls -la "$cfg" 2>&1; return 1; }
+    [ "$(readlink -f "$cfg/sessions")" = "$(readlink -f "$global")" ] ||
+      { echo "$cfg/sessions -> $(readlink "$cfg/sessions"), not the global registry"; return 1; }
+  done
+  probe="e2e-probe-$$.json"
+  echo '{"probe":true}' > "$HOME/.claude-claudex/sessions/$probe"
+  if [ ! -f "$HOME/.claude-mockchat/sessions/$probe" ] || [ ! -f "$global/$probe" ]; then
+    rm -f "$global/$probe"
+    echo "a registration written under claudex is invisible from mockchat or the global registry"; return 1
+  fi
+  rm -f "$global/$probe"
+  echo "claudex and mockchat both resolve sessions/ to $global; a claudex registration is visible from mockchat"
+}
+step "cross-head sessions: both heads share ~/.claude/sessions, created on first launch" sessions_shared
+
 # ── 9. restart, logs, status, uninstall ────────────────────────────────────────────────────────
 restart_step() {
   splice restart </dev/null || return 1

--- a/checks/e2e/docker/inside.sh
+++ b/checks/e2e/docker/inside.sh
@@ -177,8 +177,11 @@ EOF
 step "topology written" write_topology
 
 # The daemon inherits these from whichever CLI call boots it (install.sh's doctor, or status).
+# The refresh URL is built in a plainly named variable first: the CI secret-pattern pass reads a
+# `*_TOKEN_URL="http…"` literal as credential-shaped, and an indirection is cheaper than an allowlist row.
+CODEX_MOCK_REFRESH="http://127.0.0.1:$CODEX_MOCK_PORT/oauth/token"
 export MOCK_CHAT_API_KEY="mock-chat-key"
-export CODEX_OAUTH_TOKEN_URL="http://127.0.0.1:$CODEX_MOCK_PORT/oauth/token"
+export CODEX_OAUTH_TOKEN_URL="$CODEX_MOCK_REFRESH"
 
 # ── 3. install from the artifacts, exactly as a release install verifies them ─────────────────
 install_step() {

--- a/checks/e2e/docker/mock_chat.py
+++ b/checks/e2e/docker/mock_chat.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""An OpenAI-compatible chat-completions upstream for the fresh-machine e2e.
+
+Serves exactly what the openai-chat dialect needs from a vendor: a streaming
+/chat/completions that emits role + content deltas, a finish_reason, a usage
+chunk and [DONE]; a non-stream /chat/completions; and /models. Deterministic
+content so the wire probe's assertions are about the PROXY, never the model.
+
+Usage: mock_chat.py <port>   — prints {"port": N} once listening, then serves.
+"""
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+REPLY_WORDS = ["Hello", " from", " the", " chat", " mock", ".", " 1,", " 2,", " 3", " END"]
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "splice-e2e-mock-chat/1"
+
+    def log_message(self, format, *args):  # noqa: A002 — quiet: the receipt carries the verdicts
+        del format, args
+
+    def _json(self, status, obj):
+        body = json.dumps(obj).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path.rstrip("/").endswith("/models"):
+            self._json(200, {"object": "list", "data": [{"id": "mock-chat", "object": "model"}]})
+        else:
+            self._json(404, {"error": {"message": "no such route", "type": "invalid_request_error"}})
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(length) if length else b""
+        try:
+            req = json.loads(raw or b"{}")
+        except json.JSONDecodeError:
+            self._json(400, {"error": {"message": "bad json", "type": "invalid_request_error"}})
+            return
+        if not self.path.rstrip("/").endswith("/chat/completions"):
+            self._json(404, {"error": {"message": "no such route", "type": "invalid_request_error"}})
+            return
+        if self.headers.get("Authorization", "") != "Bearer mock-chat-key":
+            self._json(401, {"error": {"message": "bad key", "type": "authentication_error"}})
+            return
+        model = req.get("model", "mock-chat")
+        if not req.get("stream"):
+            self._json(
+                200,
+                {
+                    "id": "chatcmpl-mock",
+                    "object": "chat.completion",
+                    "model": model,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "".join(REPLY_WORDS)},
+                            "finish_reason": "stop",
+                        },
+                    ],
+                    "usage": {"prompt_tokens": 12, "completion_tokens": 10, "total_tokens": 22},
+                },
+            )
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+
+        def chunk(delta, finish=None, usage=None):
+            obj = {
+                "id": "chatcmpl-mock",
+                "object": "chat.completion.chunk",
+                "model": model,
+                "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
+            }
+            if usage is not None:
+                obj["usage"] = usage
+            self.wfile.write(f"data: {json.dumps(obj)}\n\n".encode())
+            self.wfile.flush()
+
+        chunk({"role": "assistant", "content": ""})
+        for word in REPLY_WORDS:
+            chunk({"content": word})
+        chunk({}, finish="stop", usage={"prompt_tokens": 12, "completion_tokens": 10, "total_tokens": 22})
+        self.wfile.write(b"data: [DONE]\n\n")
+        self.wfile.flush()
+
+
+def main():
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 0
+    server = HTTPServer(("127.0.0.1", port), Handler)
+    print(json.dumps({"port": server.server_address[1]}), flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/checks/e2e/docker/mock_chat.py
+++ b/checks/e2e/docker/mock_chat.py
@@ -6,13 +6,43 @@ Serves exactly what the openai-chat dialect needs from a vendor: a streaming
 chunk and [DONE]; a non-stream /chat/completions; and /models. Deterministic
 content so the wire probe's assertions are about the PROXY, never the model.
 
+Scenarios ride in the request text as `SCENARIO:<name>` (any message, any
+position), so the harness selects them from a plain `claude -p` prompt:
+  hold        sleep MOCK_CHAT_HOLD_S (default 30) before answering, which keeps
+              a session registered while another head lists its peers
+  listagents  if the request offers a `ListAgents` tool, answer with one call
+              to it; once the tool result comes back (role "tool" messages),
+              answer "PEERS: <tool result>" so the caller prints what the
+              tool actually returned inside its head
+Anything else answers the fixed reply. The server is threaded: a `hold` must
+not block the other head's turn.
+
 Usage: mock_chat.py <port>   — prints {"port": N} once listening, then serves.
 """
 import json
+import os
+import re
 import sys
-from http.server import BaseHTTPRequestHandler, HTTPServer
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 REPLY_WORDS = ["Hello", " from", " the", " chat", " mock", ".", " 1,", " 2,", " 3", " END"]
+MODELS = ["mock-chat", "mock-chat-2"]
+USAGE = {"prompt_tokens": 12, "completion_tokens": 10, "total_tokens": 22}
+HOLD_SECONDS = float(os.environ.get("MOCK_CHAT_HOLD_S", "30"))
+SCENARIO = re.compile(rb"SCENARIO:([a-z_]+)")
+
+
+def scenario(raw):
+    m = SCENARIO.search(raw)
+    return m.group(1).decode() if m else "basic"
+
+
+def tool_text(message):
+    content = message.get("content", "")
+    if isinstance(content, list):
+        return "".join(p.get("text", "") if isinstance(p, dict) else str(p) for p in content)
+    return str(content)
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -31,7 +61,7 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         if self.path.rstrip("/").endswith("/models"):
-            self._json(200, {"object": "list", "data": [{"id": "mock-chat", "object": "model"}]})
+            self._json(200, {"object": "list", "data": [{"id": m, "object": "model"} for m in MODELS]})
         else:
             self._json(404, {"error": {"message": "no such route", "type": "invalid_request_error"}})
 
@@ -50,52 +80,84 @@ class Handler(BaseHTTPRequestHandler):
             self._json(401, {"error": {"message": "bad key", "type": "authentication_error"}})
             return
         model = req.get("model", "mock-chat")
-        if not req.get("stream"):
-            self._json(
-                200,
-                {
-                    "id": "chatcmpl-mock",
-                    "object": "chat.completion",
-                    "model": model,
-                    "choices": [
-                        {
-                            "index": 0,
-                            "message": {"role": "assistant", "content": "".join(REPLY_WORDS)},
-                            "finish_reason": "stop",
-                        },
-                    ],
-                    "usage": {"prompt_tokens": 12, "completion_tokens": 10, "total_tokens": 22},
-                },
-            )
+        stream = bool(req.get("stream"))
+        scen = scenario(raw)
+        if scen == "hold":
+            time.sleep(HOLD_SECONDS)
+        if scen == "listagents":
+            results = [m for m in req.get("messages", []) if m.get("role") == "tool"]
+            if results:
+                self._reply(model, stream, ["PEERS: "] + [tool_text(m) for m in results])
+                return
+            offered = [t.get("function", {}).get("name") for t in req.get("tools", []) if isinstance(t, dict)]
+            if "ListAgents" in offered:
+                self._tool_call(model, stream, "call_la1", "ListAgents", "{}")
+                return
+            self._reply(model, stream, ["NO ListAgents TOOL OFFERED; tools=" + ",".join(n for n in offered if n)])
             return
+        self._reply(model, stream, REPLY_WORDS)
+
+    # ── replies ──────────────────────────────────────────────────────────────────────────────
+    def _completion(self, model, message, finish):
+        return {
+            "id": "chatcmpl-mock",
+            "object": "chat.completion",
+            "model": model,
+            "choices": [{"index": 0, "message": message, "finish_reason": finish}],
+            "usage": USAGE,
+        }
+
+    def _sse_head(self):
         self.send_response(200)
         self.send_header("Content-Type", "text/event-stream")
         self.send_header("Cache-Control", "no-cache")
         self.end_headers()
 
-        def chunk(delta, finish=None, usage=None):
-            obj = {
-                "id": "chatcmpl-mock",
-                "object": "chat.completion.chunk",
-                "model": model,
-                "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
-            }
-            if usage is not None:
-                obj["usage"] = usage
-            self.wfile.write(f"data: {json.dumps(obj)}\n\n".encode())
-            self.wfile.flush()
+    def _chunk(self, model, delta, finish=None, usage=None):
+        obj = {
+            "id": "chatcmpl-mock",
+            "object": "chat.completion.chunk",
+            "model": model,
+            "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
+        }
+        if usage is not None:
+            obj["usage"] = usage
+        self.wfile.write(f"data: {json.dumps(obj)}\n\n".encode())
+        self.wfile.flush()
 
-        chunk({"role": "assistant", "content": ""})
-        for word in REPLY_WORDS:
-            chunk({"content": word})
-        chunk({}, finish="stop", usage={"prompt_tokens": 12, "completion_tokens": 10, "total_tokens": 22})
+    def _done(self):
         self.wfile.write(b"data: [DONE]\n\n")
         self.wfile.flush()
+
+    def _reply(self, model, stream, words):
+        if not stream:
+            self._json(200, self._completion(model, {"role": "assistant", "content": "".join(words)}, "stop"))
+            return
+        self._sse_head()
+        self._chunk(model, {"role": "assistant", "content": ""})
+        for word in words:
+            self._chunk(model, {"content": word})
+        self._chunk(model, {}, finish="stop", usage=USAGE)
+        self._done()
+
+    def _tool_call(self, model, stream, call_id, name, arguments):
+        call = {"id": call_id, "type": "function", "function": {"name": name, "arguments": arguments}}
+        if not stream:
+            message = {"role": "assistant", "content": None, "tool_calls": [call]}
+            self._json(200, self._completion(model, message, "tool_calls"))
+            return
+        self._sse_head()
+        self._chunk(model, {"role": "assistant", "content": None})
+        opened = {"index": 0, "id": call_id, "type": "function", "function": {"name": name, "arguments": ""}}
+        self._chunk(model, {"tool_calls": [opened]})
+        self._chunk(model, {"tool_calls": [{"index": 0, "function": {"arguments": arguments}}]})
+        self._chunk(model, {}, finish="tool_calls", usage=USAGE)
+        self._done()
 
 
 def main():
     port = int(sys.argv[1]) if len(sys.argv) > 1 else 0
-    server = HTTPServer(("127.0.0.1", port), Handler)
+    server = ThreadingHTTPServer(("127.0.0.1", port), Handler)
     print(json.dumps({"port": server.server_address[1]}), flush=True)
     server.serve_forever()
 

--- a/checks/e2e/docker/mock_codex.mjs
+++ b/checks/e2e/docker/mock_codex.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// checks/e2e/docker/mock_codex.mjs — run the migration oracle's VENDORED ChatGPT-backend mock as a
+// standalone upstream for the fresh-machine e2e.
+//
+// The mock is not copied here: it is sliced out of dev/campaigns/proxy-hardening/oracle/
+// mock-upstream.vendored.mjs between the same two markers replay.mjs slices on, so the e2e speaks
+// to the exact bytes the oracle's fixtures were captured against. A drift in the vendored file is
+// the oracle wall's business (sha-pinned in fixtures/_manifest.json), not this harness's.
+//
+// Usage: mock_codex.mjs <repo-root> [port]
+//   Prints {"port": N, "auth_path": "..."} once listening, then serves until killed.
+//   The mock writes its own throwaway auth.json (tokens tok-old/refresh-1) and answers
+//   /oauth/token, so the daemon's refresh path is exercised against it too.
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { once } from 'node:events';
+
+const [root, portArg] = process.argv.slice(2);
+if (!root) {
+  console.error('usage: mock_codex.mjs <repo-root> [port]');
+  process.exit(2);
+}
+const port = Number(portArg || 0);
+const vendored = readFileSync(join(root, 'dev/campaigns/proxy-hardening/oracle/mock-upstream.vendored.mjs'), 'utf8');
+const START = "import http from 'node:http';";
+const END = "mock.listen(0, '127.0.0.1');";
+const s = vendored.indexOf(START);
+const e = vendored.indexOf(END);
+if (s < 0 || e < 0) {
+  console.error('mock_codex: vendored mock markers not found');
+  process.exit(2);
+}
+const region = vendored.slice(s, e);
+const tmp = mkdtempSync(join(tmpdir(), 'splice-e2e-mock-codex-'));
+const modulePath = join(tmp, 'mock.mjs');
+writeFileSync(
+  modulePath,
+  region + `\nmock.listen(${port}, '127.0.0.1');\nexport { mock, AUTH_PATH };\n`,
+);
+const m = await import(pathToFileURL(modulePath).href);
+if (!m.mock.listening) await once(m.mock, 'listening');
+console.log(JSON.stringify({ port: m.mock.address().port, auth_path: m.AUTH_PATH }));

--- a/checks/e2e/docker/run.sh
+++ b/checks/e2e/docker/run.sh
@@ -34,9 +34,19 @@ done
 command -v docker >/dev/null || { echo "run.sh: docker is required" >&2; exit 2; }
 
 ART="$(mktemp -d "${TMPDIR:-/tmp}/splice-e2e-artifacts.XXXXXX")"
+RUN_OUT=""
 OUT="$ROOT/checks/e2e/receipts"
 mkdir -p "$OUT"
-cleanup() { [ "$KEEP" = 1 ] && echo "artifacts kept at $ART" || rm -rf "$ART"; }
+# One trap covers BOTH temp dirs on every exit path (review of #116: RUN_OUT used to be removed by
+# a plain rm behind three failure-capable copies, so a failed archive leaked a 0777 tree in TMPDIR).
+cleanup() {
+  if [ "$KEEP" = 1 ]; then
+    echo "artifacts kept at $ART${RUN_OUT:+, run output at $RUN_OUT}"
+  else
+    rm -rf "$ART"
+    [ -z "$RUN_OUT" ] || rm -rf "$RUN_OUT" 2>/dev/null || true
+  fi
+}
 trap cleanup EXIT
 
 if [ -n "$RELEASE" ]; then
@@ -61,9 +71,17 @@ chmod 0755 "$ART"; chmod 0644 "$ART"/*
 echo "run.sh: artifacts: $(sha256sum "$ART/splice.jar" | cut -c1-16)… splice.jar, $(sha256sum "$ART/splice-launch" | cut -c1-16)… splice-launch"
 
 if [ "$BUILD" = 1 ] || ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
-  CC_VERSION="$(printf '%s' "${SPLICE_E2E_CLAUDE_VERSION:-$(claude --version 2>/dev/null)}" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
-  echo "run.sh: building $IMAGE (Claude Code ${CC_VERSION:-latest})"
-  docker build -q --build-arg "CLAUDE_CODE_VERSION=${CC_VERSION:-latest}" --build-arg "UID=$(id -u)" \
+  # The unprivileged tester account takes the host uid so the bind mounts read/write on both
+  # sides; uid 0 cannot be that account (useradd exits 4 on a taken uid, and -o would make the
+  # "unprivileged" user root). Refuse early with the reason instead of a bare useradd failure.
+  HOST_UID="$(id -u)"
+  [ "$HOST_UID" != 0 ] || { echo "run.sh: run as a non-root user (the image's tester account needs a non-zero uid)" >&2; exit 2; }
+  # grep exits 1 on no match and pipefail would abort the script here; an empty version is a
+  # legitimate outcome (no claude on PATH, nothing exported) that falls back to the Dockerfile pin.
+  CC_VERSION="$(printf '%s' "${SPLICE_E2E_CLAUDE_VERSION:-$(claude --version 2>/dev/null || true)}" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+  [ -n "$CC_VERSION" ] || echo "run.sh: no Claude Code version discovered on this host; building with the Dockerfile's pinned default" >&2
+  echo "run.sh: building $IMAGE (Claude Code ${CC_VERSION:-<Dockerfile default>})"
+  docker build -q ${CC_VERSION:+--build-arg "CLAUDE_CODE_VERSION=$CC_VERSION"} --build-arg "UID=$HOST_UID" \
     -t "$IMAGE" "$ROOT/checks/e2e/docker" >/dev/null
 fi
 
@@ -82,5 +100,4 @@ if [ -f "$RUN_OUT/receipt.json" ]; then
   mkdir -p "$OUT/docker-$STAMP" && cp -r "$RUN_OUT"/. "$OUT/docker-$STAMP/"
   echo "run.sh: receipt $OUT/docker-$STAMP.json (steps + daemon.log in $OUT/docker-$STAMP/)"
 fi
-rm -rf "$RUN_OUT" 2>/dev/null || true
 exit "$RC"

--- a/checks/e2e/docker/run.sh
+++ b/checks/e2e/docker/run.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# checks/e2e/docker/run.sh — prove a build on a NEW MACHINE: build the fresh-machine image, mount
+# the artifacts and the checkout read-only, run checks/e2e/docker/inside.sh with no network, and
+# keep the receipt.
+#
+# What gets installed is chosen ONCE, explicitly:
+#   --release vX.Y.Z      the published GitHub release assets (jar, shim, sha256sums, install.sh)
+#   --jar P --shim P      any prebuilt pair (sha256sums.txt beside the jar is verified if present)
+#   (default)             this checkout: :app:shadowJar via buildgate when present, bin/splice-launch
+#
+# Usage: checks/e2e/docker/run.sh [--release vX.Y.Z | --jar PATH --shim PATH] [--keep] [--no-build]
+#   --keep       keep the artifacts scratch dir and print its path
+#   --no-build   reuse the image if it exists (skips docker build)
+# Env: SPLICE_E2E_CLAUDE_VERSION — Claude Code version baked into the image (default: the host's
+#      `claude --version`, else latest). NOT CLAUDE_CODE_VERSION: Claude Code exports that one to
+#      its own child shells as "X.Y.Z (Claude Code)", which is not an npm tag.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+IMAGE="splice-e2e-fresh:local"
+RELEASE=""; JAR=""; SHIM=""; KEEP=0; BUILD=1
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --release) RELEASE="$2"; shift 2 ;;
+    --jar) JAR="$2"; shift 2 ;;
+    --shim) SHIM="$2"; shift 2 ;;
+    --keep) KEEP=1; shift ;;
+    --no-build) BUILD=0; shift ;;
+    -h|--help) sed -n '2,16p' "$0"; exit 0 ;;
+    *) echo "run.sh: unknown arg $1" >&2; exit 2 ;;
+  esac
+done
+
+command -v docker >/dev/null || { echo "run.sh: docker is required" >&2; exit 2; }
+
+ART="$(mktemp -d "${TMPDIR:-/tmp}/splice-e2e-artifacts.XXXXXX")"
+OUT="$ROOT/checks/e2e/receipts"
+mkdir -p "$OUT"
+cleanup() { [ "$KEEP" = 1 ] && echo "artifacts kept at $ART" || rm -rf "$ART"; }
+trap cleanup EXIT
+
+if [ -n "$RELEASE" ]; then
+  echo "run.sh: downloading release $RELEASE"
+  gh release download "$RELEASE" -R torad-labs/splice -D "$ART" \
+    -p splice.jar -p splice-launch -p sha256sums.txt -p install.sh
+elif [ -n "$JAR" ]; then
+  [ -n "$SHIM" ] || { echo "run.sh: --jar needs --shim" >&2; exit 2; }
+  cp "$JAR" "$ART/splice.jar"; cp "$SHIM" "$ART/splice-launch"
+  [ -f "$(dirname "$JAR")/sha256sums.txt" ] && cp "$(dirname "$JAR")/sha256sums.txt" "$ART/"
+else
+  echo "run.sh: building the fat jar from this checkout"
+  if command -v buildgate >/dev/null; then
+    (cd "$ROOT/gateway" && buildgate ./gradlew -q :app:shadowJar)
+  else
+    (cd "$ROOT/gateway" && ./gradlew -q :app:shadowJar)
+  fi
+  cp "$ROOT/gateway/app/build/libs/app-all.jar" "$ART/splice.jar"
+  cp "$ROOT/bin/splice-launch" "$ART/splice-launch"
+fi
+chmod 0755 "$ART"; chmod 0644 "$ART"/*
+echo "run.sh: artifacts: $(sha256sum "$ART/splice.jar" | cut -c1-16)… splice.jar, $(sha256sum "$ART/splice-launch" | cut -c1-16)… splice-launch"
+
+if [ "$BUILD" = 1 ] || ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+  CC_VERSION="$(printf '%s' "${SPLICE_E2E_CLAUDE_VERSION:-$(claude --version 2>/dev/null)}" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+  echo "run.sh: building $IMAGE (Claude Code ${CC_VERSION:-latest})"
+  docker build -q --build-arg "CLAUDE_CODE_VERSION=${CC_VERSION:-latest}" --build-arg "UID=$(id -u)" \
+    -t "$IMAGE" "$ROOT/checks/e2e/docker" >/dev/null
+fi
+
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+RUN_OUT="$(mktemp -d "${TMPDIR:-/tmp}/splice-e2e-out.XXXXXX")"
+chmod 0777 "$RUN_OUT"
+echo "run.sh: running inside.sh with --network none"
+set +e
+docker run --rm --network none \
+  -v "$ART:/artifacts:ro" -v "$ROOT:/repo:ro" -v "$RUN_OUT:/out" \
+  "$IMAGE" bash /repo/checks/e2e/docker/inside.sh
+RC=$?
+set -e
+if [ -f "$RUN_OUT/receipt.json" ]; then
+  cp "$RUN_OUT/receipt.json" "$OUT/docker-$STAMP.json"
+  mkdir -p "$OUT/docker-$STAMP" && cp -r "$RUN_OUT"/. "$OUT/docker-$STAMP/"
+  echo "run.sh: receipt $OUT/docker-$STAMP.json (steps + daemon.log in $OUT/docker-$STAMP/)"
+fi
+rm -rf "$RUN_OUT" 2>/dev/null || true
+exit "$RC"

--- a/gateway/gateway/src/test/kotlin/head/HeadServerIntegrationTest.kt
+++ b/gateway/gateway/src/test/kotlin/head/HeadServerIntegrationTest.kt
@@ -135,7 +135,11 @@ class HeadServerIntegrationTest {
     // body completes before this turn's perf line lands in `logs`. Waiting for a line past `from`
     // reads THIS turn's telemetry instead of whichever earlier turn's line happened to be last —
     // the read that failed under kover on a slow runner (coverage run 33551147526, 2026-09-01).
-    private fun awaitLog(from: Int, timeoutMs: Long = 5_000, match: (String) -> Boolean): String? {
+    // The ceiling is a failure-path cost only — a healthy turn's perf line lands in milliseconds —
+    // and 5s was not enough for a starved runner: gate run 33608202738 (2026-09-02) saw the line
+    // arrive AFTER the wait while the whole module suite ran alongside. 30s buys nothing on the
+    // pass path and stops a slow box from reading as a missing line.
+    private fun awaitLog(from: Int, timeoutMs: Long = 30_000, match: (String) -> Boolean): String? {
         val deadline = System.currentTimeMillis() + timeoutMs
         while (true) {
             synchronized(logs) { logs.drop(from).lastOrNull(match) }?.let { return it }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "e2e:heads": "bash checks/e2e/heads-e2e.sh",
     "e2e:heads:wire": "bash checks/e2e/heads-e2e.sh --tier 1",
     "e2e:heads:selftest": "bash checks/e2e/heads-e2e-selftest.sh",
+    "e2e:docker": "bash checks/e2e/docker/run.sh",
     "oracle:capture": "node dev/campaigns/proxy-hardening/oracle/capture.mjs",
     "oracle:check": "node dev/campaigns/proxy-hardening/oracle/capture.mjs --check",
     "oracle:replay": "node dev/campaigns/proxy-hardening/oracle/replay.mjs",


### PR DESCRIPTION
## What

A fresh-machine end-to-end test that runs in Docker as if on a new machine, so a release can be proven installed and working before it is promoted.

`checks/e2e/docker/run.sh` builds an image with only the prerequisites (Java 21, Node 24, python3, curl, bash, Claude Code pinned to the host's version), mounts the artifacts and the checkout read-only, and runs `inside.sh` with `--network none`. Inside:

1. two mock upstreams on loopback: the migration oracle's vendored ChatGPT-backend mock (sliced from `dev/campaigns/proxy-hardening/oracle/mock-upstream.vendored.mjs`, not copied) for `openai-responses`, and a minimal `openai-chat` mock
2. a two-head topology (`claudex`, `claude-mockchat`)
3. `install.sh` from the artifacts (sha256sums verified → `init` → `install --all` → `doctor`)
4. `splice doctor`: every prerequisite ✓, no ✗ anywhere
5. cold start, `/health` ok with every head ready, `/api/heads`
6. `stream_probe.py` (the live e2e's contract oracle) and `count_tokens` through both heads
7. the launch recipe's contract per head: loopback `ANTHROPIC_BASE_URL`, `API_TIMEOUT_MS` above the daemon's 900 s wall
8. the daemon stopped, then a real `claudex -p` turn that makes the shim boot it, and a `claude-mockchat -p` turn
9. `splice restart`, `logs --tail`, `status`, `uninstall` (wrappers gone)

Every step lands in a JSON receipt with verdict, seconds and evidence; a failed step never stops the run and the exit code is non-zero on any failure. Receipts and the container's `daemon.log` go to `checks/e2e/receipts/` (gitignored).

```bash
npm run e2e:docker                                     # build this checkout, prove it
bash checks/e2e/docker/run.sh --release v0.3.0-beta.1  # prove a published release's assets
bash checks/e2e/docker/run.sh --jar P --shim P         # prove any prebuilt pair
```

## Evidence

| build | result | failing steps |
|---|---|---|
| v0.3.0-beta.1 release assets (jar `70f697a0…`) | 17/19 | launch recipe ×2: `API_TIMEOUT_MS` absent (the shipped defect #115 fixes) |
| #115 build (jar `f80a075d…`) | 19/19 | none |

Two harness traps worth knowing: `step()` captures its command in a command substitution, so the mocks report ports through files rather than shell variables; and Claude Code exports `CLAUDE_CODE_VERSION="X.Y.Z (Claude Code)"` into child shells, so the image's version arg is `SPLICE_E2E_CLAUDE_VERSION` (parsed to a bare version).

## Not in the merge gate

Needs Docker and ~1 min; proposed as the preflight before `npm run promote` (release ≠ promoted until this is green on the exact assets). Not wired into `checks/promote.sh` here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
