### PR TITLE
build(deps): keep the Apache HTTP client off the test classpaths

### DIFF
--- a/gateway/control/build.gradle.kts
+++ b/gateway/control/build.gradle.kts
@@ -9,7 +9,6 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.ktor.server.core)
     implementation(libs.ktor.server.netty)
-    testImplementation(libs.ktor.server.test.host)
     testImplementation(libs.ktor.client.cio)
     testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/gateway/gateway/build.gradle.kts
+++ b/gateway/gateway/build.gradle.kts
@@ -11,7 +11,13 @@ dependencies {
     implementation(libs.ktor.server.netty)
     implementation(libs.ktor.server.sse)
     implementation(libs.ktor.client.core)
-    testImplementation(libs.ktor.server.test.host)
+    testImplementation(libs.ktor.server.test.host) {
+        // The test host drags in ktor-client-apache5 (httpclient5 5.5.1 / httpcore5 5.3.6 — dependabot
+        // alerts #19, #21, #22), an engine no test here uses: testApplication's client is the
+        // in-process test engine, and every other test rides CIO. Excluded rather than pinned, so
+        // the advisories leave the graph instead of chasing it.
+        exclude(group = "io.ktor", module = "ktor-client-apache5")
+    }
     testImplementation(libs.ktor.client.cio)
     testImplementation(project(":dialect-openai-responses"))
     testImplementation(project(":dialect-anthropic-passthrough"))


### PR DESCRIPTION
## What

`ktor-server-test-host` pulls `ktor-client-apache5`, which carries `httpclient5` 5.5.1 and `httpcore5` 5.3.6, the subjects of dependabot alerts #19, #21 and #22 (two high). No test uses the Apache engine: `testApplication`'s client is the in-process test engine and every other test rides CIO.

- `:gateway` keeps the test host (AdmissionGateTest uses it) and excludes `ktor-client-apache5`.
- `:control` declared the test host and never imported it; the declaration goes.

Nothing shipped ever carried these artifacts (they were on test classpaths only). This removes them from the dependency graph so the alerts close on the next dependency submission from `main`.

## Proof

- `:gateway:test --tests '*AdmissionGateTest*'` 2/2 green with the exclusion.
- `:control:compileTestKotlin` green without the test host.
- `dependencyInsight --dependency httpcore5` on both modules' `testRuntimeClasspath`: no match.
- `checks/catalog-metadata-sync.py` clean (the catalog alias stays; verification metadata is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)