### PR TITLE
feat(launch): a context window edited in splice.toml reaches running sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- **A context window edited in `splice.toml` now reaches running sessions.** Every launch plants
+  one constant client window (`CLAUDE_CODE_MAX_CONTEXT_TOKENS=1000000`) and the proxy scales the
+  token counts it reports so each row, the pinned one included, compacts at its own declared
+  window. Before, the pinned row's number was the launch env, so lowering it (the 2026-09-05 move
+  of the codex rows to 272k, under OpenAI's 2x long-context price line) changed nothing for the
+  six sessions already running until each was relaunched. Now `splice restart` is enough. Ids
+  starting with `claude-` (a passthrough head's own models, a discovery-wrapped tier) ignore that
+  env in Claude Code and keep reporting raw counts.
+
 ## splice v0.3.0 — plan usage on every head, GPT-6 Astra on claudex, and a proxy that matches its reference client - 2026-09-04
 
 ### Added

--- a/checks/e2e/docker/inside.sh
+++ b/checks/e2e/docker/inside.sh
@@ -307,13 +307,15 @@ step "launch recipe: mockchat base URL + API_TIMEOUT_MS > 900s" launch_recipe mo
 # ── 7b. per-head model roster + window: what /model offers, what the client compacts on ─────
 # Each head materializes its OWN picker (settings.json availableModels + model, enforced, and a
 # .claude.json additionalModelOptionsCache row per model carrying its context_window) and hands
-# Claude Code its own CLAUDE_CODE_MAX_CONTEXT_TOKENS, from the topology alone. The four tier
+# Claude Code ONE constant client window (CLAUDE_CODE_MAX_CONTEXT_TOKENS = 1000000, 2026-09-05):
+# each row's real window is applied by usage scaling on the wire, so a topology edit reaches a
+# running session after a daemon restart instead of waiting for a relaunch. The four tier
 # slots (ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU,FABLE}_MODEL) never share a BARE id: two tiers on
 # one bare id drew that model twice in /model (v0.3.0); a repeated tier now rides the head's
 # discovery-wrapped spelling, which the allowlist hides (so wrapped values may repeat) and the
 # head still routes. Three
-# heads, three windows: a head reading another head's roster or window is exactly the
-# fresh-install drift this step exists to catch.
+# heads, three rosters: a head reading another head's roster is exactly the fresh-install drift
+# this step exists to catch.
 # The same /launch also PACKAGES the head: the daemon's own status line (settings.json statusLine
 # posting Claude Code's blob to /statusline/<head>), the in-session /login command and the hook
 # that runs the head's sign-in when it is submitted. Splice is the whole package, so a head that
@@ -341,8 +343,11 @@ print("picker:", {"model": settings.get("model"), "availableModels": settings.ge
                   "enforceAvailableModels": settings.get("enforceAvailableModels"), "rows": rows})
 print("packaging:", {"statusLine": statusline, "login.md": os.path.isfile(login_md), "UserPromptSubmit": hook_cmds})
 assert env.get("ANTHROPIC_MODEL") == model, env.get("ANTHROPIC_MODEL")
-assert env.get("CLAUDE_CODE_MAX_CONTEXT_TOKENS") == str(window), env.get("CLAUDE_CODE_MAX_CONTEXT_TOKENS")
-assert env.get("CLAUDE_CODE_AUTO_COMPACT_WINDOW") == str(window), env.get("CLAUDE_CODE_AUTO_COMPACT_WINDOW")
+# the constant client window, never the pinned row's `window` — that one is checked in the picker
+# cache rows below, which is where a per-row window is allowed to live
+assert env.get("CLAUDE_CODE_MAX_CONTEXT_TOKENS") == "1000000", env.get("CLAUDE_CODE_MAX_CONTEXT_TOKENS")
+assert env.get("CLAUDE_CODE_AUTO_COMPACT_WINDOW") == "1000000", env.get("CLAUDE_CODE_AUTO_COMPACT_WINDOW")
+assert rows.get(model) == window, "pinned row window in the picker cache: %r" % rows.get(model)
 assert settings.get("model") == model, settings.get("model")
 assert settings.get("availableModels") == list(expected_rows), "picker off: %r" % settings.get("availableModels")
 assert settings.get("enforceAvailableModels") is True, "picker is not enforced"
@@ -573,7 +578,9 @@ for head, h in t["heads"].items():
         print(f"{head:14} {command:18} launch FAILED: {e}"); bad.append(head); continue
     sessions = os.path.join(env.get("CLAUDE_CONFIG_DIR", ""), "sessions")
     linked = os.path.islink(sessions) and os.path.realpath(sessions) == registry
-    ok = (env.get("ANTHROPIC_MODEL") == pinned and env.get("CLAUDE_CODE_MAX_CONTEXT_TOKENS") == str(want)
+    # the env window is the constant client window on every head; `want` is the row's declared
+    # window, which usage scaling applies on the wire (2026-09-05)
+    ok = (env.get("ANTHROPIC_MODEL") == pinned and env.get("CLAUDE_CODE_MAX_CONTEXT_TOKENS") == "1000000"
           and linked and wrapper)
     print(f"{head:14} {command:18} model={env.get('ANTHROPIC_MODEL')} window={env.get('CLAUDE_CODE_MAX_CONTEXT_TOKENS')}"
           f" example={pinned}@{want} sessions_link={linked} wrapper={wrapper} {'OK' if ok else 'MISMATCH'}")

--- a/config/splice.example.toml
+++ b/config/splice.example.toml
@@ -231,9 +231,10 @@ context_window = 262144
 # ── heads: each is a Claude Code wrapper on its own loopback port ───────────────
 # `command` names the installed wrapper (`splice install` links ~/.local/bin/<command>).
 # `models` is this process's ordered provider-model allowlist. An explicit `context_window` forces
-# one window onto every selected row; omit it when their real backend ceilings differ. The pinned
-# row sets CLAUDE_CODE_MAX_CONTEXT_TOKENS, and usage scaling makes every other row compact at its
-# own declared window while switching live through /model.
+# one window onto every selected row; omit it when their real backend ceilings differ. Every launch
+# plants one constant CLAUDE_CODE_MAX_CONTEXT_TOKENS, and usage scaling makes every row (the pinned
+# one included) compact at its own declared window — live through /model, and a window edited here
+# reaches running sessions after `splice restart`.
 [claude]                       # global config-sharing policy for every wrapper
 # `sessions` shares the cross-session-messaging peer registry, so sessions on ANY head (and plain
 # `claude`) can see and message each other; drop it (or isolate it per head) to wall a head off.
@@ -274,7 +275,7 @@ provider = "openrouter"
 port = 3101
 discovery_prefix = "claude-openrouter--"
 pinned_model = "meta-llama/llama-4-maverick"
-# Tiers declared on purpose: Llama 4 Maverick as opus (pinned, sets the process window), GLM 5.3
+# Tiers declared on purpose: Llama 4 Maverick as opus (pinned), GLM 5.3
 # as sonnet. haiku and fable stay undeclared and 400 cleanly pre-upstream — the slot note on
 # [heads.claudex] explains what degrades (background titling, `--model haiku`). No head-wide
 # context_window: the two rows have different ceilings and each keeps its own.
@@ -299,7 +300,7 @@ provider = "kimi"
 port = 3102
 discovery_prefix = "claude-kimi--"
 pinned_model = "k3[1m]"
-# Tiers declared on purpose: opus is K3 on the 1M window (the pinned row sets the process window),
+# Tiers declared on purpose: opus is K3 on the 1M window (pinned),
 # sonnet is the same K3 held at 256k (Kimi meters the 1M tier at ~2x this one), haiku is Kimi K2.7
 # Code. fable stays undeclared and 400s cleanly pre-upstream (slot note on [heads.claudex]). No
 # head-wide context_window: the rows have different ceilings and each keeps its own.

--- a/dev/campaigns/proxy-hardening/oracle/expectations.toml
+++ b/dev/campaigns/proxy-hardening/oracle/expectations.toml
@@ -47,7 +47,7 @@ status = "sanctioned"
 authority = "7e84b89a: one constant client window — the usage payload reports context_window 1000000 with counts scaled by 1e6/declared so a TOML window edit reaches running sessions"
 pin_upstream = "fixture"
 pinned_sha256 = "010e139a7e87bbdaa2132513a919e9ea2505bd5183797ad4061be1687cc9640e"
-replay_note = "Passing byte-identical from 2026-08-07 to 2026-09-05 (upstream requests still field-identical except the sanctioned stream_options divergence, see [[divergence]]). The reference reported the pinned row's 272000 window with raw counts; since 2026-09-05 the gateway reports the constant client window (1000000) and counts scaled by 1e6/272000, so every row, the pinned one included, compacts at its declared window and a splice.toml window edit lands on running sessions after `splice restart` (ModelCatalog.clientLaunchWindow). Only the usage payload differs from the recording."
+replay_note = "Passing byte-identical from 2026-08-07 to 2026-09-05 (upstream requests still field-identical except the sanctioned stream_options divergence, see the divergence rows). The reference reported the pinned row's 272000 window with raw counts; since 2026-09-05 the gateway reports the constant client window (1000000) and counts scaled by 1e6/272000, so every row, the pinned one included, compacts at its declared window and a splice.toml window edit lands on running sessions after `splice restart` (ModelCatalog.clientLaunchWindow). Only the usage payload differs from the recording."
 covers = "happy-path streaming turn: message_start/ping/content_block_*/message_delta/message_stop ordering, usage payload shape"
 
 [[scenario]]
@@ -65,7 +65,7 @@ status = "sanctioned"
 authority = "7e84b89a: one constant client window — the usage payload reports context_window 1000000 with counts scaled by 1e6/declared so a TOML window edit reaches running sessions"
 pin_upstream = "fixture"
 pinned_sha256 = "3b8427226e38d87eded5fdaa61af7d7b6f4746f114a182c0d9c1b414af75f195"
-replay_note = "Passing byte-identical from 2026-08-07 to 2026-09-05 (upstream requests still field-identical except the sanctioned stream_options divergence, see [[divergence]]). The reference reported the pinned row's 272000 window with raw counts; since 2026-09-05 the gateway reports the constant client window (1000000) and counts scaled by 1e6/272000, so every row, the pinned one included, compacts at its declared window and a splice.toml window edit lands on running sessions after `splice restart` (ModelCatalog.clientLaunchWindow). Only the usage payload differs from the recording."
+replay_note = "Passing byte-identical from 2026-08-07 to 2026-09-05 (upstream requests still field-identical except the sanctioned stream_options divergence, see the divergence rows). The reference reported the pinned row's 272000 window with raw counts; since 2026-09-05 the gateway reports the constant client window (1000000) and counts scaled by 1e6/272000, so every row, the pinned one included, compacts at its declared window and a splice.toml window edit lands on running sessions after `splice restart` (ModelCatalog.clientLaunchWindow). Only the usage payload differs from the recording."
 covers = "tool_use block assembly from streamed function-call arguments"
 
 [[scenario]]
@@ -102,7 +102,7 @@ status = "sanctioned"
 authority = "7e84b89a: one constant client window — the usage payload reports context_window 1000000 with counts scaled by 1e6/declared so a TOML window edit reaches running sessions"
 pin_upstream = "fixture"
 pinned_sha256 = "7dc307190d27e32609b0659acea59762319655206128c2ac7bb946eeddc1e41c"
-replay_note = "Passing byte-identical from 2026-08-07 to 2026-09-05 (upstream requests still field-identical except the sanctioned stream_options divergence, see [[divergence]]). The reference reported the pinned row's 272000 window with raw counts; since 2026-09-05 the gateway reports the constant client window (1000000) and counts scaled by 1e6/272000, so every row, the pinned one included, compacts at its declared window and a splice.toml window edit lands on running sessions after `splice restart` (ModelCatalog.clientLaunchWindow). Only the usage payload differs from the recording."
+replay_note = "Passing byte-identical from 2026-08-07 to 2026-09-05 (upstream requests still field-identical except the sanctioned stream_options divergence, see the divergence rows). The reference reported the pinned row's 272000 window with raw counts; since 2026-09-05 the gateway reports the constant client window (1000000) and counts scaled by 1e6/272000, so every row, the pinned one included, compacts at its declared window and a splice.toml window edit lands on running sessions after `splice restart` (ModelCatalog.clientLaunchWindow). Only the usage payload differs from the recording."
 covers = "assistant-prefill request shaping"
 
 [[scenario]]
@@ -129,7 +129,7 @@ status = "sanctioned"
 authority = "7e84b89a: one constant client window — the usage payload reports context_window 1000000 with counts scaled by 1e6/declared so a TOML window edit reaches running sessions"
 pin_upstream = "fixture"
 pinned_sha256 = "be5bf0ff909eb41175b8e1811701908ebb0cb435e72e230b8da5092d9e49fa19"
-replay_note = "Passing byte-identical from 2026-08-07 to 2026-09-05 (upstream requests still field-identical except the sanctioned stream_options divergence, see [[divergence]]). The reference reported the pinned row's 272000 window with raw counts; since 2026-09-05 the gateway reports the constant client window (1000000) and counts scaled by 1e6/272000, so every row, the pinned one included, compacts at its declared window and a splice.toml window edit lands on running sessions after `splice restart` (ModelCatalog.clientLaunchWindow). Only the usage payload differs from the recording."
+replay_note = "Passing byte-identical from 2026-08-07 to 2026-09-05 (upstream requests still field-identical except the sanctioned stream_options divergence, see the divergence rows). The reference reported the pinned row's 272000 window with raw counts; since 2026-09-05 the gateway reports the constant client window (1000000) and counts scaled by 1e6/272000, so every row, the pinned one included, compacts at its declared window and a splice.toml window edit lands on running sessions after `splice restart` (ModelCatalog.clientLaunchWindow). Only the usage payload differs from the recording."
 covers = "output-token clamp: reported usage clamped to the client's max_tokens"
 
 [[scenario]]
@@ -169,9 +169,9 @@ recover = "needs a stateful fixture shape recording the refresh call sequence, n
 [[divergence]]
 field = "expected_upstream_requests[].stream_options"
 status = "sanctioned"
-authority = "7e84b89a: one constant client window — the usage payload reports context_window 1000000 with counts scaled by 1e6/declared so a TOML window edit reaches running sessions; then PR #57/#58 (789b2ce/561d7ec): turn-scoped summary dedup — sequential-cutoff summary delivery; wall exception bdf6bc0"
+authority = "PR #57/#58 (789b2ce/561d7ec): turn-scoped summary dedup — sequential-cutoff summary delivery; wall exception bdf6bc0"
 pinned_value = '{"reasoning_summary_delivery":"sequential_cutoff"}'
-pinned_sha256 = "5dd1a2aaa27cadb55afb6b741b9b860d62cd7ed617e45b5650fb2df8331eafc8"
+pinned_sha256 = "695bd96a217d1af7e8af90d19e93b9efa7d1fc933eff3fdbbc694ee2598e737e"
 affects = "every request the responses dialect sends — the field did not exist at capture time (captured 2026-07-26, feature merged 2026-07-27)"
 reason = """
 The legacy reference re-requested reasoning summaries on every continuation round, duplicating
@@ -185,8 +185,8 @@ regression and must go kotlin-wrong.
 [[divergence]]
 field = "expected_upstream_requests[].prompt_cache_key"
 status = "sanctioned"
-authority = "7e84b89a: one constant client window — the usage payload reports context_window 1000000 with counts scaled by 1e6/declared so a TOML window edit reaches running sessions; then cache-key strategy quirk: ResponsesRequestBuilder.kt:141 CacheKeyStrategy.SESSION_ID (TOML cache_key = \"session-id\", shipped for grok at config/splice.example.toml:94); review repair 2026-07-30"
-pinned_sha256 = "5dd1a2aaa27cadb55afb6b741b9b860d62cd7ed617e45b5650fb2df8331eafc8"
+authority = "cache-key strategy quirk: ResponsesRequestBuilder.kt:141 CacheKeyStrategy.SESSION_ID (TOML cache_key = \"session-id\", shipped for grok at config/splice.example.toml:94); review repair 2026-07-30"
+pinned_sha256 = "a40bd9951ce456fd2535274196d7ad10b857894d24f2ddbbaa1272b6adc9b28e"
 affects = "all 11 frozen fixtures — every one pins splice-ab79a7c5bb0a3cec72e01e4e19b47fac (the first-message-hash fallback)"
 expected_with_session_header = "claudex:<x-claude-code-session-id>"
 expected_without_session_header = "splice-ab79a7c5bb0a3cec72e01e4e19b47fac"

--- a/dev/campaigns/proxy-hardening/oracle/expectations.toml
+++ b/dev/campaigns/proxy-hardening/oracle/expectations.toml
@@ -34,7 +34,7 @@ source = "server/ (legacy Node reference implementation)"
 source_suite_state = "104/104 pass at capture time"
 canonicalization = ["message-id: msg_<digits>[_<sequence>] -> msg_CANON"]
 replayed = 11
-replayed_at = 2026-08-07  # node dev/campaigns/proxy-hardening/oracle/replay.mjs (hermetic jar + vendored mock)
+replayed_at = 2026-09-05  # node dev/campaigns/proxy-hardening/oracle/replay.mjs (hermetic jar + vendored mock)
 captured_count = 11
 
 # ── captured, awaiting a replay verdict ──────────────────────────────────────
@@ -43,90 +43,102 @@ captured_count = 11
 
 [[scenario]]
 name = "basic"
-status = "passing"
-proof = "replay 2026-08-07: node dev/campaigns/proxy-hardening/oracle/replay.mjs — byte-identical after msg_CANON canonicalization; upstream requests field-identical except the sanctioned stream_options divergence (see [[divergence]])"
+status = "sanctioned"
+authority = "7e84b89a: one constant client window — the usage payload reports context_window 1000000 with counts scaled by 1e6/declared so a TOML window edit reaches running sessions"
+pin_upstream = "fixture"
+pinned_sha256 = "010e139a7e87bbdaa2132513a919e9ea2505bd5183797ad4061be1687cc9640e"
+replay_note = "Passing byte-identical from 2026-08-07 to 2026-09-05 (upstream requests still field-identical except the sanctioned stream_options divergence, see [[divergence]]). The reference reported the pinned row's 272000 window with raw counts; since 2026-09-05 the gateway reports the constant client window (1000000) and counts scaled by 1e6/272000, so every row, the pinned one included, compacts at its declared window and a splice.toml window edit lands on running sessions after `splice restart` (ModelCatalog.clientLaunchWindow). Only the usage payload differs from the recording."
 covers = "happy-path streaming turn: message_start/ping/content_block_*/message_delta/message_stop ordering, usage payload shape"
 
 [[scenario]]
 name = "multipart"
 status = "sanctioned"
-authority = "22a0744: codex-rs sequential_cutoff parity; PR #99 operator lock: mirror_reasoning=false"
+authority = "7e84b89a: one constant client window — the usage payload reports context_window 1000000 with counts scaled by 1e6/declared so a TOML window edit reaches running sessions; then 22a0744: codex-rs sequential_cutoff parity; PR #99 operator lock: mirror_reasoning=false"
 pin_upstream = "fixture"
-pinned_sha256 = "374e7400e62b8b655f685bbb28cad0aa751ccbe8dea2cfd25a9d83f5f7d43ee4"
-replay_note = "The frozen mock emits the legacy cumulative-summary carrier. The Codex profile now requests sequential_cutoff and renders only reasoning_summary_text.done, while the operator lock removes the duplicate mirror block. The ordinary answer text remains byte-pinned."
+pinned_sha256 = "b2297c88736f15ed874f72bc9dc4c14caaf72efc4b5a4925f5808cd1ddd6a03a"
+replay_note = "The frozen mock emits the legacy cumulative-summary carrier. The Codex profile now requests sequential_cutoff and renders only reasoning_summary_text.done, while the operator lock removes the duplicate mirror block. The ordinary answer text remains byte-pinned. Re-pinned 2026-09-05: The reference reported the pinned row's 272000 window with raw counts; since 2026-09-05 the gateway reports the constant client window (1000000) and counts scaled by 1e6/272000, so every row, the pinned one included, compacts at its declared window and a splice.toml window edit lands on running sessions after `splice restart` (ModelCatalog.clientLaunchWindow). Only the usage payload differs from the recording."
 covers = "sequential_cutoff handling of a legacy multipart summary plus the ordinary answer text"
 
 [[scenario]]
 name = "toolcall"
-status = "passing"
-proof = "replay 2026-08-07: node dev/campaigns/proxy-hardening/oracle/replay.mjs — byte-identical after msg_CANON canonicalization; upstream requests field-identical except the sanctioned stream_options divergence (see [[divergence]])"
+status = "sanctioned"
+authority = "7e84b89a: one constant client window — the usage payload reports context_window 1000000 with counts scaled by 1e6/declared so a TOML window edit reaches running sessions"
+pin_upstream = "fixture"
+pinned_sha256 = "3b8427226e38d87eded5fdaa61af7d7b6f4746f114a182c0d9c1b414af75f195"
+replay_note = "Passing byte-identical from 2026-08-07 to 2026-09-05 (upstream requests still field-identical except the sanctioned stream_options divergence, see [[divergence]]). The reference reported the pinned row's 272000 window with raw counts; since 2026-09-05 the gateway reports the constant client window (1000000) and counts scaled by 1e6/272000, so every row, the pinned one included, compacts at its declared window and a splice.toml window edit lands on running sessions after `splice restart` (ModelCatalog.clientLaunchWindow). Only the usage payload differs from the recording."
 covers = "tool_use block assembly from streamed function-call arguments"
 
 [[scenario]]
 name = "nonstream_tool"
 status = "sanctioned"
-authority = "PR #99 operator lock: mirror_reasoning=false"
+authority = "7e84b89a: one constant client window — the usage payload reports context_window 1000000 with counts scaled by 1e6/declared so a TOML window edit reaches running sessions; then PR #99 operator lock: mirror_reasoning=false"
 pin_upstream = "fixture"
-pinned_sha256 = "21e5e54d08243ec691a925020ee0f311c34692125664a1ab06b66ae3609f5435"
-replay_note = "The reference appended the reasoning summary as a duplicate text block after the real UTF-8 answer. Transcript mirroring is now operator-locked off, so the answer remains and that duplicate block is absent."
+pinned_sha256 = "6ab4672a6edfbb77427598be334771f9e08e8e428176c92d7dd2a4f66f66a427"
+replay_note = "The reference appended the reasoning summary as a duplicate text block after the real UTF-8 answer. Transcript mirroring is now operator-locked off, so the answer remains and that duplicate block is absent. Re-pinned 2026-09-05: The reference reported the pinned row's 272000 window with raw counts; since 2026-09-05 the gateway reports the constant client window (1000000) and counts scaled by 1e6/272000, so every row, the pinned one included, compacts at its declared window and a splice.toml window edit lands on running sessions after `splice restart` (ModelCatalog.clientLaunchWindow). Only the usage payload differs from the recording."
 covers = "non-stream translation path + UTF-8 split-chunk handling without transcript mirroring"
 
 [[scenario]]
 name = "truncated"
 status = "sanctioned"
-authority = "PR #42 (8778274): mid-stream re-anchoring — salvage forwarded turns through provider brownouts; backoff deadline-gated by BS-3. Re-pinned 2026-09-03 under 11ce5512 (the re-anchor budget is DEFAULT_MAX_CONTINUATIONS in ResponsesReanchorController, 2 -> 5 at codex-rs parity; CLAUDEX_UPSTREAM_RETRIES never governed it)"
-pinned_sha256 = "22f04bb1fd0f1823ee9a5e7c7c5319e8d3565b9ad4289ada969160d8f0fa0451"
+authority = "7e84b89a: one constant client window — the usage payload reports context_window 1000000 with counts scaled by 1e6/declared so a TOML window edit reaches running sessions; then PR #42 (8778274): mid-stream re-anchoring — salvage forwarded turns through provider brownouts; backoff deadline-gated by BS-3. Re-pinned 2026-09-03 under 11ce5512 (the re-anchor budget is DEFAULT_MAX_CONTINUATIONS in ResponsesReanchorController, 2 -> 5 at codex-rs parity; CLAUDEX_UPSTREAM_RETRIES never governed it)"
+pinned_sha256 = "40e420308172cbf9bf30b000ace64cefc438f9dcbbe40f80c97ddc38ce0bad5c"
 pinned_upstream_sha256 = "ecab8b70dfaeca0712235754f3f3e94af75fadbe75536107ed1074a75db4b1d3"
-replay_note = "Reference gave up after 1 attempt (887B, one partial block + overloaded_error). Gateway re-anchors five times (DEFAULT_MAX_CONTINUATIONS=5 -> 6 upstream requests, continuation-shaped: partial text + continue-exactly instruction), then emits the SAME overloaded_error class. Mock replays the identical truncation each time, so salvage cannot succeed here by construction; the pinned bytes encode 6 attempts. Was 3 attempts (2 re-anchors) until 11ce5512."
+replay_note = "Reference gave up after 1 attempt (887B, one partial block + overloaded_error). Gateway re-anchors five times (DEFAULT_MAX_CONTINUATIONS=5 -> 6 upstream requests, continuation-shaped: partial text + continue-exactly instruction), then emits the SAME overloaded_error class. Mock replays the identical truncation each time, so salvage cannot succeed here by construction; the pinned bytes encode 6 attempts. Was 3 attempts (2 re-anchors) until 11ce5512. Re-pinned 2026-09-05: The reference reported the pinned row's 272000 window with raw counts; since 2026-09-05 the gateway reports the constant client window (1000000) and counts scaled by 1e6/272000, so every row, the pinned one included, compacts at its declared window and a splice.toml window edit lands on running sessions after `splice restart` (ModelCatalog.clientLaunchWindow). Only the usage payload differs from the recording."
 covers = "honest failure: a truncated upstream stream is an SSE error, NEVER a clean empty end_turn (invariant L3)"
 
 [[scenario]]
 name = "overflow_sse"
 status = "sanctioned"
-authority = "PR #58 (561d7ec): message_start at upstream-handoff — same authority as failed"
-pinned_sha256 = "a99587ab2be7b97be8fb53de751082a163bc6c7b6549e3c8e61c9201a5d4f1b7"
+authority = "7e84b89a: one constant client window — the usage payload reports context_window 1000000 with counts scaled by 1e6/declared so a TOML window edit reaches running sessions; then PR #58 (561d7ec): message_start at upstream-handoff — same authority as failed"
+pinned_sha256 = "275d1030f723aeae55190e8a9bdfbdbc604d1c4105f6daf25b14a263fce53be1"
 pinned_upstream_sha256 = "1da272e23af30c823c69b2557d0185c5f93ae0e4d5c283c16e0c0a24766a9cc7"
-replay_note = "Same eager-preamble shape as failed; the invalid_request_error 'prompt is too long' rewrite itself is byte-identical to the reference. The G13 question in the pre-replay note is answered from evidence: mid-stream arrival keeps client status 200 in BOTH stacks."
+replay_note = "Same eager-preamble shape as failed; the invalid_request_error 'prompt is too long' rewrite itself is byte-identical to the reference. The G13 question in the pre-replay note is answered from evidence: mid-stream arrival keeps client status 200 in BOTH stacks. Re-pinned 2026-09-05: The reference reported the pinned row's 272000 window with raw counts; since 2026-09-05 the gateway reports the constant client window (1000000) and counts scaled by 1e6/272000, so every row, the pinned one included, compacts at its declared window and a splice.toml window edit lands on running sessions after `splice restart` (ModelCatalog.clientLaunchWindow). Only the usage payload differs from the recording."
 covers = "context overflow via response.failed rewritten to 'prompt is too long' invalid_request_error — the P0 the pre-port tree died on"
 note = "captured client status was 200. Whether the Kotlin gateway should return 4xx here is a G13 question (G13 fixed PRE-stream rejections; this failure arrives mid-stream, after headers). Classify at first replay from evidence — do not assume either reading."
 
 [[scenario]]
 name = "prefill"
-status = "passing"
-proof = "replay 2026-08-07: node dev/campaigns/proxy-hardening/oracle/replay.mjs — byte-identical after msg_CANON canonicalization; upstream requests field-identical except the sanctioned stream_options divergence (see [[divergence]])"
+status = "sanctioned"
+authority = "7e84b89a: one constant client window — the usage payload reports context_window 1000000 with counts scaled by 1e6/declared so a TOML window edit reaches running sessions"
+pin_upstream = "fixture"
+pinned_sha256 = "7dc307190d27e32609b0659acea59762319655206128c2ac7bb946eeddc1e41c"
+replay_note = "Passing byte-identical from 2026-08-07 to 2026-09-05 (upstream requests still field-identical except the sanctioned stream_options divergence, see [[divergence]]). The reference reported the pinned row's 272000 window with raw counts; since 2026-09-05 the gateway reports the constant client window (1000000) and counts scaled by 1e6/272000, so every row, the pinned one included, compacts at its declared window and a splice.toml window edit lands on running sessions after `splice restart` (ModelCatalog.clientLaunchWindow). Only the usage payload differs from the recording."
 covers = "assistant-prefill request shaping"
 
 [[scenario]]
 name = "replaystream"
 status = "sanctioned"
-authority = "22a0744: codex-rs sequential_cutoff parity; PR #99 operator lock: mirror_reasoning=false"
+authority = "7e84b89a: one constant client window — the usage payload reports context_window 1000000 with counts scaled by 1e6/declared so a TOML window edit reaches running sessions; then 22a0744: codex-rs sequential_cutoff parity; PR #99 operator lock: mirror_reasoning=false"
 pin_upstream = "fixture"
-pinned_sha256 = "429edee0651e3ef935797f8a60ddbc6818521f45431c9d21a379a313f4e5dc79"
-replay_note = "The encrypted reasoning envelope and answer remain byte-pinned. sequential_cutoff drops the mock's legacy summary carrier, and mirror_reasoning=false removes its duplicate text projection."
+pinned_sha256 = "8353c020fecfc235d5a7936d9c6b9919925bf160c7df869317f9416a6cd6892e"
+replay_note = "The encrypted reasoning envelope and answer remain byte-pinned. sequential_cutoff drops the mock's legacy summary carrier, and mirror_reasoning=false removes its duplicate text projection. Re-pinned 2026-09-05: The reference reported the pinned row's 272000 window with raw counts; since 2026-09-05 the gateway reports the constant client window (1000000) and counts scaled by 1e6/272000, so every row, the pinned one included, compacts at its declared window and a splice.toml window edit lands on running sessions after `splice restart` (ModelCatalog.clientLaunchWindow). Only the usage payload differs from the recording."
 covers = "encrypted reasoning-item replay wire path and ordinary answer text under sequential_cutoff"
 
 [[scenario]]
 name = "failed"
 status = "sanctioned"
-authority = "PR #58 (561d7ec): message_start lands at upstream-handoff so G5 pre-content reissue stays safe (HeadServerReviewTest: torn-before-client stays retryable). Upstream re-pinned 2026-09-03 under 11ce5512 (re-anchor budget 2 -> 5, so the pre-content retryable path now makes 6 upstream requests instead of 3)"
-pinned_sha256 = "9c253ca5cabd9e1b7052ad03fb693ba49ea8cd45f0f752c9fccc4fe83f5f57e9"
+authority = "7e84b89a: one constant client window — the usage payload reports context_window 1000000 with counts scaled by 1e6/declared so a TOML window edit reaches running sessions; then PR #58 (561d7ec): message_start lands at upstream-handoff so G5 pre-content reissue stays safe (HeadServerReviewTest: torn-before-client stays retryable). Upstream re-pinned 2026-09-03 under 11ce5512 (re-anchor budget 2 -> 5, so the pre-content retryable path now makes 6 upstream requests instead of 3)"
+pinned_sha256 = "65da69c058506e455ed527749d48a7d077149f3a586748899879f0188ccfc5e7"
 pinned_upstream_sha256 = "821f0db66654183c49afc11f920c9b42c159b384e3ec15cb1cb14957d41852f3"
-replay_note = "Gateway emits message_start+ping BEFORE the upstream terminal, then the SAME api_error text the reference emitted bare. Error class and message identical; only the eager preamble differs. The client bytes are unchanged by the 2026-09-03 budget change: with 6 attempts the turn spends ~6s in backoff and the 2s client keepalive wrote 2 or 3 SSE comment lines run to run, which is why those comments are now canonicalized away (replay.mjs CANON_RULES, _manifest.json)."
+replay_note = "Gateway emits message_start+ping BEFORE the upstream terminal, then the SAME api_error text the reference emitted bare. Error class and message identical; only the eager preamble differs. The client bytes are unchanged by the 2026-09-03 budget change: with 6 attempts the turn spends ~6s in backoff and the 2s client keepalive wrote 2 or 3 SSE comment lines run to run, which is why those comments are now canonicalized away (replay.mjs CANON_RULES, _manifest.json). Re-pinned 2026-09-05: The reference reported the pinned row's 272000 window with raw counts; since 2026-09-05 the gateway reports the constant client window (1000000) and counts scaled by 1e6/272000, so every row, the pinned one included, compacts at its declared window and a splice.toml window edit lands on running sessions after `splice restart` (ModelCatalog.clientLaunchWindow). Only the usage payload differs from the recording."
 covers = "upstream response.failed -> honest terminal error, no fabricated end_turn"
 
 [[scenario]]
 name = "bigout"
-status = "passing"
-proof = "replay 2026-08-07: node dev/campaigns/proxy-hardening/oracle/replay.mjs — byte-identical after msg_CANON canonicalization; upstream requests field-identical except the sanctioned stream_options divergence (see [[divergence]])"
+status = "sanctioned"
+authority = "7e84b89a: one constant client window — the usage payload reports context_window 1000000 with counts scaled by 1e6/declared so a TOML window edit reaches running sessions"
+pin_upstream = "fixture"
+pinned_sha256 = "be5bf0ff909eb41175b8e1811701908ebb0cb435e72e230b8da5092d9e49fa19"
+replay_note = "Passing byte-identical from 2026-08-07 to 2026-09-05 (upstream requests still field-identical except the sanctioned stream_options divergence, see [[divergence]]). The reference reported the pinned row's 272000 window with raw counts; since 2026-09-05 the gateway reports the constant client window (1000000) and counts scaled by 1e6/272000, so every row, the pinned one included, compacts at its declared window and a splice.toml window edit lands on running sessions after `splice restart` (ModelCatalog.clientLaunchWindow). Only the usage payload differs from the recording."
 covers = "output-token clamp: reported usage clamped to the client's max_tokens"
 
 [[scenario]]
 name = "compactish"
 status = "sanctioned"
-authority = "d0202374 + 1a649eca: the empty-turn error names the upstream shape; a closed empty message ends clean"
+authority = "7e84b89a: one constant client window — the usage payload reports context_window 1000000 with counts scaled by 1e6/declared so a TOML window edit reaches running sessions; then d0202374 + 1a649eca: the empty-turn error names the upstream shape; a closed empty message ends clean"
 pin_upstream = "fixture"
-pinned_sha256 = "d3b9f8609e69edfd4a1af576656578cbbcc537ba13e50a9812f5ea78fd865815"
-replay_note = "The frozen mock predates sequential_cutoff and returns only its legacy cumulative-summary carrier, and it completes NO message item (output_item.done without an item). With no reasoning_summary_text.done, no answer text and no closed message, the gateway emits the honest no-content error, whose text now carries the upstream shape it saw (`status=completed items=[] streamed=[reasoning]`) so the class is greppable from the client side. A stream that DOES close a message, even an empty one, ends clean instead (TurnPipelineTest, 2026-09-05)."
+pinned_sha256 = "5dd1a2aaa27cadb55afb6b741b9b860d62cd7ed617e45b5650fb2df8331eafc8"
+replay_note = "The frozen mock predates sequential_cutoff and returns only its legacy cumulative-summary carrier, and it completes NO message item (output_item.done without an item). With no reasoning_summary_text.done, no answer text and no closed message, the gateway emits the honest no-content error, whose text now carries the upstream shape it saw (`status=completed items=[] streamed=[reasoning]`) so the class is greppable from the client side. A stream that DOES close a message, even an empty one, ends clean instead (TurnPipelineTest, 2026-09-05). Re-pinned 2026-09-05: The reference reported the pinned row's 272000 window with raw counts; since 2026-09-05 the gateway reports the constant client window (1000000) and counts scaled by 1e6/272000, so every row, the pinned one included, compacts at its declared window and a splice.toml window edit lands on running sessions after `splice restart` (ModelCatalog.clientLaunchWindow). Only the usage payload differs from the recording."
 covers = "real Claude Code compaction request shaping and the honest empty-output terminal under sequential_cutoff"
 
 # ── captured deliberately NOT frozen, with reasons (never silently dropped) ──
@@ -157,9 +169,9 @@ recover = "needs a stateful fixture shape recording the refresh call sequence, n
 [[divergence]]
 field = "expected_upstream_requests[].stream_options"
 status = "sanctioned"
-authority = "PR #57/#58 (789b2ce/561d7ec): turn-scoped summary dedup — sequential-cutoff summary delivery; wall exception bdf6bc0"
+authority = "7e84b89a: one constant client window — the usage payload reports context_window 1000000 with counts scaled by 1e6/declared so a TOML window edit reaches running sessions; then PR #57/#58 (789b2ce/561d7ec): turn-scoped summary dedup — sequential-cutoff summary delivery; wall exception bdf6bc0"
 pinned_value = '{"reasoning_summary_delivery":"sequential_cutoff"}'
-pinned_sha256 = "695bd96a217d1af7e8af90d19e93b9efa7d1fc933eff3fdbbc694ee2598e737e"
+pinned_sha256 = "5dd1a2aaa27cadb55afb6b741b9b860d62cd7ed617e45b5650fb2df8331eafc8"
 affects = "every request the responses dialect sends — the field did not exist at capture time (captured 2026-07-26, feature merged 2026-07-27)"
 reason = """
 The legacy reference re-requested reasoning summaries on every continuation round, duplicating
@@ -173,8 +185,8 @@ regression and must go kotlin-wrong.
 [[divergence]]
 field = "expected_upstream_requests[].prompt_cache_key"
 status = "sanctioned"
-authority = "cache-key strategy quirk: ResponsesRequestBuilder.kt:141 CacheKeyStrategy.SESSION_ID (TOML cache_key = \"session-id\", shipped for grok at config/splice.example.toml:94); review repair 2026-07-30"
-pinned_sha256 = "a40bd9951ce456fd2535274196d7ad10b857894d24f2ddbbaa1272b6adc9b28e"
+authority = "7e84b89a: one constant client window — the usage payload reports context_window 1000000 with counts scaled by 1e6/declared so a TOML window edit reaches running sessions; then cache-key strategy quirk: ResponsesRequestBuilder.kt:141 CacheKeyStrategy.SESSION_ID (TOML cache_key = \"session-id\", shipped for grok at config/splice.example.toml:94); review repair 2026-07-30"
+pinned_sha256 = "5dd1a2aaa27cadb55afb6b741b9b860d62cd7ed617e45b5650fb2df8331eafc8"
 affects = "all 11 frozen fixtures — every one pins splice-ab79a7c5bb0a3cec72e01e4e19b47fac (the first-message-hash fallback)"
 expected_with_session_header = "claudex:<x-claude-code-session-id>"
 expected_without_session_header = "splice-ab79a7c5bb0a3cec72e01e4e19b47fac"

--- a/gateway/app/src/main/kotlin/splice/app/head/LaunchSpecFactory.kt
+++ b/gateway/app/src/main/kotlin/splice/app/head/LaunchSpecFactory.kt
@@ -63,7 +63,10 @@ internal class LaunchSpecFactory(
             modelSlots = head.models.orEmpty().mapNotNull { model ->
                 model.slot?.let { slot -> model.id to slot }
             }.toMap(),
-            contextWindow = ctx.catalog.contextWindowFor(head.pinnedModel),
+            // One constant client window per process, never the pinned row's number: each row's
+            // real window is applied by usage scaling on the wire, so a TOML edit reaches a running
+            // session after `splice restart` (ModelCatalog.clientLaunchWindow).
+            contextWindow = ctx.catalog.clientLaunchWindow,
             // The client's request timeout is DERIVED from the head's whole-turn cap (never a
             // second hand-maintained number): the proxy's wall is the one that names the verdict.
             apiTimeoutMs = ctx.watchdog.totalCap.inWholeMilliseconds + CLIENT_TIMEOUT_GRACE_MS,

--- a/gateway/app/src/test/kotlin/ExampleConfigTest.kt
+++ b/gateway/app/src/test/kotlin/ExampleConfigTest.kt
@@ -178,9 +178,9 @@ class ExampleConfigTest {
 
     // DR-24 / §22: every selected Grok row keeps its REAL backend ceiling. A head-wide 500k
     // override used to flatten grok-build-latest from 256k to 500k, so a haiku turn could run past
-    // the backend limit and hard-fail instead of compacting. The pinned 4.6 row still sets the
-    // process's 500k client window; ModelCatalog.usageScale bridges that fixed denominator to each
-    // selected row live through /model. Both denominators below come from the parsed source.
+    // the backend limit and hard-fail instead of compacting. The process's client window is a
+    // constant 1e6; ModelCatalog.usageScale bridges that fixed denominator to each selected row
+    // live through /model. Every declared denominator below comes from the parsed source.
     @Test
     fun `example grok windows stay per row while the pinned row sets the process window`() {
         val topology = TopologyLoader.parse(exampleToml())
@@ -214,12 +214,13 @@ class ExampleConfigTest {
             "every selected row must retain its source-declared backend ceiling",
         )
 
-        assertEquals(500_000L, catalog.contextWindowFor(head.pinnedModel), "the pinned row launches the 500k process")
+        assertEquals(500_000L, catalog.contextWindowFor(head.pinnedModel), "the pinned row keeps its declared 500k")
         assertEquals(
-            500_000L,
+            1_000_000L,
             catalog.clientContextWindowFor("grok-build-latest"),
-            "non-[1m] rows use that process window",
+            "non-[1m] rows use the constant client window the launch plants",
         )
+        assertEquals(2.0, catalog.usageScale("grok-4.6"), "the pinned row scales too: client 1m / real 500k")
 
         // Undeclared [1m] selectors strip to the row's real ceiling while the client uses literal 1m.
         assertEquals(500_000L, catalog.contextWindowFor("grok-4.6[1m]"))
@@ -449,7 +450,7 @@ class ExampleConfigTest {
         assertEquals(
             setOf(200_000L),
             anthropic.models.map { it.contextWindow }.toSet(),
-            "all claude-splice rows must match: clientContextWindowFor has no claude-* client branch",
+            "all claude-splice rows must equal the real window: a claude-* id ignores our env, so its counts ride raw",
         )
         assertEquals(3104, topology.heads["claude-splice"]!!.port)
         // shadowing the real binary would make the wrapper invoke itself

--- a/gateway/app/src/test/kotlin/splice/app/head/LaunchSpecClientAuthTest.kt
+++ b/gateway/app/src/test/kotlin/splice/app/head/LaunchSpecClientAuthTest.kt
@@ -140,8 +140,12 @@ class LaunchSpecClientAuthTest {
         assertEquals(333_000, cachedWindow)
     }
 
+    // Until 2026-09-05 this arm pinned that the pinned row's window rode into the spec as a Long
+    // (an Int overflow regression). The spec now carries ONE constant client window whatever the
+    // row declares — that decoupling is what lets a TOML window edit reach a running session — and
+    // the row's own number lives only in the picker cache (the arm above) and in usage scaling.
     @Test
-    fun `launch spec preserves a context window above Int max`(@TempDir tmp: Path) {
+    fun `launch spec carries the constant client window whatever the pinned row declares`(@TempDir tmp: Path) {
         val window = Int.MAX_VALUE.toLong() + 1
         val model = ModelEntry(id = "m", contextWindow = window)
         val base = build(tmp, Dialect.ANTHROPIC_PASSTHROUGH)
@@ -157,7 +161,8 @@ class LaunchSpecClientAuthTest {
 
         val spec = factory(tmp).launchSpecFor(ctx, 3099, forwardClientAuth = true)
 
-        assertEquals(window, spec.contextWindow)
+        assertEquals(ctx.catalog.clientLaunchWindow, spec.contextWindow, "the row's number never rides the env")
+        assertEquals(1_000_000L, spec.contextWindow)
     }
 
     @Test

--- a/gateway/control/src/main/kotlin/splice/control/LaunchService.kt
+++ b/gateway/control/src/main/kotlin/splice/control/LaunchService.kt
@@ -17,8 +17,9 @@ import splice.core.launch.MaterializeSpec
 import splice.core.util.EnvReader
 import kotlin.math.max
 
-// Floor for CLAUDE_CODE_AUTO_COMPACT_WINDOW (buildEnv): a small context window must not shrink the
-// auto-compact window below this.
+// Floor for CLAUDE_CODE_AUTO_COMPACT_WINDOW (buildEnv): a small client window must not shrink the
+// auto-compact window below this. Moot for a real launch since the client window became a constant
+// 1e6 (LaunchSpec.contextWindow), kept so a synthetic spec cannot plant a nonsense cap.
 private const val AUTO_COMPACT_FLOOR = 60_000L
 
 // LaunchSpec + LaunchRecipe live in LaunchTypes.kt (concentration, 2026-08-19).
@@ -146,6 +147,11 @@ public class LaunchService(
                 put("ANTHROPIC_DEFAULT_${slot}_MODEL_NAME", label)
                 put("ANTHROPIC_DEFAULT_${slot}_MODEL_DESCRIPTION", label)
             }
+            // ONE constant client window per process (ModelCatalog.clientLaunchWindow), never the
+            // pinned row's number: the row's real window is applied by usage scaling on every turn,
+            // so a TOML window edit + `splice restart` reaches THIS process live (2026-09-05).
+            // AUTO_COMPACT_WINDOW rides the same number — it is an absolute cap in the client's
+            // (scaled) units, and any smaller value would compact early by exactly that ratio.
             put("CLAUDE_CODE_MAX_CONTEXT_TOKENS", spec.contextWindow.toString())
             put("CLAUDE_CODE_AUTO_COMPACT_WINDOW", max(AUTO_COMPACT_FLOOR, spec.contextWindow).toString())
             put("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE", "85")

--- a/gateway/control/src/main/kotlin/splice/control/LaunchTypes.kt
+++ b/gateway/control/src/main/kotlin/splice/control/LaunchTypes.kt
@@ -25,6 +25,8 @@ public data class LaunchSpec(
      *  is planted under this wrapped spelling so the picker's allowlist hides its row (see
      *  LaunchService.buildEnv). Blank keeps the duplicate row. */
     val discoveryPrefix: String = "",
+    /** The client window planted as CLAUDE_CODE_MAX_CONTEXT_TOKENS: ModelCatalog.clientLaunchWindow,
+     *  a constant. Per-row windows never ride the env — usage scaling applies them on the wire. */
     val contextWindow: Long,
     /** Claude Code's per-request timeout (API_TIMEOUT_MS) for THIS head: the daemon's whole-turn
      *  cap plus a grace, so the client always outlives the proxy's own wall and receives its honest

--- a/gateway/control/src/main/kotlin/splice/control/StatuslineRow.kt
+++ b/gateway/control/src/main/kotlin/splice/control/StatuslineRow.kt
@@ -1,6 +1,6 @@
 // NEW: the picked model row as the statusline should show it. Claude Code fixes its context window
-// per PROCESS (the pinned row's, via CLAUDE_CODE_MAX_CONTEXT_TOKENS) and splice scales the token
-// counts it reports so any other row compacts at its own declared window, which leaves the blob
+// per PROCESS (one constant, via CLAUDE_CODE_MAX_CONTEXT_TOKENS) and splice scales the token
+// counts it reports so every row compacts at its own declared window, which leaves the blob
 // Claude Code pipes to /statusline in client units: on a 500k row over a 256k session the bar read
 // "…/256k" with counts x 0.512 however the operator switched (operator report, 2026-09-02). This
 // lens undoes that scaling for the picked row and names it by its catalog label; with no catalog,

--- a/gateway/control/src/test/kotlin/ControlServerTest.kt
+++ b/gateway/control/src/test/kotlin/ControlServerTest.kt
@@ -147,7 +147,9 @@ class ControlServerTest {
         pinnedModel = "gpt-5.6-sol",
         availableModelIds = listOf("gpt-5.6-sol", "gpt-5.4-mini"),
         modelLabels = mapOf("gpt-5.6-sol" to "Codex 5.6 Sol", "gpt-5.4-mini" to "Codex 5.4 Mini"),
-        contextWindow = 272000,
+        // what LaunchSpecFactory passes: the constant client window (ModelCatalog.clientLaunchWindow),
+        // never the pinned row's 272k
+        contextWindow = 1_000_000,
         modelOptionsCache = kotlinx.serialization.json.buildJsonObject { },
         statuslineCommand = "\"/bin/curl\" -s :3096/statusline",
         loginCommand = "claudex login",
@@ -384,7 +386,10 @@ class ControlServerTest {
         assertEquals(key, env["ANTHROPIC_AUTH_TOKEN"]?.jsonPrimitive?.content)
         assertFalse(env.containsKey("CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"))
         assertEquals("gpt-5.6-sol", env["ANTHROPIC_MODEL"]?.jsonPrimitive?.content)
-        assertEquals("272000", env["CLAUDE_CODE_MAX_CONTEXT_TOKENS"]?.jsonPrimitive?.content)
+        // the constant client window (ModelCatalog.clientLaunchWindow), never the pinned row's 272k:
+        // per-row windows are usage-scaled on the wire so a TOML edit reaches a running session
+        assertEquals("1000000", env["CLAUDE_CODE_MAX_CONTEXT_TOKENS"]?.jsonPrimitive?.content)
+        assertEquals("1000000", env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"]?.jsonPrimitive?.content)
         // ANTHROPIC_API_KEY is UNSET (else Claude Code's custom-key approval dead-ends at /login)
         assertTrue(obj["unset"]!!.jsonArray.any { it.jsonPrimitive.content == "ANTHROPIC_API_KEY" })
         val argv = obj["argv"]!!.jsonArray.map { it.jsonPrimitive.content }

--- a/gateway/control/src/test/kotlin/StatuslineScaledRowTest.kt
+++ b/gateway/control/src/test/kotlin/StatuslineScaledRowTest.kt
@@ -1,10 +1,10 @@
-// NEW: the statusline on a SCALED row. Claude Code fixes its context window per process (the
-// pinned row's) and splice scales the counts it reports so another row compacts at its own window,
-// which left the bar reading the client's window and the scaled counts however the operator
-// switched: picking grok-4.6[500k] on a 256k grok head kept "…/256k" on screen (operator report,
-// 2026-09-02). With the head's catalog the renderer shows the picked row's label, its declared
-// window and the real counts; a row that agrees with the client, and a head with no catalog, render
-// the blob exactly as before.
+// NEW: the statusline on a SCALED row. Claude Code fixes its context window per process (one
+// constant 1e6 since 2026-09-05) and splice scales the counts it reports so every row compacts at
+// its own window, which leaves the bar reading the client's window and the scaled counts however
+// the operator switched: picking grok-4.6[500k] on a 256k grok head kept "…/256k" on screen
+// (operator report, 2026-09-02). With the head's catalog the renderer shows the picked row's label,
+// its declared window and the real counts — the pinned row included, now that it scales too; a
+// head with no catalog renders the blob exactly as sent.
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import splice.control.StatuslineRenderer
@@ -23,12 +23,13 @@ class StatuslineScaledRowTest {
         pinnedModel = "grok-4.6",
     )
 
-    // What Claude Code pipes on the 500k row of a 256k session: its window is still the process's
-    // 256000, and the counts are the ones splice scaled by 256000/500000 = 0.512 (real used: 250k).
+    // What Claude Code pipes: its window is the process's constant 1000000, and the counts are the
+    // ones splice scaled by 1e6/declared — 500k reported is real 250k on the 500k row (x2.0) and real
+    // 128k on the 256k row (x3.90625); 50% either way, because the ratio is the row's own.
     private fun blob(id: String, display: String) = """
         {"model":{"id":"$id","display_name":"$display"},
-         "context_window":{"context_window_size":256000,"used_percentage":50,
-           "current_usage":{"input_tokens":28000,"cache_read_input_tokens":100000,"cache_creation_input_tokens":0}}}
+         "context_window":{"context_window_size":1000000,"used_percentage":50,
+           "current_usage":{"input_tokens":56000,"cache_read_input_tokens":444000,"cache_creation_input_tokens":0}}}
     """.trimIndent()
 
     private fun render(renderer: StatuslineRenderer, stdin: String): String =
@@ -43,10 +44,10 @@ class StatuslineScaledRowTest {
     }
 
     @Test
-    fun `the pinned row and a catalog-less head render the blob as sent`() {
+    fun `the pinned row is repaired too and a catalog-less head renders the blob as sent`() {
         val pinned = render(StatuslineRenderer(label = "grok", catalog = grok), blob("grok-4.6", "grok-4.6"))
-        assertTrue("Grok 4.6" in pinned && "128k/256k" in pinned, "scale 1.0 touches nothing but the label: $pinned")
+        assertTrue("Grok 4.6" in pinned && "128k/256k" in pinned, "the pinned row's real counts and window: $pinned")
         val bare = render(StatuslineRenderer(label = "grok"), blob("grok-4.6[500k]", "grok-4.6[500k]"))
-        assertTrue("grok-4.6[500k]" in bare && "128k/256k" in bare, "no catalog, no repair: $bare")
+        assertTrue("grok-4.6[500k]" in bare && "500k/1000k" in bare, "no catalog, no repair: $bare")
     }
 }

--- a/gateway/core/src/main/kotlin/splice/core/model/ModelCatalog.kt
+++ b/gateway/core/src/main/kotlin/splice/core/model/ModelCatalog.kt
@@ -22,6 +22,11 @@ private const val CLAUDE_CODE_ONE_MILLION = 1_000_000L
 // window, a silently wrong factor. Mirror the client, never improve on it.
 private val oneMillionHint = Regex("\\[1m]", RegexOption.IGNORE_CASE)
 
+/** Claude Code honors CLAUDE_CODE_MAX_CONTEXT_TOKENS only for an active id NOT starting with this
+ *  (cli 2.1.257 `kL`: `!id.startsWith("claude-") && !knownAlias(id)`); any other id resolves to
+ *  the client's built-in table or its 200k default, and nothing we launch with can move it. */
+private const val CLIENT_OWN_ID_PREFIX = "claude-"
+
 @Serializable
 public data class ModelEntry(
     val id: String,
@@ -49,8 +54,9 @@ public data class ModelCatalog(
     val extraWindows: List<ExtraWindow> = emptyList(),
     val windowRules: List<WindowRule> = emptyList(),
     val defaultContextWindow: Long,
-    /** The head's pinned model — the row whose window became CLAUDE_CODE_MAX_CONTEXT_TOKENS at
-     *  launch, and therefore the window the CLIENT believes every non-"[1m]" row has. */
+    /** The head's pinned model (ANTHROPIC_MODEL at launch). Since 2026-09-05 it does NOT name the
+     *  client's window — every launch plants [clientLaunchWindow] — so nothing in here reads it;
+     *  the head assembly and the launch spec still carry it. */
     val pinnedModel: String = "",
 ) {
     init {
@@ -116,18 +122,28 @@ public data class ModelCatalog(
             ?: fallback
     }
 
-    /** The window the CLIENT will actually use for [id], which is not always what we declare.
-     *  Claude Code resolves it as: `KE(id) = /\[1m\]/i` -> exactly 1e6, else
-     *  CLAUDE_CODE_MAX_CONTEXT_TOKENS (cli 2.1.233 `G4u`). That "[1m]" test on the id is the ONLY
-     *  id-keyed branch there is — no other spelling moves it — and the env is one number for the
-     *  whole process, so every other row is stuck with the PINNED row's window however it is
-     *  declared here. [usageScale] is what bridges the two. */
-    public fun clientContextWindowFor(id: String): Long =
-        if (oneMillionHint.containsMatchIn(unwrap(id))) {
-            CLAUDE_CODE_ONE_MILLION
-        } else {
-            contextWindowFor(pinnedModel)
-        }
+    /** The ONE window every launch declares to the client (CLAUDE_CODE_MAX_CONTEXT_TOKENS): a
+     *  constant, deliberately the number Claude Code hardcodes for a "[1m]" id, so the client-side
+     *  denominator is fixed for the life of the process however the catalog changes. [usageScale]
+     *  then carries EVERY row, the pinned one included, against its declared window — which is
+     *  what lets a TOML window edit + `splice restart` reach a RUNNING session on its next turn.
+     *  Before 2026-09-05 the pinned row's own window was the launch env, so editing it was
+     *  invisible to every live process: the daemon computed a 1.0 factor against the new number
+     *  while the client kept dividing by the old one (the 2026-09-05 272k cutover: six sessions
+     *  stayed on 400k until relaunched). */
+    public val clientLaunchWindow: Long get() = CLAUDE_CODE_ONE_MILLION
+
+    /** The window the CLIENT will actually use for [id] — mirrored from cli 2.1.257 `PL()`, never
+     *  improved on: `/\[1m\]/i` anywhere in the id -> exactly 1e6; an id starting with "claude-"
+     *  (a discovery-wrapped tier, or a passthrough head's native model) ignores our env and
+     *  resolves to the client's own table or its 200k default, so the DECLARED window is returned
+     *  and the counts ride raw — a factor we cannot honestly compute is 1.0; every other id ->
+     *  [clientLaunchWindow], the env the launch planted. */
+    public fun clientContextWindowFor(id: String): Long = when {
+        oneMillionHint.containsMatchIn(unwrap(id)) -> CLAUDE_CODE_ONE_MILLION
+        id.startsWith(CLIENT_OWN_ID_PREFIX) -> contextWindowFor(id)
+        else -> clientLaunchWindow
+    }
 
     /** Multiplier for the input-token counts reported to the client, so a row compacts at ITS OWN
      *  declared window rather than the session's.
@@ -136,8 +152,10 @@ public data class ModelCatalog(
      *  splice authors the NUMERATOR of that ratio even though the denominator is fixed in the
      *  client's process. Scaling the numerator by `client/declared` makes the ratio reach 1 exactly
      *  when real usage reaches the declared window — so a 500k row on a 256k session compacts at
-     *  500k, live, switchable from the /model menu. Returns 1.0 (untouched counts) whenever the row
-     *  already agrees with the client, which is every row on a head that declares one window. */
+     *  500k, live, switchable from the /model menu. With the client window a constant (see
+     *  [clientLaunchWindow]) every row scales, the pinned one included; 1.0 (untouched counts) is
+     *  left only where the client's window is genuinely not ours: a declared 1e6 row and the
+     *  "claude-" ids [clientContextWindowFor] names. */
     public fun usageScale(id: String): Double {
         val declared = contextWindowFor(id)
         // NO "[1m]" exemption, deliberately. `contains()` strips the suffix before its membership

--- a/gateway/core/src/test/kotlin/ModelCatalogTest.kt
+++ b/gateway/core/src/test/kotlin/ModelCatalogTest.kt
@@ -149,9 +149,9 @@ class ModelCatalogTest {
     @Test
     fun `usage scaling gives a row a window the client cannot be told about`() {
         // Claude Code resolves a window two ways only: /\[1m\]/i on the id -> 1e6, else the ONE
-        // process-wide CLAUDE_CODE_MAX_CONTEXT_TOKENS (= the pinned row's window). A third window
-        // therefore cannot come from the client — it comes from us scaling the token counts we
-        // report, since it compacts on (input+cache)/window and splice owns the numerator.
+        // process-wide CLAUDE_CODE_MAX_CONTEXT_TOKENS, which the launch plants as a constant 1e6.
+        // Every declared window therefore comes from us scaling the token counts we report, since
+        // it compacts on (input+cache)/window and splice owns the numerator.
         val xai = ModelCatalog(
             discoveryPrefix = "claude-grok--",
             models = listOf(
@@ -162,17 +162,21 @@ class ModelCatalogTest {
             defaultContextWindow = 256_000,
             pinnedModel = "grok-4.6",
         )
-        // the pinned row IS the env: exact counts, nothing to correct
-        assertEquals(256_000L, xai.clientContextWindowFor("grok-4.6"))
-        assertEquals(1.0, xai.usageScale("grok-4.6"))
-        // a "[1m]" row bypasses the env entirely, so it is honest too
+        // the pinned row scales like any other: the client believes the constant 1e6
+        assertEquals(1_000_000L, xai.clientContextWindowFor("grok-4.6"))
+        assertEquals(3.90625, xai.usageScale("grok-4.6"))
+        // a "[1m]" row bypasses the env entirely and declares 1e6, so its counts ride raw
         assertEquals(1_000_000L, xai.clientContextWindowFor("grok-4.3[1m]"))
         assertEquals(1.0, xai.usageScale("grok-4.3[1m]"))
-        // the middle row is the one the client has no way to represent: it believes 256k, so
-        // halving the reported counts makes it compact when REAL usage reaches 500k
-        assertEquals(256_000L, xai.clientContextWindowFor("grok-4.6[500k]"))
-        assertEquals(0.512, xai.usageScale("grok-4.6[500k]"))
-        assertEquals(0.512, xai.usageScale("claude-grok--grok-4.6[500k]"), "wrapped form too")
+        // the 500k row: the client believes 1e6, so doubling the reported counts makes it compact
+        // when REAL usage reaches 500k
+        assertEquals(1_000_000L, xai.clientContextWindowFor("grok-4.6[500k]"))
+        assertEquals(2.0, xai.usageScale("grok-4.6[500k]"))
+        // the discovery-WRAPPED spelling starts with "claude-", which makes Claude Code ignore the
+        // env (cli 2.1.257 kL) and fall back to its 200k default: no window of ours is in play, so
+        // the counts ride raw rather than against a client number we did not set
+        assertEquals(500_000L, xai.clientContextWindowFor("claude-grok--grok-4.6[500k]"))
+        assertEquals(1.0, xai.usageScale("claude-grok--grok-4.6[500k]"), "wrapped: the client ignores our env")
     }
 
     // DR-24: the 0.512 pin above once depended on exactWindows last-wins — fixture DECLARATION
@@ -199,8 +203,8 @@ class ModelCatalogTest {
                 defaultContextWindow = 256_000,
                 pinnedModel = "grok-4.6",
             )
-            assertEquals(0.512, xai.usageScale("grok-4.6[500k]"), "order ${rows.map { it.id }}")
-            assertEquals(1.0, xai.usageScale("grok-4.6"), "order ${rows.map { it.id }}")
+            assertEquals(2.0, xai.usageScale("grok-4.6[500k]"), "order ${rows.map { it.id }}")
+            assertEquals(3.90625, xai.usageScale("grok-4.6"), "order ${rows.map { it.id }}")
         }
     }
 
@@ -240,7 +244,11 @@ class ModelCatalogTest {
             pinnedModel = "k3-256k",
         )
         assertEquals(1.0, kimi.usageScale("k3[1m]"), "client 1e6 over declared 1e6")
-        assertEquals(1.0, kimi.usageScale("k3-256k"), "the pinned row is the env: exact")
+        assertEquals(
+            1_000_000.0 / 262_144.0,
+            kimi.usageScale("k3-256k"),
+            "the pinned row scales like any other: constant client 1e6 over its declared 256k",
+        )
     }
 
     @Test
@@ -296,9 +304,9 @@ class ModelCatalogTest {
     }
 
     @Test
-    fun `a row declaring LESS than the session window compacts at its own window`() {
-        // codex pins a 400k model but ships a 128k spark row; the client gives every non-[1m] id the
-        // one env window, so spark would run to 400k and overrun upstream. Scaling up fixes that.
+    fun `every row compacts at its own window - the pinned one included`() {
+        // codex pins a 400k model and ships a 128k spark row; the client gives every non-[1m] id the
+        // one env window (a constant 1e6), so each row is scaled up to compact at its own number.
         val codex = ModelCatalog(
             discoveryPrefix = "claude-codex--",
             models = listOf(
@@ -308,8 +316,44 @@ class ModelCatalogTest {
             defaultContextWindow = 400_000,
             pinnedModel = "gpt-5.6-sol",
         )
-        assertEquals(1.0, codex.usageScale("gpt-5.6-sol"))
-        assertEquals(3.125, codex.usageScale("gpt-5.3-codex-spark"))
+        assertEquals(2.5, codex.usageScale("gpt-5.6-sol"))
+        assertEquals(7.8125, codex.usageScale("gpt-5.3-codex-spark"))
+    }
+
+    // 2026-09-05: the codex rows moved 400k -> 272k to stay under OpenAI's 2x price line, and six
+    // running sessions kept compacting at 340k because the pinned row's window WAS the launch env:
+    // the rebuilt catalog computed a 1.0 factor against 272k while each process still divided by
+    // its frozen 400k. A constant client window makes the same edit land on the next turn.
+    @Test
+    fun `a window edit reaches a running process - the client window is a constant`() {
+        fun codex(sol: Long) = ModelCatalog(
+            discoveryPrefix = "claude-codex--",
+            models = listOf(ModelEntry(id = "gpt-5.6-sol", contextWindow = sol)),
+            defaultContextWindow = sol,
+            pinnedModel = "gpt-5.6-sol",
+        )
+        val before = codex(400_000)
+        val after = codex(272_000)
+        assertEquals(before.clientLaunchWindow, after.clientLaunchWindow, "the launch env never moves")
+        assertEquals(1_000_000L, before.clientContextWindowFor("gpt-5.6-sol"))
+        assertEquals(1_000_000L, after.clientContextWindowFor("gpt-5.6-sol"))
+        assertEquals(2.5, before.usageScale("gpt-5.6-sol"), "400k real reads as the client's 1e6")
+        assertEquals(1_000_000.0 / 272_000.0, after.usageScale("gpt-5.6-sol"), "272k real reads as 1e6 now")
+    }
+
+    // A passthrough head serves Claude Code's own model ids, which start with "claude-": the client
+    // ignores CLAUDE_CODE_MAX_CONTEXT_TOKENS for those and resolves the window from its own table
+    // (cli 2.1.257 kL/PL), so no window of ours exists to scale against — counts must ride raw.
+    @Test
+    fun `a claude- id ignores the launch env so its counts ride raw`() {
+        val anthropic = ModelCatalog(
+            discoveryPrefix = "claude-splice--",
+            models = listOf(ModelEntry(id = "claude-fable-5", contextWindow = 200_000)),
+            defaultContextWindow = 200_000,
+            pinnedModel = "claude-fable-5",
+        )
+        assertEquals(200_000L, anthropic.clientContextWindowFor("claude-fable-5"), "the declared window, not ours")
+        assertEquals(1.0, anthropic.usageScale("claude-fable-5"))
     }
 
     @Test

--- a/gateway/core/src/test/kotlin/TopologyConfigOverridesTest.kt
+++ b/gateway/core/src/test/kotlin/TopologyConfigOverridesTest.kt
@@ -127,7 +127,7 @@ class TopologyConfigOverridesTest {
         assertEquals(listOf("wide-b", "wide-a"), catalog.availableModelIds())
         assertEquals(provider.models.map { it.id }, provider.catalogFor(head.copy(models = null)).availableModelIds())
         assertEquals(setOf(500_000L), catalog.models.map { it.contextWindow }.toSet())
-        assertEquals(1.0, catalog.usageScale("wide-a"))
+        assertEquals(2.0, catalog.usageScale("wide-a"), "constant 1e6 client window over the 500k override")
         assertThrows(IllegalArgumentException::class.java) {
             provider.catalogFor(head.copy(models = listOf(HeadModel("not-declared-by-provider"))))
         }

--- a/gateway/gateway/src/main/kotlin/splice/gateway/wire/TurnWiring.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/wire/TurnWiring.kt
@@ -32,8 +32,9 @@ internal class TurnWiring(
             val cached = usage?.cachedTokens ?: 0
             val nonCachedInput = ((usage?.inputTokens ?: 0) - cached).coerceAtLeast(0)
             // Per-model context windows are a PROXY concern. Claude Code fixes its window per PROCESS
-            // (the launch env) for every id except a "[1m]" one, so a row wanting any other window can
-            // only be served from this side — by moving the numerator of the ratio it compacts on.
+            // (the launch env, one constant since 2026-09-05) for every id except a "[1m]" one, so a
+            // row's real window can only be served from this side — by moving the numerator of the
+            // ratio it compacts on — and that is also what lets a TOML edit reach a running session.
             // Scale by clientWindow/declared and the row compacts at ITS window, switchable live from
             // /model. Keyed on originalModel (the RAW picker id), because two rows can share one
             // upstream id and it is the row that owns the window. Output tokens are NOT scaled: they

--- a/gateway/gateway/src/test/kotlin/UsageTest.kt
+++ b/gateway/gateway/src/test/kotlin/UsageTest.kt
@@ -275,10 +275,10 @@ class UsageTest {
 /** The proxy seam that gives a picker row a window the CLIENT has no way to represent.
  *
  * Claude Code resolves a context window two ways only — `/\[1m\]/i` on the id -> 1e6, else the one
- * process-wide CLAUDE_CODE_MAX_CONTEXT_TOKENS — so at most two windows exist per session. It
+ * process-wide CLAUDE_CODE_MAX_CONTEXT_TOKENS, which the launch plants as a constant 1e6. It
  * compacts on `(input + cache_creation + cache_read) / window`, and splice writes that numerator,
- * which is the third window's only possible source. These pin that the scale actually reaches the
- * payload, keyed on the RAW picker id (two rows can share one upstream id).
+ * which is every declared window's only possible source. These pin that the scale actually reaches
+ * the payload, keyed on the RAW picker id (two rows can share one upstream id).
  */
 class UsageScalingTest {
 
@@ -320,25 +320,29 @@ class UsageScalingTest {
         assertTrue(logged.single().contains("grok-4.6[500k]"), "the line names the row: $logged")
 
         val exact = mutableListOf<String>()
-        TurnWiring(LogSink { exact += it }).usagePayloadBuilder(xai, meta("grok-4.6"))(Usage(1_000, 7, 200))
-        assertTrue(exact.isEmpty(), "an exact row must not log, got $exact")
+        TurnWiring(LogSink { exact += it }).usagePayloadBuilder(xai, meta("grok-4.3[1m]"))(Usage(1_000, 7, 200))
+        assertTrue(exact.isEmpty(), "an exact row (declared 1e6 = the client's 1e6) must not log, got $exact")
     }
 
     @Test
-    fun `the pinned row is reported EXACTLY - no head that wants one window may drift`() {
+    fun `the pinned row scales too - the client's constant 1e6 carries its declared 256k`() {
+        // Since 2026-09-05 the launch plants a constant 1e6 client window, so the pinned row is no
+        // longer exempt: real 100k of a 256k row must read as 39.06% of the client's 1e6, which is
+        // what lets a TOML window edit reach this process without a relaunch.
         val p = payload("grok-4.6", input = 100_000, cached = 40_000)
-        assertEquals(60_000, p["input_tokens"]?.jsonPrimitive?.content?.toLong(), "input minus cached")
-        assertEquals(40_000, p["cache_read_input_tokens"]?.jsonPrimitive?.content?.toLong())
-        assertEquals(256_000, p["context_window"]?.jsonPrimitive?.content?.toLong())
+        assertEquals(234_375, p["input_tokens"]?.jsonPrimitive?.content?.toLong(), "(100k - 40k) x 3.90625")
+        assertEquals(156_250, p["cache_read_input_tokens"]?.jsonPrimitive?.content?.toLong(), "40k x 3.90625")
+        assertEquals(1_000_000, p["context_window"]?.jsonPrimitive?.content?.toLong(), "what the client uses")
+        assertEquals("39.0625", p["used_percentage"]?.jsonPrimitive?.content, "100k of the row's own 256k")
     }
 
     @Test
-    fun `a 500k row halves the reported counts so it compacts at a REAL 500k`() {
-        // The client believes 256k. Real 250k of context must read as ~128k (50.0%), so the bar
-        // fills at real 500k instead of real 256k. Selectable live from /model.
+    fun `a 500k row doubles the reported counts so it compacts at a REAL 500k`() {
+        // The client believes 1e6. Real 250k of context must read as 500k (50.0%), so the bar
+        // fills at real 500k. Selectable live from /model.
         val p = payload("grok-4.6[500k]", input = 250_000, cached = 0)
-        assertEquals(128_000, p["input_tokens"]?.jsonPrimitive?.content?.toLong())
-        assertEquals(256_000, p["context_window"]?.jsonPrimitive?.content?.toLong(), "what the client uses")
+        assertEquals(500_000, p["input_tokens"]?.jsonPrimitive?.content?.toLong())
+        assertEquals(1_000_000, p["context_window"]?.jsonPrimitive?.content?.toLong(), "what the client uses")
         assertEquals("50", p["used_percentage"]?.jsonPrimitive?.content, "half of the row's own 500k")
     }
 
@@ -348,12 +352,13 @@ class UsageScalingTest {
     // shape rather than an edge case (review 2026-08-28, PR 99). BOTH terms scale, deliberately: the
     // ratio Claude Code compacts on is (input + cache_read)/window, so scaling only one half would
     // report 250k of real context as 69% of the client's 256k instead of the true 50%, and the row's
-    // whole reason for existing is that that percentage is honest against ITS window.
+    // whole reason for existing is that that percentage is honest against ITS window. Scaled only
+    // one half, 250k real on a 500k row would read 250k+200k = 45% of 1e6 instead of the true 50%.
     @Test
     fun `cache_read scales with input, so the compaction ratio is unchanged by the cached split`() {
         val p = payload("grok-4.6[500k]", input = 250_000, cached = 100_000)
-        assertEquals(76_800, p["input_tokens"]?.jsonPrimitive?.content?.toLong(), "(250k - 100k) x 0.512")
-        assertEquals(51_200, p["cache_read_input_tokens"]?.jsonPrimitive?.content?.toLong(), "100k x 0.512")
+        assertEquals(300_000, p["input_tokens"]?.jsonPrimitive?.content?.toLong(), "(250k - 100k) x 2.0")
+        assertEquals(200_000, p["cache_read_input_tokens"]?.jsonPrimitive?.content?.toLong(), "100k x 2.0")
         assertEquals("50", p["used_percentage"]?.jsonPrimitive?.content, "same 50% as the cached=0 case")
     }
 


### PR DESCRIPTION
## Why
Lowering the codex rows to 272k on 2026-09-05 changed nothing for the six sessions already running: the pinned row's window was the launch env (`CLAUDE_CODE_MAX_CONTEXT_TOKENS`), so the rebuilt catalog computed a 1.0 scale factor against 272k while each process kept dividing by its frozen 400k. Hot config is the point of the proxy; this closes that gap.

## What
- Every launch plants one constant client window, `1000000` (the number Claude Code hardcodes for a `[1m]` id), for both `CLAUDE_CODE_MAX_CONTEXT_TOKENS` and `CLAUDE_CODE_AUTO_COMPACT_WINDOW`.
- `ModelCatalog.usageScale` now carries every row, the pinned one included, as `1e6 / declared`. A TOML window edit plus `splice restart` reaches a running session on its next turn.
- Mirrored from cli 2.1.257 (`kL`/`PL`): ids starting with `claude-` ignore the env, so a passthrough head's models and a discovery-wrapped tier report their declared window and ride raw.
- Statusline already divides the scaled counts back; its tests now cover the pinned row.

## Verification
`:core:test :control:test :app:test :gateway:test --tests UsageScalingTest` and detekt on all four modules green locally; `gate:rules` and `gate:concentration` hold. The docker e2e head contract (`checks/e2e/docker/inside.sh`) now asserts the env constant and checks the pinned row's window in the picker cache instead.

One more relaunch of currently running sessions is needed to pick up the constant env; after that, none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)