### PR TITLE
feat(claudex): GPT-6 Astra rides the ChatGPT plan; release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,40 +1,13 @@
 # Changelog
 
-## splice v0.3.1 — one picker row per model, and the proofs the review asked for - 2026-09-04
-
-### Fixed
-
-- **The `/model` picker lists each model once.** Every head showed a slotted model twice (Sol
-  twice on `claudex`; Kimi K3 (256k) and Kimi K2.7 Code twice on `claude-kimi`). Claude Code draws
-  one row per planted tier (`ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU,FABLE}_MODEL`) and dedupes rows
-  by their alias, so two tiers on one model drew it twice: Fable shares the frontier with Opus, and
-  on a two-model head Haiku shares Sonnet. A tier cannot be left unset, because its alias then
-  resolves to Claude Code's built-in model, which the head rejects. A repeated tier is now planted
-  under the head's discovery-wrapped spelling (`claude-codex--gpt-5.6-sol`): the head routes it
-  like the bare id, and the picker's allowlist hides the row. Cache rows are unchanged; they are
-  where the Default line's label comes from.
-
-### Changed
-
-- **The watchdog turn-line tests pin what production does.** A test claimed a compaction's
-  first-output tier is lifted to the whole-turn cap; production switches that tier off
-  (`WatchdogBudget.forCompact`), so only the total cap ends a silent compaction. The arm now pins a
-  non-compact first-output fire and a compact total-cap fire, and two new `TurnFinish` arms fire
-  real pollers on virtual ticks and assert the rendered line carries the sentinel through the
-  production hop.
-- **`CLAUDEX_QUOTA_POLL=off` has an effect test.** `ManagedHeadFactory` exposes a poller-start
-  seam; assembling a real ChatGPT subscription head with the knob off starts nothing, with `auto`
-  starts one.
-- **The stable pin recipe is exercised.** `checks/release/accept.sh` now installs with
-  `SPLICE_VERSION` pinned to the jar's own stable tag as well as a synthetic prerelease, and fails
-  when `install.sh` ignores the pin.
-- **Changelog bookkeeping.** "Heads that see each other" landed after `v0.3.0-beta.1` and now sits
-  in the v0.3.0 section, so the beta.1 list matches its tag.
-
-## splice v0.3.0 — plan usage on every head, and a proxy that matches its reference client - 2026-09-03
+## splice v0.3.0 — plan usage on every head, GPT-6 Astra on claudex, and a proxy that matches its reference client - 2026-09-04
 
 ### Added
-
+- **GPT-6 Astra is a row on `claudex`.** OpenAI shipped GPT-6 Astra on 2026-09-03 and it is
+  included in the ChatGPT plan allowance. The example config carries it as `gpt-6-astra` (label
+  "Codex 6 Astra") and plants it on the head's fable tier, so `/model` lists it beside the 5.6 rows
+  and the default pin is untouched. Codex's own catalog serves it responses-lite with efforts up
+  to `max`, so the lite gate now matches the gpt-6 family as well as gpt-5.6.
 - **Every head shows its plan usage the way the native Claude head does.** The daemon tracks each
   head's 5-hour and 7-day windows (ChatGPT's usage endpoint and its `x-codex-*` round headers,
   Kimi's usage endpoint, SuperGrok's billing period, Anthropic's own unified headers on the
@@ -115,6 +88,22 @@
   the proxy-side answer to that loop, so the budget is now five. Turn recovery and its cooldown
   backoff are unchanged; only the number of times they may run has widened.
 
+
+- **The watchdog turn-line tests pin what production does.** A test claimed a compaction's
+  first-output tier is lifted to the whole-turn cap; production switches that tier off
+  (`WatchdogBudget.forCompact`), so only the total cap ends a silent compaction. The arm now pins a
+  non-compact first-output fire and a compact total-cap fire, and two new `TurnFinish` arms fire
+  real pollers on virtual ticks and assert the rendered line carries the sentinel through the
+  production hop.
+- **`CLAUDEX_QUOTA_POLL=off` has an effect test.** `ManagedHeadFactory` exposes a poller-start
+  seam; assembling a real ChatGPT subscription head with the knob off starts nothing, with `auto`
+  starts one.
+- **The stable pin recipe is exercised.** `checks/release/accept.sh` now installs with
+  `SPLICE_VERSION` pinned to the jar's own stable tag as well as a synthetic prerelease, and fails
+  when `install.sh` ignores the pin.
+- **Changelog bookkeeping.** "Heads that see each other" landed after `v0.3.0-beta.1` and now sits
+  in the v0.3.0 section, so the beta.1 list matches its tag.
+
 ### Fixed
 
 - **Compactions no longer die on the ChatGPT backend's capacity signal.** An in-stream
