### PR TITLE
chore(release): promote main to prod (v0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@
 
 ### Fixed
 
-- **The `/model` picker lists each model once.** Every head showed its slotted models twice (Sol
-  twice on `claudex`; Kimi K3 (256k) and Kimi K2.7 Code twice on `claude-kimi`). Both rows were
-  ours: the launch recipe plants `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU,FABLE}_MODEL`, which Claude
-  Code renders as its tier rows with the `_NAME` label, and then appends every
-  `additionalModelOptionsCache` row under the raw catalog id, and its dedupe compares values only.
-  The materialized cache now omits any id already planted in a slot; `availableModels` keeps every
-  id, so a saved model choice stays allowed, and unslotted rows keep their fields.
+- **The `/model` picker lists each model once.** Every head showed a slotted model twice (Sol
+  twice on `claudex`; Kimi K3 (256k) and Kimi K2.7 Code twice on `claude-kimi`). Claude Code draws
+  one row per planted tier (`ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU,FABLE}_MODEL`) and dedupes rows
+  by their alias, so two tiers on one model drew it twice: Fable shares the frontier with Opus, and
+  on a two-model head Haiku shares Sonnet. A tier cannot be left unset, because its alias then
+  resolves to Claude Code's built-in model, which the head rejects. A repeated tier is now planted
+  under the head's discovery-wrapped spelling (`claude-codex--gpt-5.6-sol`): the head routes it
+  like the bare id, and the picker's allowlist hides the row. Cache rows are unchanged; they are
+  where the Default line's label comes from.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## splice v0.3.1 — one picker row per model, and the proofs the review asked for - 2026-09-04
+
+### Fixed
+
+- **The `/model` picker lists each model once.** Every head showed its slotted models twice (Sol
+  twice on `claudex`; Kimi K3 (256k) and Kimi K2.7 Code twice on `claude-kimi`). Both rows were
+  ours: the launch recipe plants `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU,FABLE}_MODEL`, which Claude
+  Code renders as its tier rows with the `_NAME` label, and then appends every
+  `additionalModelOptionsCache` row under the raw catalog id, and its dedupe compares values only.
+  The materialized cache now omits any id already planted in a slot; `availableModels` keeps every
+  id, so a saved model choice stays allowed, and unslotted rows keep their fields.
+
+### Changed
+
+- **The watchdog turn-line tests pin what production does.** A test claimed a compaction's
+  first-output tier is lifted to the whole-turn cap; production switches that tier off
+  (`WatchdogBudget.forCompact`), so only the total cap ends a silent compaction. The arm now pins a
+  non-compact first-output fire and a compact total-cap fire, and two new `TurnFinish` arms fire
+  real pollers on virtual ticks and assert the rendered line carries the sentinel through the
+  production hop.
+- **`CLAUDEX_QUOTA_POLL=off` has an effect test.** `ManagedHeadFactory` exposes a poller-start
+  seam; assembling a real ChatGPT subscription head with the knob off starts nothing, with `auto`
+  starts one.
+- **The stable pin recipe is exercised.** `checks/release/accept.sh` now installs with
+  `SPLICE_VERSION` pinned to the jar's own stable tag as well as a synthetic prerelease, and fails
+  when `install.sh` ignores the pin.
+- **Changelog bookkeeping.** "Heads that see each other" landed after `v0.3.0-beta.1` and now sits
+  in the v0.3.0 section, so the beta.1 list matches its tag.
+
 ## splice v0.3.0 — plan usage on every head, and a proxy that matches its reference client - 2026-09-03
 
 ### Added
@@ -19,6 +48,14 @@
   outbound traffic since the beta, so it is named here rather than left implicit;
   `CLAUDEX_QUOTA_POLL=off` stops every poller (daemon restart), and the bars then draw only from
   the rate-limit headers each round already carries.
+
+- **Heads that see each other.** Every wrapper's `sessions` directory is linked at the one registry
+  under `~/.claude/sessions` on first launch (created if plain `claude` never ran on the machine), so
+  claudex, claude-grok, claude-kimi, claude-openrouter, claude-splice and plain `claude` sessions all
+  appear in each other's `ListAgents` and can message each other with `SendMessage`: a session on one
+  backend can orchestrate a session on another. On by default through `[claude].share`;
+  `isolate = ["sessions"]` walls a head off. (Shipped in this release without a changelog entry;
+  recorded here.)
 
 ### Changed
 
@@ -128,13 +165,6 @@
 
 ### Added
 
-- **Heads that see each other.** Every wrapper's `sessions` directory is linked at the one registry
-  under `~/.claude/sessions` on first launch (created if plain `claude` never ran on the machine), so
-  claudex, claude-grok, claude-kimi, claude-openrouter, claude-splice and plain `claude` sessions all
-  appear in each other's `ListAgents` and can message each other with `SendMessage`: a session on one
-  backend can orchestrate a session on another. On by default through `[claude].share`;
-  `isolate = ["sessions"]` walls a head off. (Shipped in this release without a changelog entry;
-  recorded here.)
 - **`claude-splice`, the native-auth Claude head.** Claude Code keeps its own Anthropic login and
   sends the caller credential through the local passthrough head; splice never stores, reads,
   refreshes, or logs that credential. The management key is not reused on this route.

--- a/bin/splice-launch
+++ b/bin/splice-launch
@@ -62,7 +62,7 @@ DANGEROUS="false"
 # — bump both together whenever this shim's behavior changes. No code generation.
 SPLICE_SHIM_VERSION="shim-2"
 # Hand-paired with splice.core.GATEWAY_VERSION. Release acceptance verifies the marker.
-SPLICE_GATEWAY_VERSION="0.3.0"
+SPLICE_GATEWAY_VERSION="0.3.1"
 
 need_jar() {
   if [ ! -f "$JAR" ]; then

--- a/checks/e2e/docker/inside.sh
+++ b/checks/e2e/docker/inside.sh
@@ -305,13 +305,15 @@ step "launch recipe: claudex base URL + API_TIMEOUT_MS > 900s" launch_recipe cla
 step "launch recipe: mockchat base URL + API_TIMEOUT_MS > 900s" launch_recipe mockchat "$CHAT_HEAD_PORT"
 
 # ── 7b. per-head model roster + window: what /model offers, what the client compacts on ─────
-# Each head materializes its OWN picker (settings.json availableModels + model, enforced) and
-# hands Claude Code its own CLAUDE_CODE_MAX_CONTEXT_TOKENS, from the topology alone. Every
-# catalog model reaches the picker EXACTLY ONCE (v0.3.1): either as a tier slot the recipe plants
-# (ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU,FABLE}_MODEL, which Claude Code renders as its own rows)
-# or as a .claude.json additionalModelOptionsCache row carrying its context_window, never both
-# (both was the duplicated picker of v0.3.0). Three heads, three windows: a head reading another
-# head's roster or window is exactly the fresh-install drift this step exists to catch.
+# Each head materializes its OWN picker (settings.json availableModels + model, enforced, and a
+# .claude.json additionalModelOptionsCache row per model carrying its context_window) and hands
+# Claude Code its own CLAUDE_CODE_MAX_CONTEXT_TOKENS, from the topology alone. The four tier
+# slots (ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU,FABLE}_MODEL) never share a BARE id: two tiers on
+# one bare id drew that model twice in /model (v0.3.0); a repeated tier now rides the head's
+# discovery-wrapped spelling, which the allowlist hides (so wrapped values may repeat) and the
+# head still routes. Three
+# heads, three windows: a head reading another head's roster or window is exactly the
+# fresh-install drift this step exists to catch.
 # The same /launch also PACKAGES the head: the daemon's own status line (settings.json statusLine
 # posting Claude Code's blob to /statusline/<head>), the in-session /login command and the hook
 # that runs the head's sign-in when it is submitted. Splice is the whole package, so a head that
@@ -344,11 +346,13 @@ assert env.get("CLAUDE_CODE_AUTO_COMPACT_WINDOW") == str(window), env.get("CLAUD
 assert settings.get("model") == model, settings.get("model")
 assert settings.get("availableModels") == list(expected_rows), "picker off: %r" % settings.get("availableModels")
 assert settings.get("enforceAvailableModels") is True, "picker is not enforced"
-slots = {v for k, v in env.items() if re.fullmatch(r"ANTHROPIC_DEFAULT_(OPUS|SONNET|HAIKU|FABLE)_MODEL", k)}
-print("slots:", sorted(slots))
-assert not (set(rows) & slots), "a slotted model is also a cache row (the v0.3.0 duplication): %r" % (set(rows) & slots)
-assert slots | set(rows) == set(expected_rows), "picker roster %r != expected %r" % (sorted(slots | set(rows)), sorted(expected_rows))
-assert all(rows[m] == expected_rows[m] for m in rows), "cache row windows off: %r" % rows
+assert rows == expected_rows, rows
+slots = [v for k, v in sorted(env.items()) if re.fullmatch(r"ANTHROPIC_DEFAULT_(OPUS|SONNET|HAIKU|FABLE)_MODEL", k)]
+print("slots:", slots)
+bare = [v for v in slots if v in expected_rows]
+wrapped = [v for v in slots if v not in expected_rows]
+assert len(set(bare)) == len(bare), "two tiers carry one bare id, so /model draws that model twice: %r" % slots
+assert all(any(v.endswith("--" + m) for m in expected_rows) for v in wrapped), "a tier points outside the roster: %r" % slots
 assert statusline == f"curl -sS --data-binary @- http://127.0.0.1:{control}/statusline/{head}", "status line not splice's: %r" % statusline
 assert os.path.isfile(login_md), "no in-session /login command materialized"
 assert any("splice-login-hook" in c for c in hook_cmds), "no /login hook on UserPromptSubmit: %r" % hook_cmds

--- a/checks/e2e/docker/inside.sh
+++ b/checks/e2e/docker/inside.sh
@@ -305,11 +305,13 @@ step "launch recipe: claudex base URL + API_TIMEOUT_MS > 900s" launch_recipe cla
 step "launch recipe: mockchat base URL + API_TIMEOUT_MS > 900s" launch_recipe mockchat "$CHAT_HEAD_PORT"
 
 # ── 7b. per-head model roster + window: what /model offers, what the client compacts on ─────
-# Each head materializes its OWN picker (settings.json availableModels + model, enforced, and a
-# .claude.json additionalModelOptionsCache row per model carrying its context_window) and hands
-# Claude Code its own CLAUDE_CODE_MAX_CONTEXT_TOKENS, from the topology alone. Three heads, three
-# windows: a head reading another head's roster or window is exactly the fresh-install drift
-# this step exists to catch.
+# Each head materializes its OWN picker (settings.json availableModels + model, enforced) and
+# hands Claude Code its own CLAUDE_CODE_MAX_CONTEXT_TOKENS, from the topology alone. Every
+# catalog model reaches the picker EXACTLY ONCE (v0.3.1): either as a tier slot the recipe plants
+# (ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU,FABLE}_MODEL, which Claude Code renders as its own rows)
+# or as a .claude.json additionalModelOptionsCache row carrying its context_window, never both
+# (both was the duplicated picker of v0.3.0). Three heads, three windows: a head reading another
+# head's roster or window is exactly the fresh-install drift this step exists to catch.
 # The same /launch also PACKAGES the head: the daemon's own status line (settings.json statusLine
 # posting Claude Code's blob to /statusline/<head>), the in-session /login command and the hook
 # that runs the head's sign-in when it is submitted. Splice is the whole package, so a head that
@@ -319,7 +321,7 @@ head_contract() { # head pinned-model pinned-window rows("id:window,...")
     --data '{"dangerouslySkipPermissions":"","args":[]}' "http://127.0.0.1:$CONTROL_PORT/launch/$1" \
     > "$OUT/recipe-$1.json" || return 1
   python3 - "$1" "$2" "$3" "$4" "$HOME" "$OUT/recipe-$1.json" "$CONTROL_PORT" <<'EOF'
-import json, os, sys
+import json, os, re, sys
 head, model, window, rows_arg, home, recipe, control = sys.argv[1:8]
 window = int(window)
 expected_rows = {kv.split(":")[0]: int(kv.split(":")[1]) for kv in rows_arg.split(",")}
@@ -342,7 +344,11 @@ assert env.get("CLAUDE_CODE_AUTO_COMPACT_WINDOW") == str(window), env.get("CLAUD
 assert settings.get("model") == model, settings.get("model")
 assert settings.get("availableModels") == list(expected_rows), "picker off: %r" % settings.get("availableModels")
 assert settings.get("enforceAvailableModels") is True, "picker is not enforced"
-assert rows == expected_rows, rows
+slots = {v for k, v in env.items() if re.fullmatch(r"ANTHROPIC_DEFAULT_(OPUS|SONNET|HAIKU|FABLE)_MODEL", k)}
+print("slots:", sorted(slots))
+assert not (set(rows) & slots), "a slotted model is also a cache row (the v0.3.0 duplication): %r" % (set(rows) & slots)
+assert slots | set(rows) == set(expected_rows), "picker roster %r != expected %r" % (sorted(slots | set(rows)), sorted(expected_rows))
+assert all(rows[m] == expected_rows[m] for m in rows), "cache row windows off: %r" % rows
 assert statusline == f"curl -sS --data-binary @- http://127.0.0.1:{control}/statusline/{head}", "status line not splice's: %r" % statusline
 assert os.path.isfile(login_md), "no in-session /login command materialized"
 assert any("splice-login-hook" in c for c in hook_cmds), "no /login hook on UserPromptSubmit: %r" % hook_cmds

--- a/checks/release/accept.sh
+++ b/checks/release/accept.sh
@@ -213,42 +213,44 @@ grep -q "splice.jar attestation: OK" "$stable_output" || { echo "release accept:
 grep -q "splice-launch attestation: OK" "$stable_output" || { echo "release accept: stable install missing splice-launch attestation OK" >&2; exit 1; }
 rm -rf "$stable_sandbox"
 
-# A prerelease install must pin every download to that exact tag.
-: > "$remote_log"
-: > "$remote_curl_log"
-versioned_sandbox="$(mktemp -d)"
-versioned_output="$versioned_sandbox/output.log"
-mkdir -p "$versioned_sandbox/home" "$versioned_sandbox/share" "$versioned_sandbox/bin" "$versioned_sandbox/work"
-(
-  cd "$versioned_sandbox/work"
-  HOME="$versioned_sandbox/home" \
-  JAVA_TOOL_OPTIONS="-Duser.home=$versioned_sandbox/home" \
-  SPLICE_SHARE_DIR="$versioned_sandbox/share" \
-  SPLICE_BIN_DIR="$versioned_sandbox/bin" \
-  SPLICE_VERSION="v9.8.7-beta.6" \
-  SPLICE_FAKE_RELEASE_ASSETS="$DIST" \
-  SPLICE_FAKE_CURL_LOG="$remote_curl_log" \
-  SPLICE_FAKE_GH_LOG="$remote_log" \
-  PATH="$remote_tools:$versioned_sandbox/bin:$PATH" \
-    bash -s < "$DIST/install.sh"
-) >"$versioned_output" 2>&1 || { cat "$versioned_output" >&2; exit 1; }
-expected_versioned_base="https://github.com/torad-labs/splice/releases/download/v9.8.7-beta.6"
-printf '%s\n' \
-  "$expected_versioned_base/splice.jar" \
-  "$expected_versioned_base/sha256sums.txt" \
-  "$expected_versioned_base/splice-launch" > "$remote_tools/expected-versioned-urls.log"
-cmp -s "$remote_tools/expected-versioned-urls.log" "$remote_curl_log" || {
-  echo "release accept: prerelease install did not use the exact version-pinned URLs" >&2
-  exit 1
-}
-[ "$(grep -c '^attestation verify ' "$remote_log")" -eq 2 ] || {
-  echo "release accept: prerelease install did not attest both release artifacts" >&2
-  cat "$remote_log" >&2
-  exit 1
-}
-grep -q "splice.jar attestation: OK" "$versioned_output" || { echo "release accept: prerelease install missing splice.jar attestation OK" >&2; exit 1; }
-grep -q "splice-launch attestation: OK" "$versioned_output" || { echo "release accept: prerelease install missing splice-launch attestation OK" >&2; exit 1; }
-rm -rf "$versioned_sandbox"
+# Stable and prerelease pins must send every download to their exact tag.
+for pinned_version in "v$jar_version" v9.8.7-beta.6; do
+  : > "$remote_log"
+  : > "$remote_curl_log"
+  versioned_sandbox="$(mktemp -d)"
+  versioned_output="$versioned_sandbox/output.log"
+  mkdir -p "$versioned_sandbox/home" "$versioned_sandbox/share" "$versioned_sandbox/bin" "$versioned_sandbox/work"
+  (
+    cd "$versioned_sandbox/work"
+    HOME="$versioned_sandbox/home" \
+    JAVA_TOOL_OPTIONS="-Duser.home=$versioned_sandbox/home" \
+    SPLICE_SHARE_DIR="$versioned_sandbox/share" \
+    SPLICE_BIN_DIR="$versioned_sandbox/bin" \
+    SPLICE_VERSION="$pinned_version" \
+    SPLICE_FAKE_RELEASE_ASSETS="$DIST" \
+    SPLICE_FAKE_CURL_LOG="$remote_curl_log" \
+    SPLICE_FAKE_GH_LOG="$remote_log" \
+    PATH="$remote_tools:$versioned_sandbox/bin:$PATH" \
+      bash -s < "$DIST/install.sh"
+  ) >"$versioned_output" 2>&1 || { cat "$versioned_output" >&2; exit 1; }
+  expected_versioned_base="https://github.com/torad-labs/splice/releases/download/$pinned_version"
+  printf '%s\n' \
+    "$expected_versioned_base/splice.jar" \
+    "$expected_versioned_base/sha256sums.txt" \
+    "$expected_versioned_base/splice-launch" > "$remote_tools/expected-versioned-urls.log"
+  cmp -s "$remote_tools/expected-versioned-urls.log" "$remote_curl_log" || {
+    echo "release accept: $pinned_version install did not use the exact version-pinned URLs" >&2
+    exit 1
+  }
+  [ "$(grep -c '^attestation verify ' "$remote_log")" -eq 2 ] || {
+    echo "release accept: $pinned_version install did not attest both release artifacts" >&2
+    cat "$remote_log" >&2
+    exit 1
+  }
+  grep -q "splice.jar attestation: OK" "$versioned_output" || { echo "release accept: $pinned_version install missing splice.jar attestation OK" >&2; exit 1; }
+  grep -q "splice-launch attestation: OK" "$versioned_output" || { echo "release accept: $pinned_version install missing splice-launch attestation OK" >&2; exit 1; }
+  rm -rf "$versioned_sandbox"
+done
 
 # A failed provenance check must abort before the candidate artifacts become live.
 cat > "$remote_tools/gh" <<'SH'

--- a/gateway/app/src/main/kotlin/splice/app/head/LaunchSpecFactory.kt
+++ b/gateway/app/src/main/kotlin/splice/app/head/LaunchSpecFactory.kt
@@ -57,6 +57,7 @@ internal class LaunchSpecFactory(
             // reinterpreting the declaration. See ManagedHeadFactory.forwardClientAuth.
             forwardClientAuth = forwardClientAuth,
             pinnedModel = head.pinnedModel,
+            discoveryPrefix = head.discoveryPrefix,
             availableModelIds = ctx.catalog.availableModelIds(),
             modelLabels = ctx.catalog.models.associate { it.id to it.label.ifEmpty { it.id } },
             modelSlots = head.models.orEmpty().mapNotNull { model ->

--- a/gateway/app/src/main/kotlin/splice/app/head/ManagedHeadFactory.kt
+++ b/gateway/app/src/main/kotlin/splice/app/head/ManagedHeadFactory.kt
@@ -13,6 +13,7 @@ import splice.app.UsageStoreSource
 import splice.app.provider.ProviderAssembly
 import splice.app.provider.ProviderBuild
 import splice.app.quota.QuotaPoller
+import splice.app.quota.QuotaProbe
 import splice.app.quota.QuotaProbes
 import splice.control.ManagedHead
 import splice.core.auth.ClientAuthProvider
@@ -24,6 +25,10 @@ import splice.gateway.usage.QuotaTracker
 import splice.gateway.usage.UsageStore
 import splice.provider.openai.ApiKeyAuthProvider
 
+internal fun interface StartQuotaPoller {
+    operator fun invoke(head: String, probe: QuotaProbe, tracker: QuotaTracker)
+}
+
 internal class ManagedHeadFactory(
     private val statePaths: StatePaths,
     private val providerAssembly: ProviderAssembly,
@@ -33,6 +38,9 @@ internal class ManagedHeadFactory(
      *  end with Daemon.stop() like every other background probe. */
     private val probeScope: CoroutineScope,
     private val log: LogSink,
+    private val startQuotaPoller: StartQuotaPoller = StartQuotaPoller { head, probe, tracker ->
+        QuotaPoller(probeScope, head, probe, tracker, log).start()
+    },
 ) {
     private val quotaProbes by lazy { QuotaProbes(AuthHttpClientFactory().create()) }
 
@@ -52,7 +60,7 @@ internal class ManagedHeadFactory(
         // daemon-wide QUOTA_POLL knob ("off") is the operator's way to stop that outbound egress.
         if (!cfg.quotaPollOff) {
             quotaProbes.forHead(ctx, wired.auth)?.let { probe ->
-                QuotaPoller(probeScope, key, probe, stores.quota, log).start()
+                startQuotaPoller(key, probe, stores.quota)
             }
         }
         val logFile = statePaths.logsDir.resolve("daemon.log")

--- a/gateway/app/src/test/kotlin/splice/app/head/ManagedHeadFactoryQuotaPollTest.kt
+++ b/gateway/app/src/test/kotlin/splice/app/head/ManagedHeadFactoryQuotaPollTest.kt
@@ -1,0 +1,112 @@
+// NEW: CLAUDEX_QUOTA_POLL had parser coverage but no production-effect arm. These tests drive
+// ManagedHeadFactory.assembleHead through a subscription head and count the poller-start seam, so
+// the off switch and the default-on path are both observable without making a network request.
+package splice.app.head
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import splice.app.SignInPlanner
+import splice.app.TokenUrlRefreshCall
+import splice.app.provider.HeadBuildInputs
+import splice.app.provider.ProviderAssembly
+import splice.app.provider.ProviderBuild
+import splice.core.config.ConfigService
+import splice.core.config.MgmtKey
+import splice.core.config.StatePaths
+import splice.core.model.ModelCatalog
+import splice.core.model.ModelEntry
+import splice.core.topology.AuthConfig
+import splice.core.topology.ClaudeWrapperConfig
+import splice.core.topology.Dialect
+import splice.core.topology.HeadConfig
+import splice.core.topology.ProviderConfig
+import splice.core.topology.Topology
+import splice.core.turn.WatchdogBudget
+import splice.core.util.LogSink
+import java.nio.file.Path
+import kotlin.time.Duration.Companion.seconds
+
+class ManagedHeadFactoryQuotaPollTest {
+
+    private fun factory(
+        statePaths: StatePaths,
+        scope: CoroutineScope,
+        startQuotaPoller: StartQuotaPoller,
+    ): ManagedHeadFactory {
+        val log = LogSink { }
+        val config = ConfigService(statePaths)
+        val mgmtKey = MgmtKey(statePaths)
+        val signInPlanner = SignInPlanner()
+        return ManagedHeadFactory(
+            statePaths = statePaths,
+            providerAssembly = ProviderAssembly(
+                statePaths,
+                scope,
+                log,
+                TokenUrlRefreshCall { _, _ -> error("refresh must not run during assembly") },
+            ),
+            headServerFactory = HeadServerFactory(config, mgmtKey, log),
+            launchSpecFactory = LaunchSpecFactory(
+                topology = Topology(),
+                signInPlanner = signInPlanner,
+                mgmtKey = mgmtKey,
+                buildInputs = HeadBuildInputs(config, signInPlanner),
+            ),
+            probeScope = scope,
+            log = log,
+            startQuotaPoller = startQuotaPoller,
+        )
+    }
+
+    private fun build(statePaths: StatePaths, quotaPoll: String): ProviderBuild {
+        val model = ModelEntry(id = "gpt-5.6-sol", contextWindow = 400_000)
+        return ProviderBuild(
+            key = "claudex",
+            head = HeadConfig(
+                provider = "codex",
+                port = 3099,
+                discoveryPrefix = "claude-codex--",
+                pinnedModel = model.id,
+                claude = ClaudeWrapperConfig(command = "claudex", configDir = statePaths.stateDir.toString()),
+            ),
+            providerCfg = ProviderConfig(
+                dialect = Dialect.OPENAI_RESPONSES,
+                baseUrl = "https://chatgpt.com/backend-api/codex",
+                auth = AuthConfig(kind = "chatgpt-oauth", file = statePaths.stateDir.resolve("auth.json").toString()),
+            ),
+            catalog = ModelCatalog(
+                discoveryPrefix = "claude-codex--",
+                models = listOf(model),
+                defaultContextWindow = model.contextWindow,
+            ),
+            watchdog = WatchdogBudget(300.seconds, 300.seconds, 900.seconds),
+            cfg = ConfigService(statePaths, headOverrides = mapOf("quotaPoll" to quotaPoll)).getConfig(),
+            loginCommand = "claudex login",
+        )
+    }
+
+    @Test
+    fun `quota poll off does not start a poller`(@TempDir tmp: Path) = runTest {
+        val statePaths = StatePaths(baseOverride = tmp.resolve("off"))
+        var starts = 0
+        val factory = factory(statePaths, backgroundScope, StartQuotaPoller { _, _, _ -> starts += 1 })
+
+        factory.assembleHead(build(statePaths, quotaPoll = "off"), controlPort = 3098)
+
+        assertEquals(0, starts)
+    }
+
+    @Test
+    fun `quota poll auto starts one poller for a subscription head`(@TempDir tmp: Path) = runTest {
+        val statePaths = StatePaths(baseOverride = tmp.resolve("auto"))
+        var starts = 0
+        val factory = factory(statePaths, backgroundScope, StartQuotaPoller { _, _, _ -> starts += 1 })
+
+        factory.assembleHead(build(statePaths, quotaPoll = "auto"), controlPort = 3098)
+
+        assertEquals(1, starts)
+    }
+}

--- a/gateway/build-logic/src/main/kotlin/splice.kotlin-common.gradle.kts
+++ b/gateway/build-logic/src/main/kotlin/splice.kotlin-common.gradle.kts
@@ -54,4 +54,13 @@ tasks.withType<Test>().configureEach {
     // per-connection state, so the 1000-stream CEILING test needs the extra heap. Real load is tens
     // of streams (far under 1g either way); this only funds the stress ceiling.
     maxHeapSize = "2g"
+    // A CI failure must carry its assertion MESSAGE, not only "AssertionFailedError at X.kt:274".
+    // Gradle's default prints the location alone, so the two CI-only failures of the perf
+    // telemetry integration arm (runs 33608202738 and 33928312116) left no way to read what was
+    // logged instead of the expected line. Failed events only: a green run stays quiet.
+    testLogging {
+        events("failed")
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+        showStackTraces = true
+    }
 }

--- a/gateway/control/src/main/kotlin/splice/control/LaunchService.kt
+++ b/gateway/control/src/main/kotlin/splice/control/LaunchService.kt
@@ -12,6 +12,10 @@
 // only), which per-head context windows depend on.
 package splice.control
 
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import splice.core.launch.ClaudeConfigMaterializer
 import splice.core.launch.MaterializeSpec
 import splice.core.util.EnvReader
@@ -43,13 +47,21 @@ public class LaunchService(
         keyPresentNow: Boolean = true,
     ): LaunchRecipe {
         val effective = if (keyPresentNow) spec.copy(tokenCapture = null, advertiseKeySetup = false) else spec
+        // Slots first: the picker filter needs the planted ids, including positional fill
+        // (a declared-empty head still plants four tiers). LaunchSpec.modelOptionsCache stays
+        // the full catalog projection; only the materialized cache is stripped.
+        val slots = aliasSlots(effective)
+        val pickerCache = cacheWithoutSlotIds(
+            effective.modelOptionsCache,
+            slots.map { it.second }.toSet(),
+        )
         materializer.materialize(
             MaterializeSpec(
                 configDir = effective.configDir,
                 policy = effective.policy,
                 availableModelIds = effective.availableModelIds,
                 defaultModel = effective.pinnedModel,
-                modelOptionsCache = effective.modelOptionsCache,
+                modelOptionsCache = pickerCache,
                 statuslineCommand = effective.statuslineCommand,
                 loginCommand = effective.loginCommand,
                 signInLabel = effective.signInLabel,
@@ -59,7 +71,6 @@ public class LaunchService(
                 loginOutcomeFile = effective.loginOutcomeFile,
             ),
         )
-        val slots = aliasSlots(effective)
         val env = buildEnv(effective, slots)
         val unset = staleEnvUnsets(effective, slots)
         val argv = buildList {
@@ -76,6 +87,24 @@ public class LaunchService(
             null
         }
         return LaunchRecipe(env, unset, argv, warning)
+    }
+
+    // Claude Code 2.1.257 picker (gXr) starts from lXr slot rows whose value is the alias
+    // ("opus"/"sonnet"/"haiku"/"fable") and label is ANTHROPIC_DEFAULT_*_MODEL_NAME, then
+    // appends additionalModelOptionsCache rows whose value is the raw catalog id. eF/nHe
+    // collapse equal values only, so a slot labeled Sol plus a cache row valued "sol" both
+    // survive and the picker lists the same model twice. Drop cache rows whose value is
+    // already a planted slot id; keep availableModels so the id stays allowed, keep
+    // unslotted rows (including context_window, which vP ignores; Claude Code's window is
+    // CLAUDE_CODE_MAX_CONTEXT_TOKENS), keep slot NAME/DESCRIPTION.
+    private fun cacheWithoutSlotIds(cache: JsonElement, slotIds: Set<String>): JsonElement {
+        val rows = cache as? JsonArray ?: return cache
+        return JsonArray(
+            rows.filter { row ->
+                val value = (row as? JsonObject)?.get("value")?.jsonPrimitive?.content
+                value !in slotIds
+            },
+        )
     }
 
     /** Vars a launched head must SCRUB from the inherited environment: bin/splice-launch execs

--- a/gateway/control/src/main/kotlin/splice/control/LaunchService.kt
+++ b/gateway/control/src/main/kotlin/splice/control/LaunchService.kt
@@ -12,10 +12,6 @@
 // only), which per-head context windows depend on.
 package splice.control
 
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import splice.core.launch.ClaudeConfigMaterializer
 import splice.core.launch.MaterializeSpec
 import splice.core.util.EnvReader
@@ -47,21 +43,14 @@ public class LaunchService(
         keyPresentNow: Boolean = true,
     ): LaunchRecipe {
         val effective = if (keyPresentNow) spec.copy(tokenCapture = null, advertiseKeySetup = false) else spec
-        // Slots first: the picker filter needs the planted ids, including positional fill
-        // (a declared-empty head still plants four tiers). LaunchSpec.modelOptionsCache stays
-        // the full catalog projection; only the materialized cache is stripped.
         val slots = aliasSlots(effective)
-        val pickerCache = cacheWithoutSlotIds(
-            effective.modelOptionsCache,
-            slots.map { it.second }.toSet(),
-        )
         materializer.materialize(
             MaterializeSpec(
                 configDir = effective.configDir,
                 policy = effective.policy,
                 availableModelIds = effective.availableModelIds,
                 defaultModel = effective.pinnedModel,
-                modelOptionsCache = pickerCache,
+                modelOptionsCache = effective.modelOptionsCache,
                 statuslineCommand = effective.statuslineCommand,
                 loginCommand = effective.loginCommand,
                 signInLabel = effective.signInLabel,
@@ -87,24 +76,6 @@ public class LaunchService(
             null
         }
         return LaunchRecipe(env, unset, argv, warning)
-    }
-
-    // Claude Code 2.1.257 picker (gXr) starts from lXr slot rows whose value is the alias
-    // ("opus"/"sonnet"/"haiku"/"fable") and label is ANTHROPIC_DEFAULT_*_MODEL_NAME, then
-    // appends additionalModelOptionsCache rows whose value is the raw catalog id. eF/nHe
-    // collapse equal values only, so a slot labeled Sol plus a cache row valued "sol" both
-    // survive and the picker lists the same model twice. Drop cache rows whose value is
-    // already a planted slot id; keep availableModels so the id stays allowed, keep
-    // unslotted rows (including context_window, which vP ignores; Claude Code's window is
-    // CLAUDE_CODE_MAX_CONTEXT_TOKENS), keep slot NAME/DESCRIPTION.
-    private fun cacheWithoutSlotIds(cache: JsonElement, slotIds: Set<String>): JsonElement {
-        val rows = cache as? JsonArray ?: return cache
-        return JsonArray(
-            rows.filter { row ->
-                val value = (row as? JsonObject)?.get("value")?.jsonPrimitive?.content
-                value !in slotIds
-            },
-        )
     }
 
     /** Vars a launched head must SCRUB from the inherited environment: bin/splice-launch execs
@@ -152,8 +123,25 @@ public class LaunchService(
             // availableModels + .claude.json additionalModelOptionsCache) — see the header for why
             // the wrapped /v1/models spelling must never reach the picker.
             put("ANTHROPIC_MODEL", spec.pinnedModel)
+            // The picker lists one row per PLANTED TIER (Claude Code 2.1.257: fen()/hen()/uen()
+            // emit a row whenever ANTHROPIC_DEFAULT_<tier>_MODEL is set, value = the alias, label =
+            // _NAME) and dedupes rows by value only, so two tiers on one model drew that model
+            // twice: Sol as opus and as fable on claudex, K2.7 Code as sonnet and as haiku on
+            // claude-kimi (the 2026-09-04 release recording). The tier cannot be left unset: the
+            // alias then resolves to Claude Code's built-in model, which this head rejects
+            // ("proxies its own models only"), and every fable- or haiku-tiered subagent dies.
+            // The one lever is the allowlist: a tier row whose model is not on availableModels is
+            // hidden, while the head accepts its own DISCOVERY-WRAPPED spelling (catalog.contains
+            // unwraps). So a repeated tier is planted as "<prefix><id>": routed like the first, drawn
+            // never. Cache rows are untouched on purpose: Claude Code already drops a cache row that
+            // repeats a tier's model, and the cache row is where the Default line's label comes from
+            // (stripping them printed "currently gpt-5.6-sol[1m]"; verified live 2026-09-04). Known
+            // cost: a subagent on the wrapped tier runs under a wrapped ACTIVE id, for which Claude
+            // Code does not honor CLAUDE_CODE_MAX_CONTEXT_TOKENS (header note).
+            val planted = mutableSetOf<String>()
             slots.forEach { (slot, model) ->
-                put("ANTHROPIC_DEFAULT_${slot}_MODEL", model)
+                val repeated = !planted.add(model) && spec.discoveryPrefix.isNotBlank()
+                put("ANTHROPIC_DEFAULT_${slot}_MODEL", if (repeated) spec.discoveryPrefix + model else model)
                 val label = spec.modelLabels[model] ?: model
                 put("ANTHROPIC_DEFAULT_${slot}_MODEL_NAME", label)
                 put("ANTHROPIC_DEFAULT_${slot}_MODEL_DESCRIPTION", label)

--- a/gateway/control/src/main/kotlin/splice/control/LaunchTypes.kt
+++ b/gateway/control/src/main/kotlin/splice/control/LaunchTypes.kt
@@ -21,6 +21,10 @@ public data class LaunchSpec(
      *  fully retired for that head, and an undeclared tier stays un-set rather than pointing a
      *  second alias at an already-claimed model (the 2-model duplication this exists to remove). */
     val modelSlots: Map<String, String> = emptyMap(),
+    /** The head's discovery prefix ("claude-codex--"): a tier that repeats an earlier tier's model
+     *  is planted under this wrapped spelling so the picker's allowlist hides its row (see
+     *  LaunchService.buildEnv). Blank keeps the duplicate row. */
+    val discoveryPrefix: String = "",
     val contextWindow: Long,
     /** Claude Code's per-request timeout (API_TIMEOUT_MS) for THIS head: the daemon's whole-turn
      *  cap plus a grace, so the client always outlives the proxy's own wall and receives its honest

--- a/gateway/control/src/test/kotlin/splice/control/LaunchServiceTest.kt
+++ b/gateway/control/src/test/kotlin/splice/control/LaunchServiceTest.kt
@@ -4,6 +4,14 @@
 // LaunchSpec construction mirrors ControlServerTest.kt/WebuiContractTest.kt in this same package.
 package splice.control
 
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.addJsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import kotlinx.serialization.json.put
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -182,6 +190,83 @@ class LaunchServiceTest {
         assertNull(env["ANTHROPIC_DEFAULT_OPUS_MODEL"], "an undeclared tier is omitted, never filled")
         assertNull(env["ANTHROPIC_DEFAULT_SONNET_MODEL"])
         assertNull(env["ANTHROPIC_DEFAULT_FABLE_MODEL"])
+    }
+
+    // 2026-09-04: Claude Code 2.1.257 picker (gXr/lXr) renders each ANTHROPIC_DEFAULT_*_MODEL as
+    // an alias row (value "opus"/"sonnet"/"haiku"/"fable", label from _NAME) and THEN appends
+    // additionalModelOptionsCache rows whose value is the raw catalog id. eF/nHe only collapse
+    // equal values, so "opus" labeled Sol and "sol" labeled Sol both survive. A model that fills
+    // a slot must not also be a cache row; unslotted roster rows stay, availableModels stays.
+    private fun kimiRosterCache() = buildJsonArray {
+        addJsonObject {
+            put("value", "kimi-k3")
+            put("label", "Kimi K3 (256k)")
+            put("description", "Kimi K3 (256k)")
+            put("context_window", 256_000)
+        }
+        addJsonObject {
+            put("value", "kimi-k2.7-code")
+            put("label", "Kimi K2.7 Code")
+            put("description", "Kimi K2.7 Code")
+            put("context_window", 256_000)
+        }
+        addJsonObject {
+            put("value", "kimi-extra")
+            put("label", "Extra")
+            put("description", "Extra")
+            put("context_window", 128_000)
+        }
+    }
+
+    /** A three-model kimi head with two of them declared into slots; kimi-extra is unslotted. */
+    private fun launchKimiWithSlots(): LaunchRecipe = service.launch(
+        spec(
+            "kimi",
+            pinned = "kimi-k3",
+            available = listOf("kimi-k3", "kimi-k2.7-code", "kimi-extra"),
+            labels = mapOf(
+                "kimi-k3" to "Kimi K3 (256k)",
+                "kimi-k2.7-code" to "Kimi K2.7 Code",
+                "kimi-extra" to "Extra",
+            ),
+        ).copy(
+            modelSlots = mapOf("kimi-k3" to "opus", "kimi-k2.7-code" to "sonnet"),
+            modelOptionsCache = kimiRosterCache(),
+        ),
+        extraArgs = emptyList(),
+        dangerouslySkipPermissions = false,
+    )
+
+    @Test
+    fun `a slot-planted id is not also a cache row`() {
+        val recipe = launchKimiWithSlots()
+        val slotIds = listOf("OPUS", "SONNET", "HAIKU", "FABLE")
+            .mapNotNull { recipe.env["ANTHROPIC_DEFAULT_${it}_MODEL"] }
+            .toSet()
+        val written = Json.parseToJsonElement(
+            Files.readString(tmp.resolve(".claude-kimi/.claude.json")),
+        ).jsonObject.getValue("additionalModelOptionsCache").jsonArray
+        val cacheIds = written.map { it.jsonObject.getValue("value").jsonPrimitive.content }
+        val overlap = slotIds.intersect(cacheIds.toSet())
+        assertTrue(overlap.isEmpty(), "slot ids must not reappear as cache rows: $overlap")
+        assertEquals(listOf("kimi-extra"), cacheIds, "unslotted roster rows stay in the cache")
+        assertEquals(
+            128_000,
+            written.single().jsonObject.getValue("context_window").jsonPrimitive.long,
+            "unslotted rows keep the per-row window the catalog projected",
+        )
+    }
+
+    @Test
+    fun `dropping a slotted cache row keeps the id allowed and the slot labels intact`() {
+        val recipe = launchKimiWithSlots()
+        val settings = Files.readString(tmp.resolve(".claude-kimi/settings.json"))
+        for (id in listOf("kimi-k3", "kimi-k2.7-code", "kimi-extra")) {
+            assertTrue(id in settings, "$id must stay on availableModels so the id stays allowed")
+        }
+        assertEquals("Kimi K3 (256k)", recipe.env["ANTHROPIC_DEFAULT_OPUS_MODEL_NAME"])
+        assertEquals("Kimi K2.7 Code", recipe.env["ANTHROPIC_DEFAULT_SONNET_MODEL_NAME"])
+        assertEquals("272000", recipe.env["CLAUDE_CODE_MAX_CONTEXT_TOKENS"])
     }
 
     // Discovery retirement (2026-08-30). CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY made the

--- a/gateway/control/src/test/kotlin/splice/control/LaunchServiceTest.kt
+++ b/gateway/control/src/test/kotlin/splice/control/LaunchServiceTest.kt
@@ -192,11 +192,6 @@ class LaunchServiceTest {
         assertNull(env["ANTHROPIC_DEFAULT_FABLE_MODEL"])
     }
 
-    // 2026-09-04: Claude Code 2.1.257 picker (gXr/lXr) renders each ANTHROPIC_DEFAULT_*_MODEL as
-    // an alias row (value "opus"/"sonnet"/"haiku"/"fable", label from _NAME) and THEN appends
-    // additionalModelOptionsCache rows whose value is the raw catalog id. eF/nHe only collapse
-    // equal values, so "opus" labeled Sol and "sol" labeled Sol both survive. A model that fills
-    // a slot must not also be a cache row; unslotted roster rows stay, availableModels stays.
     private fun kimiRosterCache() = buildJsonArray {
         addJsonObject {
             put("value", "kimi-k3")
@@ -210,63 +205,71 @@ class LaunchServiceTest {
             put("description", "Kimi K2.7 Code")
             put("context_window", 256_000)
         }
-        addJsonObject {
-            put("value", "kimi-extra")
-            put("label", "Extra")
-            put("description", "Extra")
-            put("context_window", 128_000)
-        }
     }
 
-    /** A three-model kimi head with two of them declared into slots; kimi-extra is unslotted. */
-    private fun launchKimiWithSlots(): LaunchRecipe = service.launch(
+    /** A two-model kimi head, positional: k3 fills opus and fable, k2.7 fills sonnet and haiku. */
+    private fun launchKimiWithRepeatedTier(prefix: String): LaunchRecipe = service.launch(
         spec(
             "kimi",
             pinned = "kimi-k3",
-            available = listOf("kimi-k3", "kimi-k2.7-code", "kimi-extra"),
-            labels = mapOf(
-                "kimi-k3" to "Kimi K3 (256k)",
-                "kimi-k2.7-code" to "Kimi K2.7 Code",
-                "kimi-extra" to "Extra",
-            ),
-        ).copy(
-            modelSlots = mapOf("kimi-k3" to "opus", "kimi-k2.7-code" to "sonnet"),
-            modelOptionsCache = kimiRosterCache(),
-        ),
+            available = listOf("kimi-k3", "kimi-k2.7-code"),
+            labels = mapOf("kimi-k3" to "Kimi K3 (256k)", "kimi-k2.7-code" to "Kimi K2.7 Code"),
+        ).copy(discoveryPrefix = prefix, modelOptionsCache = kimiRosterCache()),
         extraArgs = emptyList(),
         dangerouslySkipPermissions = false,
     )
 
+    // 2026-09-04: Claude Code 2.1.257 draws one picker row per PLANTED tier and dedupes by value
+    // ("opus" vs "fable"), so two tiers on one model listed it twice. A repeated tier is planted
+    // under the head's discovery-wrapped id: routed (catalog.contains unwraps), hidden (not on
+    // availableModels). The first tier, the labels and the cache rows are untouched.
     @Test
-    fun `a slot-planted id is not also a cache row`() {
-        val recipe = launchKimiWithSlots()
-        val slotIds = listOf("OPUS", "SONNET", "HAIKU", "FABLE")
-            .mapNotNull { recipe.env["ANTHROPIC_DEFAULT_${it}_MODEL"] }
-            .toSet()
-        val written = Json.parseToJsonElement(
-            Files.readString(tmp.resolve(".claude-kimi/.claude.json")),
-        ).jsonObject.getValue("additionalModelOptionsCache").jsonArray
-        val cacheIds = written.map { it.jsonObject.getValue("value").jsonPrimitive.content }
-        val overlap = slotIds.intersect(cacheIds.toSet())
-        assertTrue(overlap.isEmpty(), "slot ids must not reappear as cache rows: $overlap")
-        assertEquals(listOf("kimi-extra"), cacheIds, "unslotted roster rows stay in the cache")
+    fun `a tier that repeats an earlier tier's model is planted under the wrapped id`() {
+        val env = launchKimiWithRepeatedTier(prefix = "claude-kimi--").env
+        assertEquals("kimi-k3", env["ANTHROPIC_DEFAULT_OPUS_MODEL"])
+        assertEquals("kimi-k2.7-code", env["ANTHROPIC_DEFAULT_SONNET_MODEL"])
         assertEquals(
-            128_000,
-            written.single().jsonObject.getValue("context_window").jsonPrimitive.long,
-            "unslotted rows keep the per-row window the catalog projected",
+            "claude-kimi--kimi-k2.7-code",
+            env["ANTHROPIC_DEFAULT_HAIKU_MODEL"],
+            "haiku repeats sonnet: wrapped",
         )
+        assertEquals("claude-kimi--kimi-k3", env["ANTHROPIC_DEFAULT_FABLE_MODEL"], "fable repeats opus: wrapped")
+        assertEquals("Kimi K2.7 Code", env["ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME"], "the label stays the model's own")
+        assertEquals("Kimi K3 (256k)", env["ANTHROPIC_DEFAULT_FABLE_MODEL_NAME"])
     }
 
     @Test
-    fun `dropping a slotted cache row keeps the id allowed and the slot labels intact`() {
-        val recipe = launchKimiWithSlots()
-        val settings = Files.readString(tmp.resolve(".claude-kimi/settings.json"))
-        for (id in listOf("kimi-k3", "kimi-k2.7-code", "kimi-extra")) {
-            assertTrue(id in settings, "$id must stay on availableModels so the id stays allowed")
-        }
-        assertEquals("Kimi K3 (256k)", recipe.env["ANTHROPIC_DEFAULT_OPUS_MODEL_NAME"])
-        assertEquals("Kimi K2.7 Code", recipe.env["ANTHROPIC_DEFAULT_SONNET_MODEL_NAME"])
-        assertEquals("272000", recipe.env["CLAUDE_CODE_MAX_CONTEXT_TOKENS"])
+    fun `positional fill plants the repeated frontier and mid tiers under the wrapped id`() {
+        val env = service.launch(
+            spec("codex", available = listOf("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"))
+                .copy(discoveryPrefix = "claude-codex--"),
+            extraArgs = emptyList(),
+            dangerouslySkipPermissions = false,
+        ).env
+        assertEquals("gpt-5.6-sol", env["ANTHROPIC_DEFAULT_OPUS_MODEL"])
+        assertEquals("gpt-5.6-terra", env["ANTHROPIC_DEFAULT_SONNET_MODEL"])
+        assertEquals("gpt-5.6-luna", env["ANTHROPIC_DEFAULT_HAIKU_MODEL"])
+        assertEquals(
+            "claude-codex--gpt-5.6-sol",
+            env["ANTHROPIC_DEFAULT_FABLE_MODEL"],
+            "fable shares the frontier: wrapped",
+        )
+        assertEquals("gpt-5.6-sol", env["ANTHROPIC_DEFAULT_FABLE_MODEL_NAME"], "the label is the model's own")
+    }
+
+    @Test
+    fun `a head without a discovery prefix keeps the repeated tier bare, and the cache keeps every row`() {
+        val recipe = launchKimiWithRepeatedTier(prefix = "")
+        assertEquals("kimi-k3", recipe.env["ANTHROPIC_DEFAULT_OPUS_MODEL"])
+        val written = Json.parseToJsonElement(
+            Files.readString(tmp.resolve(".claude-kimi/.claude.json")),
+        ).jsonObject.getValue("additionalModelOptionsCache").jsonArray
+        assertEquals(
+            listOf("kimi-k3", "kimi-k2.7-code"),
+            written.map { it.jsonObject.getValue("value").jsonPrimitive.content },
+            "every roster row stays in the cache: Claude Code dedupes them against the tiers itself",
+        )
+        assertEquals(256_000, written.first().jsonObject.getValue("context_window").jsonPrimitive.long)
     }
 
     // Discovery retirement (2026-08-30). CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY made the

--- a/gateway/core/src/main/kotlin/splice/core/Versions.kt
+++ b/gateway/core/src/main/kotlin/splice/core/Versions.kt
@@ -3,7 +3,7 @@
 // /health). Single daemon (P4): one version restarts every head together (documented change).
 package splice.core
 
-public const val GATEWAY_VERSION: String = "0.3.0"
+public const val GATEWAY_VERSION: String = "0.3.1"
 
 // Hand-paired with the SPLICE_SHIM_VERSION marker embedded in bin/splice-launch (same
 // hand-paired pattern as GATEWAY_VERSION/wantVersion already used for head staleness in

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnLine.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnLine.kt
@@ -35,11 +35,12 @@ internal class TurnLine(
      *  sentinel says a client frame was seen — and it prints the CONFIGURED streamIdle, never the
      *  limit that fired. Their perf rows carried no first_frame and no content_frames_out at all,
      *  i.e. the round's client-frame probe should have read false and put them on the first-output
-     *  tier, which a compact turn lifts to the whole-turn cap. Message and counters disagreed and
-     *  nothing in the log could break the tie, because the one number that would — the limit the
-     *  poller compared against — was never written down. The production-path test for exactly this
-     *  case passes, so the harness does not reproduce whatever the live path does; the next
-     *  occurrence has to answer for itself. Absent a fire this adds nothing to the line. */
+     *  tier, a tier a compact turn does not have (WatchdogBudget.forCompact switches it off), so
+     *  only the whole-turn cap could have ended them. Message and counters disagreed and nothing in
+     *  the log could break the tie, because the one number that would — the limit the poller
+     *  compared against — was never written down. The production-path test for exactly this case
+     *  passes, so the harness does not reproduce whatever the live path does; the next occurrence
+     *  has to answer for itself. Absent a fire this adds nothing to the line. */
     private fun verdict(fired: WatchdogFired?): String = when (fired) {
         null -> ""
         is WatchdogFired.Idle -> {

--- a/gateway/gateway/src/test/kotlin/head/HeadServerIntegrationTest.kt
+++ b/gateway/gateway/src/test/kotlin/head/HeadServerIntegrationTest.kt
@@ -59,6 +59,13 @@ class HeadServerIntegrationTest {
 
     private val mock = MockChatGptUpstream()
     private val client = HttpClient(CIO) {
+        // CIO's engine default caps a call at 15s (CIOEngineConfig.requestTimeout). On a loaded CI
+        // runner a turn that lands late trips it, the client hangs up, TurnFinish's terminal write
+        // hits a dead socket and the perf row lands as a conn-reset tag instead of "ok" (runs
+        // 33608202738 on 2026-09-02 and 33928312116 on 2026-09-04, both at the "expected a perf
+        // line" assertion; green locally every time). The awaitLog ceiling below is the one
+        // clock a test here should run on, so the engine's own is off.
+        engine { requestTimeout = 0 }
         defaultRequest { bearerAuth("test-inference-token") }
     }
     private val port = freshPort()

--- a/gateway/gateway/src/test/kotlin/head/TurnFinishTest.kt
+++ b/gateway/gateway/src/test/kotlin/head/TurnFinishTest.kt
@@ -4,8 +4,11 @@
 // stays Success. Pre-fix the turn line said success, head health recorded nothing, and (for the
 // collect rewrite) the perf row said "ok" — the client saw a 502 while every instrument read
 // green. These arms drive TurnFinish directly: outcome in, then assert what the instruments saw.
+// The watchdog arms fire real pollers first, then prove TurnFinish carries each sentinel into the line.
 package head
 
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.serialization.json.buildJsonObject
@@ -15,6 +18,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import splice.core.perf.TurnPerf
+import splice.core.turn.ErrorType
 import splice.core.turn.ReasoningDisplay
 import splice.core.turn.TurnMeta
 import splice.core.turn.TurnOutcome
@@ -39,12 +43,16 @@ import splice.gateway.wire.CollectingTerminal
 import splice.gateway.wire.ImmediateSseWriter
 import splice.gateway.wire.TurnTerminal
 import splice.gateway.wire.UsagePayloadBuilder
+import splice.spi.ClientFrameEmitted
 import splice.spi.InflightGate
 import splice.spi.LiveLimit
+import splice.spi.Ticker
 import splice.spi.TurnWatchdog
+import splice.spi.WatchdogFired
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -55,6 +63,16 @@ class TurnFinishTest {
     @BeforeAll
     fun setUp() {
         tmp = Files.createTempDirectory("turn-finish")
+    }
+
+    private class VirtualTicks {
+        var now = 0L
+            private set
+        val clock = ElapsedClock { now }
+        val ticker = Ticker { intervalMs ->
+            now += intervalMs
+            true
+        }
     }
 
     /** One TurnFinish with observable instruments; [tag] isolates each test's files. */
@@ -72,7 +90,10 @@ class TurnFinishTest {
             telemetry,
         )
 
-        suspend fun drive(emitter: TurnTerminal): TurnDrive = TurnDrive(
+        suspend fun drive(
+            emitter: TurnTerminal,
+            watchdog: TurnWatchdog = TurnWatchdog(WatchdogBudget(10.seconds, 10.seconds, 30.seconds)),
+        ): TurnDrive = TurnDrive(
             requestBody = buildJsonObject { },
             meta = TurnMeta(
                 compact = false,
@@ -86,7 +107,7 @@ class TurnFinishTest {
                 budgetTokens = null,
             ),
             emitter = emitter,
-            watchdog = TurnWatchdog(WatchdogBudget(10.seconds, 10.seconds, 30.seconds)),
+            watchdog = watchdog,
             slot = InflightGate(LiveLimit { 1 }).acquire(),
             pipeline = TurnPipeline(
                 CompactStats(perfFile.resolveSibling("compact-dr8x.jsonl")),
@@ -105,6 +126,64 @@ class TurnFinishTest {
             ),
             toolSearch = null,
         )
+    }
+
+    private suspend fun finishAndReadTurnLine(tag: String, watchdog: TurnWatchdog): String {
+        val rig = Rig(tmp, tag)
+        val emitter = CollectingTerminal("gpt-5.6-sol", UsagePayloadBuilder { buildJsonObject { } })
+        val drive = rig.drive(emitter, watchdog)
+        try {
+            rig.finish.finishTurn(drive, TurnOutcome.Failure(ErrorType.OVERLOADED, "upstream stalled"))
+        } finally {
+            drive.slot.release()
+        }
+        return rig.logs.first()
+    }
+
+    @Test
+    fun `a fired mid-output idle watchdog reaches the rendered turn line`() = runBlocking {
+        val ticks = VirtualTicks()
+        val watchdog = TurnWatchdog(
+            WatchdogBudget(10.seconds, 100.milliseconds, 30.seconds),
+            clock = ticks.clock,
+            ticker = ticks.ticker,
+        )
+        val slot = InflightGate(LiveLimit { 1 }, clock = ticks.clock).acquire()
+        val target = launch { delay(10.seconds) }
+        val poller = watchdog.launchIn(this, slot, target, ClientFrameEmitted { true })
+        try {
+            target.join()
+        } finally {
+            poller.cancel()
+            slot.release()
+        }
+        assertTrue(watchdog.fired is WatchdogFired.Idle, "setup must fire the mid-output idle tier")
+
+        val line = finishAndReadTurnLine("watchdog-idle", watchdog)
+
+        assertTrue("watchdog=idle(tier=mid-output limit=100ms idle=250ms)" in line, line)
+    }
+
+    @Test
+    fun `a fired total cap watchdog reaches the rendered turn line`() = runBlocking {
+        val ticks = VirtualTicks()
+        val watchdog = TurnWatchdog(
+            WatchdogBudget(10.seconds, 10.seconds, 400.milliseconds),
+            clock = ticks.clock,
+            ticker = ticks.ticker,
+        )
+        val target = launch { delay(10.seconds) }
+        val poller = watchdog.launchTotalCap(this, target)
+        try {
+            target.join()
+        } finally {
+            poller.cancel()
+        }
+        assertTrue(watchdog.fired is WatchdogFired.TotalCap, "setup must fire the whole-turn cap")
+
+        val line = finishAndReadTurnLine("watchdog-cap", watchdog)
+
+        assertTrue("watchdog=total-cap(elapsed=500ms)" in line, line)
     }
 
     @Test

--- a/gateway/gateway/src/test/kotlin/head/TurnLineWatchdogVerdictTest.kt
+++ b/gateway/gateway/src/test/kotlin/head/TurnLineWatchdogVerdictTest.kt
@@ -3,10 +3,8 @@
 // The gap this closes, from the live log: five compactions died saying "no completion within the
 // 180s idle cap". That wording is chosen by the fired sentinel's sawClientFrame flag, and the
 // number in it is the CONFIGURED streamIdle, never the limit the poller actually compared against.
-// Their perf rows had no first_frame and no content_frames_out, so the round's client-frame probe
-// should have read false and put them on the first-output tier — which a compact turn lifts to the
-// whole-turn cap. Message and counters disagreed and the log could not break the tie. These arms
-// pin the tie-breaker: the tier NAME, the limit that fired, and the idleness that tripped it.
+// A compact turn has no first-output tier: WatchdogBudget.forCompact disables it, so only the
+// total cap can end a silent compaction. These arms pin the valid verdicts and their measured values.
 package head
 
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -51,32 +49,30 @@ class TurnLineWatchdogVerdictTest {
         assertTrue("watchdog=idle(tier=mid-output limit=180000ms idle=180004ms)" in rendered, rendered)
     }
 
-    // THE ONE THAT WOULD HAVE SETTLED IT. A compaction with no client frame must read first-output,
-    // and its limit is the whole-turn cap, not streamIdle. If the live line had carried this, the
-    // five stalls would have said in one grep whether the probe or the message was lying.
     @Test
-    fun `a first-output fire on a compaction names the lifted cap, not the idle tier`() {
+    fun `a first-output fire on a non-compact turn names its real tier`() {
         val rendered = line.render(
-            meta(compact = true),
+            meta(compact = false),
             "gpt-5.6-sol",
             stalled,
-            latencyMs = 900_120,
-            fired = WatchdogFired.Idle(idleMs = 900_001, sawClientFrame = false, limitMs = 900_000),
+            latencyMs = 300_120,
+            fired = WatchdogFired.Idle(idleMs = 300_001, sawClientFrame = false, limitMs = 300_000),
         )
-        assertTrue("watchdog=idle(tier=first-output limit=900000ms idle=900001ms)" in rendered, rendered)
+        assertTrue("watchdog=idle(tier=first-output limit=300000ms idle=300001ms)" in rendered, rendered)
         assertFalse("mid-output" in rendered, "a turn the client never saw output from is not mid-output: $rendered")
     }
 
     @Test
-    fun `a whole-turn cap fire names its elapsed, which no idle tier explains`() {
+    fun `a silent compaction ended by the total cap names that verdict`() {
         val rendered = line.render(
-            meta(compact = false),
+            meta(compact = true),
             "gpt-5.6-sol",
             stalled,
             latencyMs = 900_030,
             fired = WatchdogFired.TotalCap(elapsedMs = 900_002),
         )
         assertTrue("watchdog=total-cap(elapsed=900002ms)" in rendered, rendered)
+        assertFalse("first-output" in rendered, "a compact turn has no pre-output idle tier: $rendered")
     }
 
     @Test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "splice",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "splice",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "workspaces": [
         "webui"
       ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "splice",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "engines": {
     "node": ">=24"
   },


### PR DESCRIPTION
Merging this PR IS the promotion: the resulting push to prod fires release.yml, which re-gates, builds, attests, and publishes **v0.3.1** with the tag created at the promoted commit.

Merge with a **merge commit**, not squash.