### PR TITLE
fix(launch): a tier that repeats another tier's model is planted under the wrapped id, so the picker draws it once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@
 
 ### Fixed
 
-- **The `/model` picker lists each model once.** Every head showed its slotted models twice (Sol
-  twice on `claudex`; Kimi K3 (256k) and Kimi K2.7 Code twice on `claude-kimi`). Both rows were
-  ours: the launch recipe plants `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU,FABLE}_MODEL`, which Claude
-  Code renders as its tier rows with the `_NAME` label, and then appends every
-  `additionalModelOptionsCache` row under the raw catalog id, and its dedupe compares values only.
-  The materialized cache now omits any id already planted in a slot; `availableModels` keeps every
-  id, so a saved model choice stays allowed, and unslotted rows keep their fields.
+- **The `/model` picker lists each model once.** Every head showed a slotted model twice (Sol
+  twice on `claudex`; Kimi K3 (256k) and Kimi K2.7 Code twice on `claude-kimi`). Claude Code draws
+  one row per planted tier (`ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU,FABLE}_MODEL`) and dedupes rows
+  by their alias, so two tiers on one model drew it twice: Fable shares the frontier with Opus, and
+  on a two-model head Haiku shares Sonnet. A tier cannot be left unset, because its alias then
+  resolves to Claude Code's built-in model, which the head rejects. A repeated tier is now planted
+  under the head's discovery-wrapped spelling (`claude-codex--gpt-5.6-sol`): the head routes it
+  like the bare id, and the picker's allowlist hides the row. Cache rows are unchanged; they are
+  where the Default line's label comes from.
 
 ### Changed
 

--- a/checks/e2e/docker/inside.sh
+++ b/checks/e2e/docker/inside.sh
@@ -308,9 +308,10 @@ step "launch recipe: mockchat base URL + API_TIMEOUT_MS > 900s" launch_recipe mo
 # Each head materializes its OWN picker (settings.json availableModels + model, enforced, and a
 # .claude.json additionalModelOptionsCache row per model carrying its context_window) and hands
 # Claude Code its own CLAUDE_CODE_MAX_CONTEXT_TOKENS, from the topology alone. The four tier
-# slots (ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU,FABLE}_MODEL) must carry four DISTINCT values: two
-# tiers on one bare id drew that model twice in /model (v0.3.0); a repeated tier now rides the
-# head's discovery-wrapped spelling, which the allowlist hides and the head still routes. Three
+# slots (ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU,FABLE}_MODEL) never share a BARE id: two tiers on
+# one bare id drew that model twice in /model (v0.3.0); a repeated tier now rides the head's
+# discovery-wrapped spelling, which the allowlist hides (so wrapped values may repeat) and the
+# head still routes. Three
 # heads, three windows: a head reading another head's roster or window is exactly the
 # fresh-install drift this step exists to catch.
 # The same /launch also PACKAGES the head: the daemon's own status line (settings.json statusLine
@@ -348,8 +349,10 @@ assert settings.get("enforceAvailableModels") is True, "picker is not enforced"
 assert rows == expected_rows, rows
 slots = [v for k, v in sorted(env.items()) if re.fullmatch(r"ANTHROPIC_DEFAULT_(OPUS|SONNET|HAIKU|FABLE)_MODEL", k)]
 print("slots:", slots)
-assert len(set(slots)) == len(slots), "two tiers carry one value, so /model draws that model twice: %r" % slots
-assert all(any(v == m or v.endswith("--" + m) for m in expected_rows) for v in slots), "a tier points outside the roster: %r" % slots
+bare = [v for v in slots if v in expected_rows]
+wrapped = [v for v in slots if v not in expected_rows]
+assert len(set(bare)) == len(bare), "two tiers carry one bare id, so /model draws that model twice: %r" % slots
+assert all(any(v.endswith("--" + m) for m in expected_rows) for v in wrapped), "a tier points outside the roster: %r" % slots
 assert statusline == f"curl -sS --data-binary @- http://127.0.0.1:{control}/statusline/{head}", "status line not splice's: %r" % statusline
 assert os.path.isfile(login_md), "no in-session /login command materialized"
 assert any("splice-login-hook" in c for c in hook_cmds), "no /login hook on UserPromptSubmit: %r" % hook_cmds