@@ -162,6 +151,17 @@
   failed stalled" of a morning (13) landed while a 5–6.5 MB frame was in flight — a healthy socket
   poisoned and the same megabytes re-sent over SSE. The budget is now the floor plus the frame's own
   transfer time at 100 KB/s, and the stall line names both the budget and the frame size.
+
+
+- **The `/model` picker lists each model once.** Every head showed a slotted model twice (Sol
+  twice on `claudex`; Kimi K3 (256k) and Kimi K2.7 Code twice on `claude-kimi`). Claude Code draws
+  one row per planted tier (`ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU,FABLE}_MODEL`) and dedupes rows
+  by their alias, so two tiers on one model drew it twice: Fable shares the frontier with Opus, and
+  on a two-model head Haiku shares Sonnet. A tier cannot be left unset, because its alias then
+  resolves to Claude Code's built-in model, which the head rejects. A repeated tier is now planted
+  under the head's discovery-wrapped spelling (`claude-codex--gpt-5.6-sol`): the head routes it
+  like the bare id, and the picker's allowlist hides the row. Cache rows are unchanged; they are
+  where the Default line's label comes from.
 
 ## splice v0.3.0-beta.1 — native Claude auth and a hardened multi-head gateway - 2026-08-30
 

--- a/bin/splice-launch
+++ b/bin/splice-launch
@@ -62,7 +62,7 @@ DANGEROUS="false"
 # — bump both together whenever this shim's behavior changes. No code generation.
 SPLICE_SHIM_VERSION="shim-2"
 # Hand-paired with splice.core.GATEWAY_VERSION. Release acceptance verifies the marker.
