### PR TITLE
chore(release): promote main to prod (v0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,15 @@
   in the v0.3.0 section, so the beta.1 list matches its tag.
 
 ### Fixed
+- **An empty answer is an answer, not an API error.** When the model closes a message with no
+  text in it, the turn now ends clean, the way codex ends it (only a tool call asks for a
+  follow-up there). Found on GPT-6 Astra: after its final answer, a project Stop hook echoed an
+  end-of-turn report back as a continuation, Astra correctly had nothing to add, and the empty-turn
+  gate graded that `empty_model`, so Claude Code retried the identical 120k to 320k-token request
+  eleven times per incident, thirteen times in one evening. A round with no message item at all
+  is still the honest error it was, a compaction that returns nothing is still an error, and the
+  clean case is tagged `empty_message` in the perf row and names the shape the backend sent
+  (`reasoning(summary=0,enc=1700)`, `message(output_text:0)`) in the log.
 
 - **Compactions no longer die on the ChatGPT backend's capacity signal.** An in-stream
   `server_is_overloaded` (or `slow_down`) used to classify as a non-retryable `api_error`, so the

--- a/dev/campaigns/proxy-hardening/oracle/expectations.toml
+++ b/dev/campaigns/proxy-hardening/oracle/expectations.toml
@@ -123,10 +123,10 @@ covers = "output-token clamp: reported usage clamped to the client's max_tokens"
 [[scenario]]
 name = "compactish"
 status = "sanctioned"
-authority = "22a0744: codex-rs sequential_cutoff parity"
+authority = "d0202374 + 1a649eca: the empty-turn error names the upstream shape; a closed empty message ends clean"
 pin_upstream = "fixture"
-pinned_sha256 = "e755e61e21fdd9b696ca6b5bc4409f5efafeb43e5c386b7795a51278fe23c6f9"
-replay_note = "The frozen mock predates sequential_cutoff and returns only its legacy cumulative-summary carrier. With no reasoning_summary_text.done and no answer text, the gateway now emits the honest no-content error rather than fabricating a clean stop."
+pinned_sha256 = "d3b9f8609e69edfd4a1af576656578cbbcc537ba13e50a9812f5ea78fd865815"
+replay_note = "The frozen mock predates sequential_cutoff and returns only its legacy cumulative-summary carrier, and it completes NO message item (output_item.done without an item). With no reasoning_summary_text.done, no answer text and no closed message, the gateway emits the honest no-content error, whose text now carries the upstream shape it saw (`status=completed items=[] streamed=[reasoning]`) so the class is greppable from the client side. A stream that DOES close a message, even an empty one, ends clean instead (TurnPipelineTest, 2026-09-05)."
 covers = "real Claude Code compaction request shaping and the honest empty-output terminal under sequential_cutoff"
 
 # ── captured deliberately NOT frozen, with reasons (never silently dropped) ──

--- a/gateway/core/src/main/kotlin/splice/core/turn/TurnOutcome.kt
+++ b/gateway/core/src/main/kotlin/splice/core/turn/TurnOutcome.kt
@@ -68,6 +68,21 @@ public sealed class TurnOutcome {
          *  Only the latter can answer "did this turn put anything on the wire", which is the
          *  question the empty-turn honesty gate has to ask before calling a turn empty. */
         val emittedThinking: Boolean = false,
+        /** A `message` output item COMPLETED this round, whether or not it carried text.
+         *
+         *  An empty message is the model's finished answer, not an absence: given nothing to add
+         *  (Astra after a Stop hook echoes an end-of-turn report back at it, 2026-09-05) it closes
+         *  a message with no text, exactly as codex renders — codex ends the turn there, since
+         *  only a tool call sets `needs_follow_up`. Grading that turn `empty_model` handed Claude
+         *  Code an API error it retried a dozen times per incident, so the empty-turn gate reads
+         *  this first: a closed message ends clean; a round with NO message item stays the honest
+         *  error it always was. */
+        val messageClosed: Boolean = false,
+        /** What the completed upstream response actually held, item by item, in one short line
+         *  (`status=completed items=[reasoning(summary=0,enc=1842) message(output_text:0)]`).
+         *  Evidence only: read by the empty-turn line so a "no content" verdict names the shape
+         *  the backend sent instead of asserting an absence nobody can grep. */
+        val outputShape: String = "",
         /** splice-reasoning envelopes (base64) of THIS round's encrypted reasoning items, for
          *  reasoning-continuation replay. Populated only when the turn is fold-eligible; empty
          *  otherwise (opaque handles — the gateway forwards them to the provider's fold controller,

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesHarvest.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesHarvest.kt
@@ -91,6 +91,51 @@ internal class ResponsesHarvest {
         return Harvested(text.toString(), thinking.toString())
     }
 
+    /** One line naming the completed response's status and every output item by type, with the
+     *  sizes that decide whether it could reach the client: a message's part types and text length,
+     *  a reasoning item's summary count and encrypted length, any other type by its key set. This
+     *  is the evidence the empty-turn honesty gate prints — an item type this dialect does not
+     *  render (agent_message, custom_tool_call, context_compaction, ...) is invisible everywhere
+     *  else, and "model returned no content" was asserting an absence nobody could grep. */
+    public fun describeOutput(resp: JsonObject?, streamedTypes: List<String> = emptyList()): String {
+        if (resp == null) {
+            val streamed = if (streamedTypes.isEmpty()) "" else " streamed=[${streamedTypes.joinToString(",")}]"
+            return "status=<no terminal response>$streamed"
+        }
+        val status = JsonScalars.strOrEmpty(resp["status"]).ifEmpty { "?" }
+        val output = resp["output"] as? JsonArray ?: return "status=$status items=<none>"
+        val items = output.mapNotNull { el -> (el as? JsonObject)?.let(::describeItem) }
+        val streamed = if (streamedTypes.isEmpty()) "" else " streamed=[${streamedTypes.joinToString(",")}]"
+        return "status=$status items=[${items.joinToString(" ")}]$streamed"
+    }
+
+    /** One output item in the evidence form [describeOutput] prints: `message(output_text:0)`,
+     *  `reasoning(summary=0,enc=1842)`, `function_call(name)`, or an unknown type by its keys.
+     *  Public so [ResponsesItemFold] records completed items in the SAME words the terminal
+     *  harvest uses — one vocabulary for the empty-turn line. */
+    public fun describeItem(item: JsonObject): String {
+        val type = JsonScalars.strOrEmpty(item["type"]).ifEmpty { "?" }
+        return when (type) {
+            "message" -> {
+                val parts = (item["content"] as? JsonArray)?.mapNotNull { it as? JsonObject }.orEmpty()
+                val detail = parts.joinToString(",") { part ->
+                    val t = JsonScalars.strOrEmpty(part["type"]).ifEmpty { "?" }
+                    val len = JsonScalars.strOrEmpty(part["text"]).length +
+                        JsonScalars.strOrEmpty(part["refusal"]).length
+                    "$t:$len"
+                }
+                "message(${detail.ifEmpty { "no parts" }})"
+            }
+            "reasoning" -> {
+                val summaries = (item["summary"] as? JsonArray)?.size ?: 0
+                val enc = JsonScalars.strOrEmpty(item["encrypted_content"]).length
+                "reasoning(summary=$summaries,enc=$enc)"
+            }
+            "function_call" -> "function_call(${JsonScalars.strOrEmpty(item["name"])})"
+            else -> "$type(${item.keys.filter { it != "type" }.joinToString(",")})"
+        }
+    }
+
     /** Append one reasoning item's fullest readable text as a blank-line-separated paragraph. */
     private fun appendReasoningText(thinking: StringBuilder, item: JsonObject) {
         val t = reasoningReadableText(item)

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesItemFold.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesItemFold.kt
@@ -13,10 +13,12 @@ internal class ResponsesItemFold(
 ) {
 
     private val frames = ResponsesFrameParse()
+    private val harvest = ResponsesHarvest()
     private var toolSynthCounter = 0
 
     suspend fun onItemAdded(evt: JsonObject, sink: WireSink) {
         val item = evt["item"] as? JsonObject ?: return
+        state.streamedItemTypes.add(JsonScalars.strOrEmpty(item["type"]).ifEmpty { "?" })
         val oi = frames.intOr(evt[OUTPUT_INDEX]) ?: frames.intOr(item["index"]) ?: state.blocks.size
         // codex parity: EVERY added item (reasoning, message, function_call, search) becomes the
         // active item; summary done-events are rendered only while their item is active.
@@ -64,6 +66,8 @@ internal class ResponsesItemFold(
         // not only via the end-of-turn harvest fallback.
         reasoningFold.maybeEmitLateReasoning(item, oi, sink)
         maybeHarvestLateToolArgs(item, oi, sink)
+        recordDoneDetail(item)
+        if (item != null && JsonScalars.strOrEmpty(item["type"]) == "message") state.messageClosed = true
         closeOpenBlocks(oi, sink)
         if (item == null) return
         replay.emitReplayedReasoning(item, sink)
@@ -84,6 +88,18 @@ internal class ResponsesItemFold(
         // site of the DR-108 law, and the only one reached with no output_item.added — so DR-107's
         // eviction never runs here and cannot cover it.
         if (b.tool && !b.sawDelta) emitToolArgText(b, JsonScalars.strOrEmpty(item["arguments"]), sink)
+    }
+
+    /** Evidence for the empty-turn line: what a completed message/reasoning item actually carried,
+     *  since these can ride output_item.done with an EMPTY terminal output array. The bare type
+     *  recorded at added-time is replaced with [ResponsesHarvest.describeItem]'s form. Evidence only. */
+    private fun recordDoneDetail(item: JsonObject?) {
+        if (item == null) return
+        val type = JsonScalars.strOrEmpty(item["type"])
+        if (type != "message" && type != "reasoning") return
+        val detail = harvest.describeItem(item)
+        val idx = state.streamedItemTypes.indexOfLast { it == type }
+        if (idx >= 0) state.streamedItemTypes[idx] = detail else state.streamedItemTypes.add(detail)
     }
 
     /** onItemDone's block-closing half: close both the tool/message block and any reasoning block at

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesOutcomePayload.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesOutcomePayload.kt
@@ -23,6 +23,8 @@ internal class ResponsesOutcomePayload(private val ctx: StreamTurnContext) {
         bodyText = state.textBuf.toString(),
         emittedText = state.emittedText,
         emittedThinking = state.emittedThinking,
+        messageClosed = state.messageClosed,
+        outputShape = harvest.describeOutput(state.finalResponse, state.streamedItemTypes),
         reasoningEnvelopes = state.reasoningEnvelopes.toList(),
         // The harvest fallback runs ONLY when the streamed list is empty (needs no dedup): a round
         // that emitted only a search call and was missed by the live capture would otherwise

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesTurnState.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesTurnState.kt
@@ -54,6 +54,10 @@ internal class ResponsesTurnState {
      *  completed response object without emitting anything, and that is precisely the turn the
      *  honesty gate must still call empty. */
     var emittedThinking = false
+
+    /** A `message` item reached output_item.done this round (text or not) — see
+     *  [splice.core.turn.TurnOutcome.Success.messageClosed]. */
+    var messageClosed = false
     var incomplete = false
 
     // response.incomplete carrying a non-max_output_tokens reason (content_filter, etc.) — the
@@ -88,6 +92,12 @@ internal class ResponsesTurnState {
 
     // Reasoning-cache capture (RC-1): the round's REAL upstream function_call ids, in order.
     val turnToolIds = mutableListOf<String>()
+
+    /** Every output item this round STREAMED, by `type`, in arrival order. The empty-turn line
+     *  reads this because a code-mode model (Astra) can stream an item type this dialect drops
+     *  and finish with an empty terminal `output` array — so `finalResponse` shows nothing while
+     *  the stream carried the whole (unrendered) round. Evidence only; nothing branches on it. */
+    val streamedItemTypes = mutableListOf<String>()
 
     // tool_search_call items this round emitted (deferred tool surface) — populated only when the
     // gateway declared deferral this turn; empty otherwise (pre-deferral behaviour intact).

--- a/gateway/dialect-openai-responses/src/test/kotlin/HarvestedTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/HarvestedTest.kt
@@ -75,4 +75,35 @@ class HarvestedTest {
         )
         assertEquals("first\n\nsecond", h.thinking)
     }
+
+    @Test
+    fun `describeOutput names every item type with the sizes that decide client visibility`() {
+        val line = harvest.describeOutput(
+            resp(
+                """{"status":"completed","output":[
+                   {"type":"reasoning","summary":[],"encrypted_content":"abcd"},
+                   {"type":"message","content":[{"type":"output_text","text":""}]},
+                   {"type":"function_call","name":"Bash","arguments":"{}"},
+                   {"type":"agent_message","author":"a","recipient":"b","content":[]}]}""",
+            ),
+        )
+        assertEquals(
+            "status=completed items=[reasoning(summary=0,enc=4) message(output_text:0) function_call(Bash) agent_message(author,recipient,content)]",
+            line,
+        )
+    }
+
+    @Test
+    fun `describeOutput says so when no terminal response was ever seen`() {
+        assertEquals("status=<no terminal response>", harvest.describeOutput(null))
+    }
+
+    @Test
+    fun `describeOutput appends the streamed item types when the terminal output is empty`() {
+        val line = harvest.describeOutput(
+            resp("""{"status":"completed","output":[]}"""),
+            listOf("reasoning", "custom_tool_call"),
+        )
+        assertEquals("status=completed items=[] streamed=[reasoning,custom_tool_call]", line)
+    }
 }

--- a/gateway/dialect-openai-responses/src/test/kotlin/ResponsesStreamTranslatorTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ResponsesStreamTranslatorTest.kt
@@ -1441,4 +1441,58 @@ class ResponsesStringErrorTest {
         val failure = assertInstanceOf(TurnOutcome.Failure::class.java, outcome)
         assertTrue(failure.message.contains("boom"), failure.message)
     }
+
+    @Test
+    fun `an empty message the backend closed marks the outcome messageClosed without any text on the wire`() = runTest {
+        // gpt-6-astra, 2026-09-05: encrypted reasoning, then a message item whose one output_text
+        // part is empty, then a terminal with an empty output array. The model's finished answer
+        // is "nothing" — the gateway must be able to tell that from a round with no message at all.
+        val sink = RecordingSink()
+        val outcome = ResponsesStreamTranslator(ctx()).driveTurn(
+            listOf(
+                ev(
+                    """{"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning"}}""",
+                ),
+                ev(
+                    """{"type":"response.output_item.done","output_index":0,"item":{"type":"reasoning","encrypted_content":"zzz","summary":[]}}""",
+                ),
+                ev(
+                    """{"type":"response.output_item.added","output_index":1,"item":{"type":"message"}}""",
+                ),
+                ev(
+                    """{"type":"response.output_item.done","output_index":1,"item":{"type":"message","content":[{"type":"output_text","text":""}]}}""",
+                ),
+                ev(
+                    """{"type":"response.completed","response":{"status":"completed","output":[],"usage":{"input_tokens":100,"output_tokens":9}}}""",
+                ),
+            ).asFlow(),
+            sink,
+        )
+        val success = assertInstanceOf(TurnOutcome.Success::class.java, outcome)
+        assertTrue(success.messageClosed, "the message item completed, so the answer is a deliberate empty")
+        assertFalse(success.emittedText, "no text was produced")
+        assertTrue(sink.calls.none { it.startsWith("text") }, "nothing may be invented on the wire: ${sink.calls}")
+    }
+
+    @Test
+    fun `a round with no message item is not messageClosed`() = runTest {
+        val outcome = ResponsesStreamTranslator(ctx()).driveTurn(
+            listOf(
+                ev(
+                    """{"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning"}}""",
+                ),
+                ev(
+                    """{"type":"response.output_item.done","output_index":0,"item":{"type":"reasoning","encrypted_content":"zzz","summary":[]}}""",
+                ),
+                ev(
+                    """{"type":"response.completed","response":{"status":"completed","output":[],"usage":{"input_tokens":100,"output_tokens":9}}}""",
+                ),
+            ).asFlow(),
+            RecordingSink(),
+        )
+        assertFalse(
+            (outcome as TurnOutcome.Success).messageClosed,
+            "no message item, so the honest error still applies",
+        )
+    }
 }

--- a/gateway/gateway/src/main/kotlin/splice/gateway/pipeline/StreamFinish.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/pipeline/StreamFinish.kt
@@ -24,7 +24,8 @@ internal class StreamFinish(
         meta: TurnMeta,
         elapsedMs: Long,
     ): String {
-        promote.apply(emitter, outcome, meta, elapsedMs)?.let { return it }
+        val verdict = promote.apply(emitter, outcome, meta, elapsedMs)
+        verdict.endedTag?.let { return it }
 
         // Reasoning mirror (L2): one mirrorInto for both paths; tools stay on.
         honesty.mirrorGated(emitter, outcome.thinkingText, meta)
@@ -41,6 +42,6 @@ internal class StreamFinish(
         // DR-87: the collect-path terminal can downgrade this emit into an error envelope
         // (malformed-tool/capacity). A literal "ok" here is what blinded perf/health/log to a
         // turn whose client saw a 502.
-        return emitter.degradedReason ?: "ok"
+        return emitter.degradedReason ?: verdict.cleanTag
     }
 }

--- a/gateway/gateway/src/main/kotlin/splice/gateway/pipeline/StreamPromote.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/pipeline/StreamPromote.kt
@@ -10,49 +10,71 @@ import splice.core.turn.TurnOutcome
 import splice.core.util.LogSink
 import splice.gateway.wire.TurnTerminal
 
+/** What the promote step decided: [endedTag] when the turn ended here (an error terminal was
+ *  emitted), else null and the turn flows on to mirror+terminal, tagged [cleanTag] for the log. */
+internal data class PromoteVerdict(val endedTag: String?, val cleanTag: String = "ok")
+
 internal class StreamPromote(
     private val compact: StreamCompact,
     private val log: LogSink,
     private val honesty: StreamHonesty,
 ) {
-    /** Apply promote-to-text / empty-compact / CX-09 empty-model. Returns a
-     *  terminal tag when the turn ends here, null to continue to mirror+emit. */
+    /** Apply promote-to-text / empty-compact / empty-message / CX-09 empty-model. */
     suspend fun apply(
         emitter: TurnTerminal,
         outcome: TurnOutcome.Success,
         meta: TurnMeta,
         elapsedMs: Long,
-    ): String? {
-        // DR-88 rider: these were vars mutated inside the promote branch (emittedText = true,
-        // bodyText += picked.text) — dead stores both, the promote arm never re-reads them and the
-        // model_text arm below is unreachable from it.
-        val emittedText = outcome.emittedText
-        val bodyText = outcome.bodyText
-
-        // Promote model thinking → text when no text AND no tools (compact needs a text channel).
-        if (!emittedText && !outcome.hasToolUse) {
-            val picked = ModelTextPicker.pickModelText(outcome.thinkingText, outcome.bodyText)
-            if (picked.text.isNotEmpty()) {
+    ): PromoteVerdict {
+        if (outcome.emittedText || outcome.hasToolUse) {
+            recordCompactShape(meta, outcome.emittedText, outcome.bodyText, elapsedMs)
+            return PromoteVerdict(null)
+        }
+        // No text AND no tools: promote model thinking to text (compact needs a text channel),
+        // else grade the empty.
+        val picked = ModelTextPicker.pickModelText(outcome.thinkingText, outcome.bodyText)
+        return when {
+            picked.text.isNotEmpty() -> {
                 log(
                     "[gateway] promote-to-text compact=${meta.compact} " +
                         "source=${picked.source} chars=${picked.text.length}\n",
                 )
                 emitter.addTextBlock(picked.text)
                 if (meta.compact) compact.record(picked.source, elapsedMs, chars = picked.text.length)
-            } else if (meta.compact) {
+                PromoteVerdict(null)
+            }
+            meta.compact -> {
                 // An empty compact is an ERROR, not an empty success (Claude Code would store a
                 // blank summary and lose the thread). Never invent locally.
                 compact.record("empty_model", elapsedMs, error = "api_error")
-                emitter.emitError(ErrorType.API_ERROR, "claudex: compact returned no content from model — retry")
-                return "empty_compact"
-            } else if (honesty.nothingReachesTheClient(outcome, meta)) {
-                emitter.emitError(ErrorType.API_ERROR, "claudex: model returned no content (empty response) — retry")
-                return "empty_model"
+                log("[gateway] empty-turn shape compact=true ${outcome.outputShape}\n")
+                emitter.emitError(
+                    ErrorType.API_ERROR,
+                    "claudex: compact returned no content from model — retry (upstream ${outcome.outputShape})",
+                )
+                PromoteVerdict("empty_compact")
             }
-        } else {
-            recordCompactShape(meta, emittedText, bodyText, elapsedMs)
+            outcome.messageClosed -> {
+                // The model closed a message with nothing in it: a finished answer, not a failure
+                // (codex ends the turn here). Ending clean is what stops the client retrying the
+                // same request a dozen times; the line keeps the shape so the class stays greppable.
+                log("[gateway] empty-message turn compact=false ${outcome.outputShape} — ending clean\n")
+                PromoteVerdict(null, cleanTag = "empty_message")
+            }
+            honesty.nothingReachesTheClient(outcome, meta) -> {
+                // Name what the backend actually sent: a reasoning-only round, an item type this
+                // dialect never renders, or a genuinely empty output are three different bugs, and
+                // the old line made them one grep-proof sentence (Astra, 2026-09-05: eleven identical
+                // client retries of one turn, each burning 258k input tokens, with no way to tell).
+                log("[gateway] empty-turn shape compact=false ${outcome.outputShape}\n")
+                emitter.emitError(
+                    ErrorType.API_ERROR,
+                    "claudex: model returned no content (empty response) — retry (upstream ${outcome.outputShape})",
+                )
+                PromoteVerdict("empty_model")
+            }
+            else -> PromoteVerdict(null)
         }
-        return null
     }
 
     /** The compact rows for every shape the promote guard skips: text present (model_text) or —

--- a/gateway/gateway/src/test/kotlin/TurnPipelineTest.kt
+++ b/gateway/gateway/src/test/kotlin/TurnPipelineTest.kt
@@ -87,7 +87,11 @@ class TurnPipelineTest {
     )
 
     /** No text, no tools — the shape that reaches the promote/honesty branch. */
-    private fun outcome(thinking: String, emittedThinking: Boolean = false) = TurnOutcome.Success(
+    private fun outcome(
+        thinking: String,
+        emittedThinking: Boolean = false,
+        messageClosed: Boolean = false,
+    ) = TurnOutcome.Success(
         hasToolUse = false,
         incomplete = false,
         usage = Usage(0, 0, 0),
@@ -98,6 +102,7 @@ class TurnPipelineTest {
         // response, sink never touched); true models every translator that streamed a real
         // thinking block. Defaulting to false keeps the original cases meaning what they meant.
         emittedThinking = emittedThinking,
+        messageClosed = messageClosed,
     )
 
     /** In the uncovered band by construction: too short to promote, too long for the old check. */
@@ -178,6 +183,40 @@ class TurnPipelineTest {
         val rec = run(mirrorReasoning = false, showReasoning = "thinking", thinking = bandThinking)
         assertEquals("error", rec.ending)
         assertEquals(ErrorType.API_ERROR, rec.errorType)
+    }
+
+    // THE ASTRA CELL (2026-09-05). Thirteen retry storms in one evening, every one the same shape:
+    // the model gave its final answer, a Stop hook echoed an end-of-turn report back as a
+    // continuation, and the model closed a message with nothing in it — a finished answer, which is
+    // how codex ends the turn. The honesty gate read it as "no content", the client retried the
+    // identical request eleven times per incident. A CLOSED message ends clean and is tagged so the
+    // perf row still names the class; a round with no message item at all stays the honest error.
+    @Test
+    fun `a message the model closed empty ends clean and is tagged, never empty_model`() = runTest {
+        val rec = RecTerminal()
+        val tag = pipeline().finishStream(
+            rec,
+            outcome("", messageClosed = true),
+            meta("text"),
+            elapsedMs = 1,
+        )
+        assertEquals("terminal", rec.ending, "a closed empty message is a finished answer")
+        assertEquals("empty_message", tag, "the log must still name the class")
+        assertTrue(rec.texts.isEmpty(), "nothing is invented for the wire: ${rec.texts}")
+    }
+
+    @Test
+    fun `a closed empty message on a compact turn is still an empty_compact error`() = runTest {
+        // Compaction needs a summary in the text channel; "nothing to add" is not one.
+        val rec = RecTerminal()
+        val tag = pipeline().finishStream(
+            rec,
+            outcome("", messageClosed = true),
+            meta("text", compact = true),
+            elapsedMs = 1,
+        )
+        assertEquals("empty_compact", tag)
+        assertEquals("error", rec.ending)
     }
 
     @Test


### PR DESCRIPTION
Merging this PR IS the promotion: the resulting push to prod fires release.yml, which re-gates, builds, attests, and publishes **v0.3.0** with the tag created at the promoted commit.

Merge with a **merge commit**, not squash.