--- a/checks/e2e/docker/inside.sh
+++ b/checks/e2e/docker/inside.sh
@@ -305,13 +305,14 @@ step "launch recipe: claudex base URL + API_TIMEOUT_MS > 900s" launch_recipe cla
 step "launch recipe: mockchat base URL + API_TIMEOUT_MS > 900s" launch_recipe mockchat "$CHAT_HEAD_PORT"
 
 # ── 7b. per-head model roster + window: what /model offers, what the client compacts on ─────
-# Each head materializes its OWN picker (settings.json availableModels + model, enforced) and
-# hands Claude Code its own CLAUDE_CODE_MAX_CONTEXT_TOKENS, from the topology alone. Every
-# catalog model reaches the picker EXACTLY ONCE (v0.3.1): either as a tier slot the recipe plants
-# (ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU,FABLE}_MODEL, which Claude Code renders as its own rows)
-# or as a .claude.json additionalModelOptionsCache row carrying its context_window, never both
-# (both was the duplicated picker of v0.3.0). Three heads, three windows: a head reading another
-# head's roster or window is exactly the fresh-install drift this step exists to catch.
+# Each head materializes its OWN picker (settings.json availableModels + model, enforced, and a
+# .claude.json additionalModelOptionsCache row per model carrying its context_window) and hands
+# Claude Code its own CLAUDE_CODE_MAX_CONTEXT_TOKENS, from the topology alone. The four tier
+# slots (ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU,FABLE}_MODEL) must carry four DISTINCT values: two
+# tiers on one bare id drew that model twice in /model (v0.3.0); a repeated tier now rides the
+# head's discovery-wrapped spelling, which the allowlist hides and the head still routes. Three
+# heads, three windows: a head reading another head's roster or window is exactly the
+# fresh-install drift this step exists to catch.
 # The same /launch also PACKAGES the head: the daemon's own status line (settings.json statusLine
 # posting Claude Code's blob to /statusline/<head>), the in-session /login command and the hook
 # that runs the head's sign-in when it is submitted. Splice is the whole package, so a head that
