### PR TITLE
ci(oss): the npm audit leg retries a registry outage instead of failing the gate on it

### DIFF
--- a/checks/oss/verify-OSS-I.sh
+++ b/checks/oss/verify-OSS-I.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
-npm audit --audit-level=critical
+# The audit is a network call to registry.npmjs.org, and the registry's advisory endpoint has
+# hung for five minutes and then answered 503 mid-gate (PR #122's first run, 2026-09-04). Three
+# attempts, each capped at one minute of fetch time, absorb an outage of that shape in under four
+# minutes; a real critical advisory still fails all three and the leg stays red.
+audit_ok=0
+for attempt in 1 2 3; do
+  if npm audit --audit-level=critical --fetch-timeout=60000; then
+    audit_ok=1
+    break
+  fi
+  echo "npm audit attempt $attempt failed — retrying in $((attempt * 20))s" >&2
+  sleep $((attempt * 20))
+done
+[ "$audit_ok" = 1 ] || { echo "npm audit failed on three attempts" >&2; exit 1; }
 ! git ls-files | grep -q "^agents/crystallize-agent/"
 test -f .github/dependabot.yml
 grep -q "\"engines\"" package.json


### PR DESCRIPTION
## What

`checks/oss/verify-OSS-I.sh` runs `npm audit`, a live call to registry.npmjs.org. On PR #122's first gate run (2026-09-04, run 33827835013) the registry's bulk advisory endpoint hung for five minutes and answered `503 Service Unavailable`, and the gate went red on an outage unrelated to the tree: the oracle replay was 11/11 and every gradle leg green in the same run. The endpoint was still timing out an hour later, so the rerun may show the same.

The leg now tries three times, each attempt capped at one minute of fetch time (`--fetch-timeout=60000`), with a 20 s then 40 s pause. A real critical advisory still fails all three attempts and keeps the leg red; the count floor and the other three checks in the leg are untouched.

## Verification

Red/green without the network, with a fake `npm` on PATH that counts calls: fails twice then succeeds → `VERIFY OSS-I: OK`, exit 0; always fails → `npm audit failed on three attempts`, exit 1. The live leg could not be shown green locally while the registry is down; this PR's own gate run is the live proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)