-SPLICE_GATEWAY_VERSION="0.3.1"
+SPLICE_GATEWAY_VERSION="0.3.0"
 
 need_jar() {
   if [ ! -f "$JAR" ]; then

--- a/config/splice.example.toml
+++ b/config/splice.example.toml
@@ -76,6 +76,11 @@ enabled = true
 # on fresh conversations.
 defer = ["LSP"]
 [[providers.codex.models]]
+id = "gpt-6-astra"
+label = "Codex 6 Astra"
+description = "GPT-6 Astra (2026-09-03). Effort up to max; included in the ChatGPT plan."
+context_window = 400000
+[[providers.codex.models]]
 id = "gpt-5.6-sol"
 label = "Codex 5.6 Sol"
 context_window = 400000
@@ -244,7 +249,7 @@ pinned_model = "gpt-5.6-sol"
 # background titling/summarization, `--model haiku` — get a clean pre-upstream 400 on this head
 # (no quota burned; the main turn is unaffected). Declare a row per tier you want served; never
 # point two tiers at one id to silence this — one honest 400 beats a duplicated picker row.
-models = [{ id = "gpt-5.6-sol", slot = "opus" }, { id = "gpt-5.6-terra", slot = "sonnet" }, { id = "gpt-5.6-luna", slot = "haiku" }]
+models = [{ id = "gpt-5.6-sol", slot = "opus" }, { id = "gpt-5.6-terra", slot = "sonnet" }, { id = "gpt-5.6-luna", slot = "haiku" }, { id = "gpt-6-astra", slot = "fable" }]
 context_window = 400000
 [heads.claudex.claude]
 command = "claudex"

--- a/gateway/app/src/test/kotlin/ExampleConfigTest.kt
+++ b/gateway/app/src/test/kotlin/ExampleConfigTest.kt
@@ -393,7 +393,7 @@ class ExampleConfigTest {
         val topology = TopologyLoader.parse(exampleToml())
         val headProfiles = mapOf(
             "claudex" to (
-                listOf("gpt-5.6-sol" to "opus", "gpt-5.6-terra" to "sonnet", "gpt-5.6-luna" to "haiku") to
+                listOf("gpt-5.6-sol" to "opus", "gpt-5.6-terra" to "sonnet", "gpt-5.6-luna" to "haiku", "gpt-6-astra" to "fable") to
                     400_000L
                 ),
             "claude-grok" to (

--- a/gateway/core/src/main/kotlin/splice/core/Versions.kt
+++ b/gateway/core/src/main/kotlin/splice/core/Versions.kt
@@ -3,7 +3,7 @@
 // /health). Single daemon (P4): one version restarts every head together (documented change).
 package splice.core
 
-public const val GATEWAY_VERSION: String = "0.3.1"
+public const val GATEWAY_VERSION: String = "0.3.0"
 
 // Hand-paired with the SPLICE_SHIM_VERSION marker embedded in bin/splice-launch (same
 // hand-paired pattern as GATEWAY_VERSION/wantVersion already used for head staleness in

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesQuirks.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesQuirks.kt
@@ -14,14 +14,15 @@ public data class ResponsesQuirks(
     val summaryRejectModelRegex: Regex? = Regex("spark", RegexOption.IGNORE_CASE),
     /** gpt-5.4-mini's ceiling is xhigh — the backend 400s effort=max on it (observed 2026-07-19). */
     val effortMaxRejectModelRegex: Regex? = Regex("mini", RegexOption.IGNORE_CASE),
-    /** codex-rs parity (read from source 2026-07-19): the gpt-5.6 family is served "responses-lite".
+    /** codex-rs parity (read from source 2026-07-19; models.json re-read 2026-09-04 for gpt-6-astra,
+     *  `use_responses_lite: true`): the gpt-5.6 and gpt-6 families are served "responses-lite".
      *  Lite turns (non-compact): instructions ride as a developer input item (top-level field
      *  omitted), tools ride as an additional_tools input item (top-level field omitted),
      *  parallel_tool_calls is FORCED false (splice omitting it left the backend default parallel ON
      *  — a sequential-tool model spraying 30-50 parallel Task calls), reasoning.context=all_turns,
      *  and the x-openai-internal-codex-responses-lite header rides. Shape accepted by the live
      *  backend (direct probe 2026-07-19: 200, correct tool call). */
-    val responsesLiteModelRegex: Regex? = Regex("gpt-5\\.6", RegexOption.IGNORE_CASE),
+    val responsesLiteModelRegex: Regex? = Regex("gpt-5\\.6|gpt-6", RegexOption.IGNORE_CASE),
     /** codex-rs serde parity: its non-optional instructions String rides as "" on lite turns.
      *  Provider-specific wire byte; false keeps the shared responses dialect's historical omission. */
     val emitEmptyLiteInstructions: Boolean = false,

--- a/gateway/dialect-openai-responses/src/test/kotlin/ResponsesRequestBuilderTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ResponsesRequestBuilderTest.kt
@@ -202,6 +202,20 @@ class ResponsesRequestBuilderTest {
         assertEquals("x", input[2]["content"]?.jsonPrimitive?.content)
     }
 
+    // gpt-6-astra (codex models.json 2026-09-04: use_responses_lite true, same shape as the 5.6
+    // family). The live /models listing shows it to this account at client_version 0.153.0.
+    @Test
+    fun `gpt-6-astra rides the lite shape like the 5-6 family`() {
+        val req = build(
+            """{"model":"m","system":"harness prompt","messages":[{"role":"user","content":"x"}]}""",
+            options = opts(model = "gpt-6-astra"),
+        )
+        assertEquals("", req["instructions"]?.jsonPrimitive?.content)
+        assertEquals("false", req["parallel_tool_calls"]?.jsonPrimitive?.content)
+        assertEquals("all_turns", req["reasoning"]?.jsonObject?.get("context")?.jsonPrimitive?.content)
+        assertEquals("developer", req["input"]!!.jsonArray[0].jsonObject["role"]?.jsonPrimitive?.content)
+    }
+
     @Test
     fun `gpt-5-6 lite without tools - developer instructions only, no additional_tools item`() {
         val req = build(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "splice",
-  "version": "0.3.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "splice",
-      "version": "0.3.1",
+      "version": "0.3.0",
       "workspaces": [
         "webui"
       ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "splice",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.0",
   "engines": {
     "node": ">=24"
   },


### PR DESCRIPTION
## Summary
- New claudex row `gpt-6-astra` ("Codex 6 Astra"), released by OpenAI on 2026-09-03; 400k window, claudex `fable` slot, effort up to max.
- `ResponsesQuirks.responsesLiteModelRegex` now matches `gpt-6` next to `gpt-5.6`, with a builder test pinning the lite shape for Astra.
- Version 0.3.0 at every site, including `bin/splice-launch` (missed by the earlier bump: a 0.3.1 shim refused the 0.3.0 daemon at the handshake). CHANGELOG folds the 0.3.1 draft into 0.3.0.

## Proof
- Live on this machine through the claudex head: non-streaming and streaming Messages requests for `gpt-6-astra` returned 200; daemon log shows `turn compact=false model=gpt-6-astra latency=2674ms ok`.
- `:dialect-openai-responses:test` and `:app:test --tests ExampleConfigTest` green (roster expectation extended with the fable slot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)