### PR TITLE
docs: describe cross-head session sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- **Heads that see each other.** Every wrapper's `sessions` directory is linked at the one registry
+  under `~/.claude/sessions` on first launch (created if plain `claude` never ran on the machine), so
+  claudex, claude-grok, claude-kimi, claude-openrouter, claude-splice and plain `claude` sessions all
+  appear in each other's `ListAgents` and can message each other with `SendMessage`: a session on one
+  backend can orchestrate a session on another. On by default through `[claude].share`;
+  `isolate = ["sessions"]` walls a head off. (Shipped in this release without a changelog entry;
+  recorded here.)
 - **`claude-splice`, the native-auth Claude head.** Claude Code keeps its own Anthropic login and
   sends the caller credential through the local passthrough head; splice never stores, reads,
   refreshes, or logs that credential. The management key is not reused on this route.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Long coding-agent sessions bleed tokens and lose the thread. splice goes after b
 What you get:
 
 - [x] A [wrapper command per backend](#quick-start): `claude-splice`, `claudex`, `claude-grok`, `claude-kimi`, `claude-openrouter`
+- [x] [Heads that see each other](#heads-that-see-each-other): every wrapper's sessions register in one shared list, so a session on one backend can find, message and orchestrate a session on another with Claude Code's own `ListAgents` and `SendMessage`
 - [x] [Provider-native reasoning display](#reasoning), without synthetic transcript mirrors
 - [x] Cache-warm compaction on the session's own model and effort
 - [x] A [fleet dashboard](#quick-start) on loopback: status, config with provenance, usage soft-warnings, logs
@@ -165,6 +166,14 @@ splice install --all  # (re)link the wrapper commands
 ```
 
 The dashboard and every control endpoint are bearer-guarded and loopback-only. The unlock key lives at `~/.claude-codex/state/mgmt-key`.
+
+## Heads that see each other
+
+Claude Code can list the other Claude Code sessions on a machine and send them messages. It discovers peers by reading the `sessions` directory inside its own config dir, and every splice head runs in its own config dir, so out of the box a claudex session would only ever see other claudex sessions.
+
+splice closes that gap on the first launch of every head. The head's `sessions` directory becomes a link to the one registry under `~/.claude/sessions`, which splice creates if plain `claude` has never run on the machine. From then on a claudex session, a claude-grok session, a claude-openrouter session and a plain `claude` session all appear in each other's `ListAgents`, and `SendMessage` reaches any of them. A session on one backend can hand work to a session on another backend and read the reply, which is how one splice install becomes a fleet of agents on different models that coordinate with each other.
+
+There is nothing to configure. `sessions` is in the default `[claude].share` list. Put it in a head's `isolate` list to wall that head off, or remove it from `share` to turn the feature off everywhere. The fresh-machine e2e checks the link on both heads of a clean install.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## What

Every head's `sessions` directory has been linked at the operator's global registry since 2026-08-25 (`SessionRegistryLink`, applied on every launch by the config materializer) and it shipped in v0.3.0-beta.1, but neither the README nor the changelog mentioned it. This is the headline of the 0.3.0 announcement, so it needs to be findable.

- README: a "what you get" line and a **Heads that see each other** section covering the mechanism, the default, the opt-out, and the e2e coverage.
- CHANGELOG: the beta.1 "Added" list gains the entry it was missing, marked as recorded after the fact.

No code changes. The matching fresh-machine e2e step lands in #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)