@@ -344,11 +345,11 @@ assert env.get("CLAUDE_CODE_AUTO_COMPACT_WINDOW") == str(window), env.get("CLAUD
 assert settings.get("model") == model, settings.get("model")
 assert settings.get("availableModels") == list(expected_rows), "picker off: %r" % settings.get("availableModels")
 assert settings.get("enforceAvailableModels") is True, "picker is not enforced"
-slots = {v for k, v in env.items() if re.fullmatch(r"ANTHROPIC_DEFAULT_(OPUS|SONNET|HAIKU|FABLE)_MODEL", k)}
-print("slots:", sorted(slots))
-assert not (set(rows) & slots), "a slotted model is also a cache row (the v0.3.0 duplication): %r" % (set(rows) & slots)
-assert slots | set(rows) == set(expected_rows), "picker roster %r != expected %r" % (sorted(slots | set(rows)), sorted(expected_rows))
-assert all(rows[m] == expected_rows[m] for m in rows), "cache row windows off: %r" % rows
+assert rows == expected_rows, rows
+slots = [v for k, v in sorted(env.items()) if re.fullmatch(r"ANTHROPIC_DEFAULT_(OPUS|SONNET|HAIKU|FABLE)_MODEL", k)]
+print("slots:", slots)
+assert len(set(slots)) == len(slots), "two tiers carry one value, so /model draws that model twice: %r" % slots
+assert all(any(v == m or v.endswith("--" + m) for m in expected_rows) for v in slots), "a tier points outside the roster: %r" % slots
 assert statusline == f"curl -sS --data-binary @- http://127.0.0.1:{control}/statusline/{head}", "status line not splice's: %r" % statusline
 assert os.path.isfile(login_md), "no in-session /login command materialized"
 assert any("splice-login-hook" in c for c in hook_cmds), "no /login hook on UserPromptSubmit: %r" % hook_cmds

--- a/gateway/app/src/main/kotlin/splice/app/head/LaunchSpecFactory.kt
+++ b/gateway/app/src/main/kotlin/splice/app/head/LaunchSpecFactory.kt
@@ -57,6 +57,7 @@ internal class LaunchSpecFactory(
             // reinterpreting the declaration. See ManagedHeadFactory.forwardClientAuth.
             forwardClientAuth = forwardClientAuth,
             pinnedModel = head.pinnedModel,
+            discoveryPrefix = head.discoveryPrefix,
             availableModelIds = ctx.catalog.availableModelIds(),
             modelLabels = ctx.catalog.models.associate { it.id to it.label.ifEmpty { it.id } },
             modelSlots = head.models.orEmpty().mapNotNull { model ->

--- a/gateway/control/src/main/kotlin/splice/control/LaunchService.kt
+++ b/gateway/control/src/main/kotlin/splice/control/LaunchService.kt
@@ -12,10 +12,6 @@
 // only), which per-head context windows depend on.
 package splice.control
 
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import splice.core.launch.ClaudeConfigMaterializer
 import splice.core.launch.MaterializeSpec
 import splice.core.util.EnvReader
@@ -47,21 +43,14 @@ public class LaunchService(
         keyPresentNow: Boolean = true,
     ): LaunchRecipe {
         val effective = if (keyPresentNow) spec.copy(tokenCapture = null, advertiseKeySetup = false) else spec
-        // Slots first: the picker filter needs the planted ids, including positional fill
-        // (a declared-empty head still plants four tiers). LaunchSpec.modelOptionsCache stays
-        // the full catalog projection; only the materialized cache is stripped.
         val slots = aliasSlots(effective)
-        val pickerCache = cacheWithoutSlotIds(
-            effective.modelOptionsCache,
-            slots.map { it.second }.toSet(),
-        )
         materializer.materialize(
             MaterializeSpec(
                 configDir = effective.configDir,
                 policy = effective.policy,
                 availableModelIds = effective.availableModelIds,
                 defaultModel = effective.pinnedModel,
-                modelOptionsCache = pickerCache,
+                modelOptionsCache = effective.modelOptionsCache,
                 statuslineCommand = effective.statuslineCommand,
                 loginCommand = effective.loginCommand,
                 signInLabel = effective.signInLabel,
@@ -87,24 +76,6 @@ public class LaunchService(
             null
         }
         return LaunchRecipe(env, unset, argv, warning)
-    }
-
-    // Claude Code 2.1.257 picker (gXr) starts from lXr slot rows whose value is the alias
-    // ("opus"/"sonnet"/"haiku"/"fable") and label is ANTHROPIC_DEFAULT_*_MODEL_NAME, then
-    // appends additionalModelOptionsCache rows whose value is the raw catalog id. eF/nHe
-    // collapse equal values only, so a slot labeled Sol plus a cache row valued "sol" both
-    // survive and the picker lists the same model twice. Drop cache rows whose value is
-    // already a planted slot id; keep availableModels so the id stays allowed, keep
-    // unslotted rows (including context_window, which vP ignores; Claude Code's window is
-    // CLAUDE_CODE_MAX_CONTEXT_TOKENS), keep slot NAME/DESCRIPTION.
-    private fun cacheWithoutSlotIds(cache: JsonElement, slotIds: Set<String>): JsonElement {
-        val rows = cache as? JsonArray ?: return cache
-        return JsonArray(
-            rows.filter { row ->
-                val value = (row as? JsonObject)?.get("value")?.jsonPrimitive?.content
-                value !in slotIds
-            },
-        )
     }
 
     /** Vars a launched head must SCRUB from the inherited environment: bin/splice-launch execs
@@ -152,8 +123,25 @@ public class LaunchService(
             // availableModels + .claude.json additionalModelOptionsCache) — see the header for why
             // the wrapped /v1/models spelling must never reach the picker.
             put("ANTHROPIC_MODEL", spec.pinnedModel)
+            // The picker lists one row per PLANTED TIER (Claude Code 2.1.257: fen()/hen()/uen()
+            // emit a row whenever ANTHROPIC_DEFAULT_<tier>_MODEL is set, value = the alias, label =
+            // _NAME) and dedupes rows by value only, so two tiers on one model drew that model
+            // twice: Sol as opus and as fable on claudex, K2.7 Code as sonnet and as haiku on
+            // claude-kimi (the 2026-09-04 release recording). The tier cannot be left unset: the
+            // alias then resolves to Claude Code's built-in model, which this head rejects
+            // ("proxies its own models only"), and every fable- or haiku-tiered subagent dies.
+            // The one lever is the allowlist: a tier row whose model is not on availableModels is
+            // hidden, while the head accepts its own DISCOVERY-WRAPPED spelling (catalog.contains
+            // unwraps). So a repeated tier is planted as "<prefix><id>": routed like the first, drawn
+            // never. Cache rows are untouched on purpose: Claude Code already drops a cache row that
+            // repeats a tier's model, and the cache row is where the Default line's label comes from
+            // (stripping them printed "currently gpt-5.6-sol[1m]"; verified live 2026-09-04). Known
+            // cost: a subagent on the wrapped tier runs under a wrapped ACTIVE id, for which Claude
+            // Code does not honor CLAUDE_CODE_MAX_CONTEXT_TOKENS (header note).
+            val planted = mutableSetOf<String>()
             slots.forEach { (slot, model) ->
-                put("ANTHROPIC_DEFAULT_${slot}_MODEL", model)
+                val repeated = !planted.add(model) && spec.discoveryPrefix.isNotBlank()
+                put("ANTHROPIC_DEFAULT_${slot}_MODEL", if (repeated) spec.discoveryPrefix + model else model)
                 val label = spec.modelLabels[model] ?: model
                 put("ANTHROPIC_DEFAULT_${slot}_MODEL_NAME", label)
                 put("ANTHROPIC_DEFAULT_${slot}_MODEL_DESCRIPTION", label)

--- a/gateway/control/src/main/kotlin/splice/control/LaunchTypes.kt
+++ b/gateway/control/src/main/kotlin/splice/control/LaunchTypes.kt
@@ -21,6 +21,10 @@ public data class LaunchSpec(
      *  fully retired for that head, and an undeclared tier stays un-set rather than pointing a
      *  second alias at an already-claimed model (the 2-model duplication this exists to remove). */
     val modelSlots: Map<String, String> = emptyMap(),
+    /** The head's discovery prefix ("claude-codex--"): a tier that repeats an earlier tier's model
+     *  is planted under this wrapped spelling so the picker's allowlist hides its row (see
+     *  LaunchService.buildEnv). Blank keeps the duplicate row. */
+    val discoveryPrefix: String = "",
     val contextWindow: Long,
     /** Claude Code's per-request timeout (API_TIMEOUT_MS) for THIS head: the daemon's whole-turn
      *  cap plus a grace, so the client always outlives the proxy's own wall and receives its honest

--- a/gateway/control/src/test/kotlin/splice/control/LaunchServiceTest.kt
+++ b/gateway/control/src/test/kotlin/splice/control/LaunchServiceTest.kt
@@ -192,11 +192,6 @@ class LaunchServiceTest {
         assertNull(env["ANTHROPIC_DEFAULT_FABLE_MODEL"])
     }
 
-    // 2026-09-04: Claude Code 2.1.257 picker (gXr/lXr) renders each ANTHROPIC_DEFAULT_*_MODEL as
-    // an alias row (value "opus"/"sonnet"/"haiku"/"fable", label from _NAME) and THEN appends
-    // additionalModelOptionsCache rows whose value is the raw catalog id. eF/nHe only collapse
-    // equal values, so "opus" labeled Sol and "sol" labeled Sol both survive. A model that fills
-    // a slot must not also be a cache row; unslotted roster rows stay, availableModels stays.
     private fun kimiRosterCache() = buildJsonArray {
         addJsonObject {
             put("value", "kimi-k3")
@@ -210,63 +205,71 @@ class LaunchServiceTest {
             put("description", "Kimi K2.7 Code")
             put("context_window", 256_000)
         }
-        addJsonObject {
-            put("value", "kimi-extra")
-            put("label", "Extra")
-            put("description", "Extra")
-            put("context_window", 128_000)
-        }
     }
 
-    /** A three-model kimi head with two of them declared into slots; kimi-extra is unslotted. */
-    private fun launchKimiWithSlots(): LaunchRecipe = service.launch(
+    /** A two-model kimi head, positional: k3 fills opus and fable, k2.7 fills sonnet and haiku. */
+    private fun launchKimiWithRepeatedTier(prefix: String): LaunchRecipe = service.launch(
         spec(
             "kimi",
             pinned = "kimi-k3",
-            available = listOf("kimi-k3", "kimi-k2.7-code", "kimi-extra"),
-            labels = mapOf(
-                "kimi-k3" to "Kimi K3 (256k)",
-                "kimi-k2.7-code" to "Kimi K2.7 Code",
-                "kimi-extra" to "Extra",
-            ),
-        ).copy(
-            modelSlots = mapOf("kimi-k3" to "opus", "kimi-k2.7-code" to "sonnet"),
-            modelOptionsCache = kimiRosterCache(),
-        ),
+            available = listOf("kimi-k3", "kimi-k2.7-code"),
+            labels = mapOf("kimi-k3" to "Kimi K3 (256k)", "kimi-k2.7-code" to "Kimi K2.7 Code"),
+        ).copy(discoveryPrefix = prefix, modelOptionsCache = kimiRosterCache()),
         extraArgs = emptyList(),
         dangerouslySkipPermissions = false,
     )
 
+    // 2026-09-04: Claude Code 2.1.257 draws one picker row per PLANTED tier and dedupes by value
+    // ("opus" vs "fable"), so two tiers on one model listed it twice. A repeated tier is planted
+    // under the head's discovery-wrapped id: routed (catalog.contains unwraps), hidden (not on
+    // availableModels). The first tier, the labels and the cache rows are untouched.
     @Test
-    fun `a slot-planted id is not also a cache row`() {
-        val recipe = launchKimiWithSlots()
-        val slotIds = listOf("OPUS", "SONNET", "HAIKU", "FABLE")
-            .mapNotNull { recipe.env["ANTHROPIC_DEFAULT_${it}_MODEL"] }
-            .toSet()
-        val written = Json.parseToJsonElement(
-            Files.readString(tmp.resolve(".claude-kimi/.claude.json")),
-        ).jsonObject.getValue("additionalModelOptionsCache").jsonArray
-        val cacheIds = written.map { it.jsonObject.getValue("value").jsonPrimitive.content }
-        val overlap = slotIds.intersect(cacheIds.toSet())
-        assertTrue(overlap.isEmpty(), "slot ids must not reappear as cache rows: $overlap")
-        assertEquals(listOf("kimi-extra"), cacheIds, "unslotted roster rows stay in the cache")
+    fun `a tier that repeats an earlier tier's model is planted under the wrapped id`() {
+        val env = launchKimiWithRepeatedTier(prefix = "claude-kimi--").env
+        assertEquals("kimi-k3", env["ANTHROPIC_DEFAULT_OPUS_MODEL"])
+        assertEquals("kimi-k2.7-code", env["ANTHROPIC_DEFAULT_SONNET_MODEL"])
         assertEquals(
-            128_000,
-            written.single().jsonObject.getValue("context_window").jsonPrimitive.long,
-            "unslotted rows keep the per-row window the catalog projected",
+            "claude-kimi--kimi-k2.7-code",
+            env["ANTHROPIC_DEFAULT_HAIKU_MODEL"],
+            "haiku repeats sonnet: wrapped",
         )
+        assertEquals("claude-kimi--kimi-k3", env["ANTHROPIC_DEFAULT_FABLE_MODEL"], "fable repeats opus: wrapped")
+        assertEquals("Kimi K2.7 Code", env["ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME"], "the label stays the model's own")
+        assertEquals("Kimi K3 (256k)", env["ANTHROPIC_DEFAULT_FABLE_MODEL_NAME"])
     }
 
     @Test
-    fun `dropping a slotted cache row keeps the id allowed and the slot labels intact`() {
-        val recipe = launchKimiWithSlots()
-        val settings = Files.readString(tmp.resolve(".claude-kimi/settings.json"))
-        for (id in listOf("kimi-k3", "kimi-k2.7-code", "kimi-extra")) {
-            assertTrue(id in settings, "$id must stay on availableModels so the id stays allowed")
-        }
-        assertEquals("Kimi K3 (256k)", recipe.env["ANTHROPIC_DEFAULT_OPUS_MODEL_NAME"])
-        assertEquals("Kimi K2.7 Code", recipe.env["ANTHROPIC_DEFAULT_SONNET_MODEL_NAME"])
-        assertEquals("272000", recipe.env["CLAUDE_CODE_MAX_CONTEXT_TOKENS"])
+    fun `positional fill plants the repeated frontier and mid tiers under the wrapped id`() {
+        val env = service.launch(
+            spec("codex", available = listOf("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"))
+                .copy(discoveryPrefix = "claude-codex--"),
+            extraArgs = emptyList(),
+            dangerouslySkipPermissions = false,
+        ).env
+        assertEquals("gpt-5.6-sol", env["ANTHROPIC_DEFAULT_OPUS_MODEL"])
+        assertEquals("gpt-5.6-terra", env["ANTHROPIC_DEFAULT_SONNET_MODEL"])
+        assertEquals("gpt-5.6-luna", env["ANTHROPIC_DEFAULT_HAIKU_MODEL"])
+        assertEquals(
+            "claude-codex--gpt-5.6-sol",
+            env["ANTHROPIC_DEFAULT_FABLE_MODEL"],
+            "fable shares the frontier: wrapped",
+        )
+        assertEquals("gpt-5.6-sol", env["ANTHROPIC_DEFAULT_FABLE_MODEL_NAME"], "the label is the model's own")
+    }
+
+    @Test
+    fun `a head without a discovery prefix keeps the repeated tier bare, and the cache keeps every row`() {
+        val recipe = launchKimiWithRepeatedTier(prefix = "")
+        assertEquals("kimi-k3", recipe.env["ANTHROPIC_DEFAULT_OPUS_MODEL"])
+        val written = Json.parseToJsonElement(
+            Files.readString(tmp.resolve(".claude-kimi/.claude.json")),
+        ).jsonObject.getValue("additionalModelOptionsCache").jsonArray
+        assertEquals(
+            listOf("kimi-k3", "kimi-k2.7-code"),
+            written.map { it.jsonObject.getValue("value").jsonPrimitive.content },
+            "every roster row stays in the cache: Claude Code dedupes them against the tiers itself",
+        )
+        assertEquals(256_000, written.first().jsonObject.getValue("context_window").jsonPrimitive.long)
     }
 
     // Discovery retirement (2026-08-30). CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY made the


### PR DESCRIPTION
The 0.3.1 dedupe (#126) removed slotted models from additionalModelOptionsCache and did not
remove the duplicate: re-recorded on the fixed daemon, /model on claudex still listed Sol twice
and on claude-kimi K3 and K2.7 Code twice, and the Default line lost its label ("currently
gpt-5.6-sol[1m]"). Read against Claude Code 2.1.257's picker: it draws one row per PLANTED tier
(fen/hen/uen emit a row whenever ANTHROPIC_DEFAULT_<tier>_MODEL is set) and dedupes rows by
alias, so Fable sharing the frontier with Opus, and Haiku sharing Sonnet on a two-model head, is
the duplication; cache rows that repeat a tier's model were already dropped by Claude Code, and
they are where the Default line's label comes from.

A tier cannot be left unset: the alias then resolves to Claude Code's built-in model, which the
head rejects ("proxies its own models only"), and every fable- or haiku-tiered subagent dies.
The lever is the allowlist. A repeated tier is now planted as "<discovery prefix><id>": the head
routes it like the bare id (catalog.contains unwraps; count_tokens on the claudex head answered
200 to claude-codex--gpt-5.6-sol), and the picker hides a tier whose model is not on
availableModels. Verified live 2026-09-04 with the recipe env edited by hand: eight rows, Sol
once, "currently Codex 5.6 Sol". The cache is materialized in full again.

LaunchSpec carries the head's discoveryPrefix (blank keeps the bare duplicate). LaunchServiceTest
pins the wrapped haiku and fable on a positional two-model head and on the codex roster, and that
a prefix-less head keeps every cache row; 20 tests. The Docker e2e head contract goes back to a
cache row per model and adds: the four tier values are distinct and point inside the roster.
CHANGELOG 0.3.1 says what the fix is.

Evidence to follow in comments: local gate, Docker e2e on this branch, and the /model recording on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)