### PR TITLE
feat(head): every OAuth head owns its credential, a compaction outlives its client, and the activity side query is answered locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Changed
+- **Every OAuth head signs in on its own credential file.** `chatgpt-oauth`, `grok-oauth` and
+  `kimi-oauth` now default to `~/.config/splice/auth/{codex,grok,kimi}.json` (kimi's `device_id`
+  beside it), written by `splice login <head>` on whichever account you choose there, which may
+  differ from the account the vendor's own CLI or desktop app uses. The apps' files
+  (`~/.codex/auth.json`, `~/.grok/auth.json`, `~/.kimi/credentials/kimi-code.json`) are never read
+  unless `auth.file` names one. Sharing a file was a trap: a refresh rotates the refresh token, so the
+  app and splice signed each other out, and the head had no credential while the other side rewrote
+  the file (24 failed turns in one 16-second rotation on 2026-09-05). Existing configs that name an
+  app's file keep working; `splice doctor` now warns about them, and the fix is to drop `file` and run
+  `splice login <head>`. The `CODEX_AUTH_PATH` / `GROK_AUTH_PATH` overrides still apply.
+
 ### Fixed
 - **A compaction outlives its client.** Claude Code abandons an auto-compaction at 600 s and
   retries the same bytes minutes later, and every abort used to cancel the upstream turn (Astra

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 ## Unreleased
 
 ### Fixed
+- **A compaction outlives its client.** Claude Code abandons an auto-compaction at 600 s and
+  retries the same bytes minutes later, and every abort used to cancel the upstream turn (Astra
+  compactions run 5-10 minutes; 7 were cut off this way on 2026-09-05). A compact stream turn now
+  runs on a scope the call's cancellation cannot reach and records its frames: a lost client
+  detaches, the turn finishes, and the byte-identical retry is served from the recording (or
+  follows the turn live if it is still running), with no second upstream turn. A head stop ends
+  the compactions still driving; the scope itself survives a restart (review: the first cut
+  cancelled it, and the first compaction after a restart came back empty with its slot leaked).
+- **Claude Code's activity-label side query is answered locally.** Every 30 s during a subagent
+  turn the client re-sends the whole transcript asking for a 3-5 word present-tense label
+  (294M input tokens in a day at 48% cache hit, 2026-09-05). The head recognises the query and
+  answers it from the transcript's last tool call, with no upstream turn.
+- **codex-rs's session and routing headers ride every turn** (`session-id`, `thread-id`,
+  `x-codex-routing-hint`, and the WebSocket handshake's `x-client-request-id`), so a reconnect
+  can land on the same backend replica and its prompt cache.
+- **A session's learned client window survives a daemon restart** (`<head>-client-windows.json`
+  in the state dir), so the first turn after a restart is scaled against the right window instead
+  of reported raw. A rejected request body is now logged with its byte counts and failure class.
 - **An auto-compaction no longer re-reads the whole transcript cold.** Claude Code compacts
   between a tool call and its execution, so the compaction body ends at the previous tool result
   and the call the backend just emitted is never answered. Chained over the WebSocket, the backend

--- a/README.md
+++ b/README.md
@@ -190,12 +190,14 @@ shell's environment; `splice doctor` detects this state explicitly. Keys in
 
 Each of these is a **password-equivalent secret**: anything that can read the file (or the environment variable) can spend against your account. Keep files `600`, never commit them, never paste them.
 
+Splice signs in on its own. Each OAuth head keeps its own credential file under `~/.config/splice/auth/`, written by `splice login <head>`, and it may be a different account from the one the vendor's own CLI or desktop app uses. The native apps' files (`~/.codex/auth.json`, `~/.grok/auth.json`, `~/.kimi/credentials/kimi-code.json`) are never read unless you name one in `auth.file`. Sharing a file with the native app is a trap: a refresh rotates the refresh token, so the app and splice invalidate each other's session, and the head has no credential while the other side rewrites the file. `splice doctor` warns when a head still names one.
+
 | Backend / route | Auth kind | Location | Notes |
 | --- | --- | --- | --- |
 | Claude (`claude-splice`) | `client` | Claude Code's native credential store | forwarded by Claude Code; splice stores no credential |
-| codex (ChatGPT) | `chatgpt-oauth` | `~/.codex/auth.json` | OAuth tokens — password-equivalent |
-| grok (xAI) | `grok-oauth` | `~/.grok/auth.json` | OAuth tokens — password-equivalent |
-| kimi (Moonshot) | `kimi-oauth` | `~/.kimi/credentials/kimi-code.json` | device-flow token — password-equivalent |
+| codex (ChatGPT) | `chatgpt-oauth` | `~/.config/splice/auth/codex.json` | splice's own OAuth tokens (`splice login claudex`); `~/.codex/auth.json` only by explicit `auth.file` |
+| grok (xAI) | `grok-oauth` | `~/.config/splice/auth/grok.json` | splice's own OAuth tokens (`claude-grok login`); `~/.grok/auth.json` only by explicit `auth.file` |
+| kimi (Moonshot) | `kimi-oauth` | `~/.config/splice/auth/kimi.json` (+ `device_id` beside it) | splice's own device-flow token (`claude-kimi login`); the app's file only by explicit `auth.file` |
 | OpenRouter | `api-key` | `$OPENROUTER_API_KEY` (env) or `~/.config/splice/keys.toml` | API key — password-equivalent |
 | Moonshot (pay-per-token) | `api-key` | `$MOONSHOT_API_KEY` (env) or `~/.config/splice/keys.toml` | API key — password-equivalent |
 | splice api-key store | — | `~/.config/splice/keys.toml` (0600) | env wins over the store — password-equivalent |

--- a/config/splice.example.toml
+++ b/config/splice.example.toml
@@ -27,9 +27,12 @@ mirror_reasoning = false     # operator-locked off; TOML, state, env, and runtim
 dialect = "openai-responses"
 base_url = "https://chatgpt.com/backend-api/codex"
 # EXPERIMENTAL: reuses the Codex CLI's public OAuth client identity — NOT a vendor-documented
-# third-party integration. auth.json is password-equivalent; splice reads AND refreshes it in place.
-# Documented alternative: OpenAI Platform API keys (kind = "api-key", env = "OPENAI_API_KEY").
-auth = { kind = "chatgpt-oauth", file = "~/.codex/auth.json" }
+# third-party integration. The credential file is password-equivalent; splice reads AND refreshes it
+# in place. Documented alternative: OpenAI Platform API keys (kind = "api-key", env = "OPENAI_API_KEY").
+# The credential is splice's OWN: ~/.config/splice/auth/codex.json, written by `splice login claudex`,
+# on whichever ChatGPT account you choose there. Set file = "~/.codex/auth.json" ONLY to share the
+# Codex app's session — the two then rotate each other's refresh token and sign each other out.
+auth = { kind = "chatgpt-oauth" }
 # Table form, not inline: tool_surface below is a sub-table, and TOML forbids adding a sub-table
 # to an inline table. Every knob here is what the daily-driven claudex runs.
 [providers.codex.quirks]
@@ -116,9 +119,11 @@ context_window = 128000
 dialect = "openai-responses"
 base_url = "https://api.x.ai/v1"
 # EXPERIMENTAL: reuses the Grok CLI's public OAuth client identity — NOT a vendor-documented
-# third-party integration. auth.json is password-equivalent; splice reads AND refreshes it in place.
-# Documented alternative: an OpenRouter API key (kind = "api-key", env = "OPENROUTER_API_KEY").
-auth = { kind = "grok-oauth", file = "~/.grok/auth.json" }  # browser login: `claude-grok login`
+# third-party integration. The credential file is password-equivalent; splice reads AND refreshes it
+# in place. Documented alternative: an OpenRouter API key (kind = "api-key", env = "OPENROUTER_API_KEY").
+# The credential is splice's OWN: ~/.config/splice/auth/grok.json, written by `claude-grok login`.
+# Set file = "~/.grok/auth.json" ONLY to share the Grok CLI's session (see the codex note above).
+auth = { kind = "grok-oauth" }  # browser login: `claude-grok login`
 # summary_field=true enables the reasoning.summary field (value comes from [daemon].summary).
 # Raw reasoning items stay encrypted by xAI; public form is summary/reasoning_text only.
 # reasoning_cache = false documented here because xai returns no encrypted reasoning envelopes —
@@ -183,9 +188,12 @@ context_window = 131072
 dialect = "anthropic-passthrough"
 base_url = "https://api.kimi.com/coding"
 # EXPERIMENTAL: reuses the Kimi CLI's public OAuth client identity — NOT a vendor-documented
-# third-party integration. kimi-code.json is password-equivalent; splice reads AND refreshes it in place.
-# Documented alternative: a Moonshot API key (kind = "api-key", env = "MOONSHOT_API_KEY").
-auth = { kind = "kimi-oauth", file = "~/.kimi/credentials/kimi-code.json" }
+# third-party integration. The credential file is password-equivalent; splice reads AND refreshes it
+# in place. Documented alternative: a Moonshot API key (kind = "api-key", env = "MOONSHOT_API_KEY").
+# The credential is splice's OWN: ~/.config/splice/auth/kimi.json plus a device_id beside it, written
+# by `claude-kimi login`. Set file = "~/.kimi/credentials/kimi-code.json" ONLY to share the Kimi
+# CLI's session and device identity (see the codex note above).
+auth = { kind = "kimi-oauth" }
 # The anthropic-passthrough dialect forwards the client's bytes FAITHFULLY by default; each knob
 # below opts into one deformation Kimi's /coding surface requires. They were hardcoded while Kimi
 # was the dialect's only consumer — declaring them here is what lets an api.anthropic.com-shaped

--- a/gateway/app/src/main/kotlin/splice/app/cli/DoctorAuth.kt
+++ b/gateway/app/src/main/kotlin/splice/app/cli/DoctorAuth.kt
@@ -6,6 +6,7 @@
 package splice.app.cli
 
 import splice.app.LoginIo
+import splice.app.TopologyLoader
 import splice.core.topology.AuthKind
 import splice.core.topology.AuthKindRegistry
 import splice.core.topology.ProviderConfig
@@ -36,7 +37,31 @@ internal class DoctorAuth {
         // is THE blocker (FAIL); once any head works, the others are ignorable (WARN).
         val missingStatus = if (heads.none { it.present }) CheckStatus.FAIL else CheckStatus.WARN
         val checks = verdict.credentialVerdict(heads, missingStatus)
-        return checks + restart.splitBrainChecks(heads, snapshot, envReader)
+        return checks + restart.splitBrainChecks(heads, snapshot, envReader) + sharedFileChecks(topology)
+    }
+
+    /** 2026-09-05: a head whose auth.file is the vendor app's own credential file shares one
+     *  refresh-token family with that app, and a refresh by either side signs the other out (the
+     *  AuthKind header). Splice's own file is the default now; a config written against the old
+     *  example still names the app's, works until the next rotation, and is told so here. WARN, never
+     *  FAIL: the head serves. */
+    private fun sharedFileChecks(topology: Topology): List<DoctorCheck> =
+        topology.heads.mapNotNull { (key, head) ->
+            topology.providers[head.provider]?.let { provider -> sharedFileCheck(key, head.provider, provider) }
+        }
+
+    private fun sharedFileCheck(key: String, providerKey: String, provider: ProviderConfig): DoctorCheck? {
+        val kind = AuthKindRegistry.from(provider.auth.kind) as? AuthKind.OAuth
+        val file = provider.auth.file
+        if (kind == null || file == null) return null
+        if (TopologyLoader.expandHome(file) != TopologyLoader.expandHome(kind.nativeAppFile)) return null
+        return DoctorCheck(
+            "auth",
+            CheckStatus.WARN,
+            "$key signs in with the ${kind.nativeApp}'s own credential file ($file) — " +
+                "a token refresh by either side signs the other out",
+            fix = "remove `file` from [providers.$providerKey] auth in splice.toml, then: splice login $key",
+        )
     }
 
     /** PHASE 1, all I/O: every configured head's credential state, read through StatusCommand.

--- a/gateway/app/src/main/kotlin/splice/app/cli/LoginCommand.kt
+++ b/gateway/app/src/main/kotlin/splice/app/cli/LoginCommand.kt
@@ -10,6 +10,7 @@ import splice.app.LoginIo
 import splice.app.LoginSpec
 import splice.app.OAuthLoginFlow
 import splice.app.TopologyLoader
+import splice.core.topology.AuthKindRegistry
 import splice.core.topology.ProviderConfig
 import splice.core.topology.Topology
 import splice.core.topology.TopologyMessages
@@ -51,7 +52,7 @@ internal class LoginCommand {
     ): Boolean =
         when (provider.auth.kind) {
             "kimi-oauth" -> DeviceLoginFlow.run(
-                kimi.spec(headKey, oauthAuthPath(provider, "~/.kimi/credentials/kimi-code.json")),
+                kimi.spec(headKey, oauthAuthPath(provider)),
             )
             // DR-97: the HEAD key, not the provider key — the daemon reads
             // effectiveApiKeyEnv(ctx.key), so the prompt must store under that var.
@@ -94,8 +95,8 @@ internal class LoginCommand {
             return null
         }
         return when (provider.auth.kind) {
-            "chatgpt-oauth" -> codex.spec(headKey, oauthAuthPath(provider, "~/.codex/auth.json"))
-            "grok-oauth" -> grok.spec(headKey, oauthAuthPath(provider, "~/.grok/auth.json"))
+            "chatgpt-oauth" -> codex.spec(headKey, oauthAuthPath(provider))
+            "grok-oauth" -> grok.spec(headKey, oauthAuthPath(provider))
             else -> {
                 println("splice: head '$headKey' uses ${provider.auth.kind} auth — no browser login for that kind.")
                 null
@@ -103,8 +104,17 @@ internal class LoginCommand {
         }
     }
 
-    internal fun oauthAuthPath(provider: ProviderConfig, fallback: String): Path =
-        Paths.get(TopologyLoader.expandHome(provider.auth.file ?: fallback))
+    /** The file a login writes: the provider's explicit auth.file, else the registry's splice-owned
+     *  default for its kind (AuthKind header, 2026-09-05). The native apps' files are never a
+     *  fallback here — an operator opts into one by naming it. Only reached for registered OAuth
+     *  kinds, whose default is non-null by construction. */
+    internal fun oauthAuthPath(provider: ProviderConfig): Path {
+        val file = provider.auth.file
+            ?: requireNotNull(AuthKindRegistry.defaultAuthFileFor(provider.auth.kind)) {
+                "no default credential file for auth kind '${provider.auth.kind}'"
+            }
+        return Paths.get(TopologyLoader.expandHome(file))
+    }
 
     /** Which heads support ANY sign-in flow (browser OAuth or api-key prompt) — keyed off auth.kind,
      *  matching login()'s own dispatch. HD-20 banned extension declarations; `Topology` lives in

--- a/gateway/app/src/main/kotlin/splice/app/cli/SetupCommand.kt
+++ b/gateway/app/src/main/kotlin/splice/app/cli/SetupCommand.kt
@@ -61,7 +61,8 @@ internal class SetupCommand {
             return true
         }
         println(
-            "$DIM  Subscription heads reuse each vendor CLI's own OAuth identity — " +
+            "$DIM  Subscription heads reuse each vendor CLI's public OAuth client identity, signed in " +
+                "separately for splice (its own credential file, any account) — " +
                 "unofficial; use at your own risk.$RESET",
         )
         var ok = true

--- a/gateway/app/src/main/kotlin/splice/app/head/ManagedHeadFactory.kt
+++ b/gateway/app/src/main/kotlin/splice/app/head/ManagedHeadFactory.kt
@@ -18,6 +18,7 @@ import splice.app.quota.QuotaProbes
 import splice.control.ManagedHead
 import splice.core.auth.ClientAuthProvider
 import splice.core.config.StatePaths
+import splice.core.model.ClientWindows
 import splice.core.util.LogSink
 import splice.gateway.compact.CompactStats
 import splice.gateway.perf.PerfStats
@@ -54,6 +55,7 @@ internal class ManagedHeadFactory(
             compactStats = CompactStats(statePaths.compactStatsFile(key)),
             perfStats = PerfStats(statePaths.perfStatsFile(key)),
             quota = QuotaTracker(statePaths.quotaFile(key)),
+            clientWindows = ClientWindows(store = statePaths.clientWindowsFile(key), log = log),
         )
         // Subscription heads (ChatGPT, Kimi, SuperGrok) have a usage endpoint; poll it so the bars
         // are right from the first tick. Every head still observes its rounds' headers. The

--- a/gateway/app/src/main/kotlin/splice/app/provider/ChatArm.kt
+++ b/gateway/app/src/main/kotlin/splice/app/provider/ChatArm.kt
@@ -9,6 +9,7 @@ package splice.app.provider
 import kotlinx.coroutines.CoroutineScope
 import splice.app.GrokRefresh
 import splice.app.TopologyLoader
+import splice.core.topology.AuthKind
 import splice.core.util.HeadScopedLogs
 import splice.core.util.LogSink
 import splice.provider.grok.GrokAuthProvider
@@ -36,7 +37,10 @@ internal class ChatArm(
             GROK_OAUTH -> {
                 val tokenUrl = GrokOAuthEndpoints.tokenUrl(System::getenv)
                 GrokAuthProvider(
-                    authPath = Paths.get(TopologyLoader.expandHome(providerCfg.auth.file ?: "~/.grok/auth.json")),
+                    // Splice's own file by default (AuthKind header, 2026-09-05); ~/.grok's only by auth.file.
+                    authPath = Paths.get(
+                        TopologyLoader.expandHome(providerCfg.auth.file ?: AuthKind.GrokOAuth.authFile),
+                    ),
                     authCacheMs = ctx.cfg.authCacheMs,
                     refreshCall = { rt -> grokRefresh.refresh(tokenUrl, rt) },
                     prefetchScope = probeScope,

--- a/gateway/app/src/main/kotlin/splice/app/provider/KimiOAuth.kt
+++ b/gateway/app/src/main/kotlin/splice/app/provider/KimiOAuth.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.CoroutineScope
 import splice.app.KimiRefresh
 import splice.app.TopologyLoader
 import splice.core.auth.RefreshableAuthProvider
+import splice.core.topology.AuthKind
 import splice.core.util.HeadScopedLogs
 import splice.core.util.LogSink
 import splice.provider.kimi.KimiAuthProvider
@@ -22,8 +23,9 @@ internal class KimiOAuth(
     private val kimiRefresh: KimiRefresh,
 ) {
     internal fun kimiOauthAuth(ctx: ProviderBuild): Pair<RefreshableAuthProvider, KimiDeviceIdentity> {
+        // Splice's own file by default (AuthKind header, 2026-09-05); the native app's only by auth.file.
         val authPath = Paths.get(
-            TopologyLoader.expandHome(ctx.providerCfg.auth.file ?: "~/.kimi/credentials/kimi-code.json"),
+            TopologyLoader.expandHome(ctx.providerCfg.auth.file ?: AuthKind.KimiOAuth.authFile),
         )
         val identity = KimiDeviceIdentity(deviceIdPath = authPath.resolveSibling("device_id"))
         val identityHeaders = identity.headers()

--- a/gateway/app/src/test/kotlin/DoctorAuthSharedFileTest.kt
+++ b/gateway/app/src/test/kotlin/DoctorAuthSharedFileTest.kt
@@ -1,0 +1,58 @@
+// NEW: 2026-09-05 — doctor warns when a head signs in with the vendor app's own credential file
+// (AuthKind header): the config keeps working, so WARN with the exact fix, and nothing for a head
+// on splice's own file or on the default.
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import splice.app.cli.CheckStatus
+import splice.app.cli.DaemonSnapshot
+import splice.app.cli.DoctorAuth
+import splice.app.cli.DoctorTopology
+import splice.core.model.ModelEntry
+import splice.core.topology.AuthConfig
+import splice.core.topology.DaemonConfig
+import splice.core.topology.Dialect
+import splice.core.topology.HeadConfig
+import splice.core.topology.ProviderConfig
+import splice.core.topology.Topology
+import splice.core.util.EnvReader
+
+class DoctorAuthSharedFileTest {
+
+    private fun topology(vararg providers: Pair<String, String?>): Topology = Topology(
+        daemon = DaemonConfig(controlPort = 4123),
+        providers = providers.associate { (key, file) ->
+            key to ProviderConfig(
+                dialect = Dialect.OPENAI_RESPONSES,
+                baseUrl = "https://example.invalid",
+                auth = AuthConfig("chatgpt-oauth", file = file),
+                models = listOf(ModelEntry("m", contextWindow = 100_000)),
+            )
+        },
+        heads = providers.associate { (key, _) ->
+            "head-$key" to HeadConfig(key, 4101, "claude-$key--", "m")
+        },
+    )
+
+    private fun authChecks(topology: Topology) =
+        DoctorAuth().authChecks(DoctorTopology.Parsed(topology), EnvReader { null }, DaemonSnapshot(4123, null))
+
+    @Test
+    fun `a head on the vendor app's own file gets a WARN naming the fix`() {
+        val checks = authChecks(topology("codex" to "~/.codex/auth.json"))
+        val shared = checks.filter { it.detail.contains("Codex CLI / ChatGPT app") }
+        assertEquals(1, shared.size, checks.toString())
+        assertEquals(CheckStatus.WARN, shared.single().status)
+        assertTrue(shared.single().detail.startsWith("head-codex signs in with"), shared.single().detail)
+        assertEquals(
+            "remove `file` from [providers.codex] auth in splice.toml, then: splice login head-codex",
+            shared.single().fix,
+        )
+    }
+
+    @Test
+    fun `splice's own file, explicit or default, draws no warning`() {
+        val checks = authChecks(topology("own" to "~/.config/splice/auth/codex.json", "default" to null))
+        assertTrue(checks.none { it.detail.contains("own credential file") }, checks.toString())
+    }
+}

--- a/gateway/app/src/test/kotlin/StatusCommandTest.kt
+++ b/gateway/app/src/test/kotlin/StatusCommandTest.kt
@@ -47,8 +47,9 @@ class StatusCommandTest {
 
     // DR-98: a kimi-oauth head with default config read permanently not-signed-in — the registry
     // row carried null (claiming a "provider-computed path" nothing computes) while every working
-    // path hard-falls-back to ~/.kimi/credentials/kimi-code.json, so credentialConfigured resolved
-    // NO file: status showed login-needed and doctor FAILed forever against a serving head.
+    // path hard-fell-back to the same literal, so credentialConfigured resolved NO file: status
+    // showed login-needed and doctor FAILed forever against a serving head. Since 2026-09-05 the
+    // default is splice's own ~/.config/splice/auth/kimi.json (AuthKind header), never the app's.
     @Test
     fun `kimi-oauth default credential file counts as configured - DR-98`(@TempDir tmp: Path) {
         val provider = ProviderConfig(
@@ -56,8 +57,8 @@ class StatusCommandTest {
             baseUrl = "https://example.invalid",
             auth = AuthConfig("kimi-oauth"),
         )
-        val creds = Files.createDirectories(tmp.resolve(".kimi").resolve("credentials"))
-        Files.writeString(creds.resolve("kimi-code.json"), """{"access_token":"k"}""")
+        val creds = Files.createDirectories(tmp.resolve(".config").resolve("splice").resolve("auth"))
+        Files.writeString(creds.resolve("kimi.json"), """{"access_token":"k"}""")
         val savedHome = System.getProperty("user.home")
         System.setProperty("user.home", tmp.toString())
         try {

--- a/gateway/app/src/test/kotlin/splice/app/cli/LoginCommandTest.kt
+++ b/gateway/app/src/test/kotlin/splice/app/cli/LoginCommandTest.kt
@@ -25,8 +25,22 @@ class LoginCommandTest {
         )
         assertEquals(
             Paths.get("/tmp/splice-custom-auth.json"),
-            LoginCommand().oauthAuthPath(provider, "~/.codex/auth.json"),
+            LoginCommand().oauthAuthPath(provider),
         )
+    }
+
+    // 2026-09-05: a head with no auth.file signs in to SPLICE's own file for its kind — never the
+    // native app's (~/.grok/auth.json here), whose refresh rotation would invalidate splice's session.
+    @Test
+    fun `oauth login defaults to the splice-owned file for the kind, never the native app's`() {
+        val provider = ProviderConfig(
+            dialect = Dialect.OPENAI_RESPONSES,
+            baseUrl = "https://example.invalid",
+            auth = AuthConfig("grok-oauth"),
+        )
+        val path = LoginCommand().oauthAuthPath(provider)
+        assertEquals(Paths.get(TopologyLoader.expandHome("~/.config/splice/auth/grok.json")), path)
+        assertFalse(path.endsWith(Paths.get(".grok", "auth.json")))
     }
 
     // DR-97: the masked prompt must derive its var from the HEAD key — the daemon reads

--- a/gateway/core/src/main/kotlin/splice/core/config/Knob.kt
+++ b/gateway/core/src/main/kotlin/splice/core/config/Knob.kt
@@ -5,6 +5,8 @@
 // anthropicUpstream + claudeCredentialsPath keys (nothing read them; claudithos leftovers).
 package splice.core.config
 
+import splice.core.topology.AuthKind
+
 // KnobKind + knobsByKey + restartRequiredKnobKeys live in KnobKind.kt
 // (concentration, 2026-08-19).
 
@@ -32,7 +34,9 @@ public enum class Knob(
         "codexAuthPath",
         KnobKind.STRING,
         listOf("CODEX_AUTH_PATH"),
-        "~/.codex/auth.json",
+        // The registry's splice-owned default (AuthKind header, 2026-09-05) — referenced, not copied,
+        // so the knob and the file `splice login` writes cannot drift apart (the DR-79 class).
+        AuthKind.ChatgptOAuth.authFile,
         restartRequired = true,
     ),
     PINNED_MODEL(
@@ -229,7 +233,8 @@ public enum class Knob(
         // DR-79: must agree with AuthKind.GrokOAuth's registry default — login writes there, the
         // arm reads here, and the spike-era ~/.local/share/claude-grok path made a head omitting
         // auth.file 401 forever while doctor said signed-in (pinned by the registry-agreement arm).
-        "~/.grok/auth.json",
+        // Since 2026-09-05 the value IS the registry's, and it is splice's own file, not ~/.grok's.
+        AuthKind.GrokOAuth.authFile,
         restartRequired = true,
     ),
     CONTROL_PORT(

--- a/gateway/core/src/main/kotlin/splice/core/config/StatePaths.kt
+++ b/gateway/core/src/main/kotlin/splice/core/config/StatePaths.kt
@@ -53,6 +53,10 @@ public class StatePaths(
     /** Per-turn perf telemetry JSONL (bottleneck instrument) — additive, not a frozen HUD name. */
     public fun perfStatsFile(headKey: String): Path = stateDir.resolve("$headKey-perf.jsonl")
 
+    /** The per-session client windows a head learned from status-line posts (ClientWindows): a warm
+     *  start across daemon restarts, re-taught by the next post. */
+    public fun clientWindowsFile(headKey: String): Path = stateDir.resolve("$headKey-client-windows.json")
+
     /** Compact-stats JSONL lives in the ROOT dir (not state/) — HUD contract. The two legacy
      *  names are irregular on purpose (claudex-…, claude-grok-…); overridable per head. */
     public fun compactStatsFile(headKey: String, nameOverride: String? = null): Path {

--- a/gateway/core/src/main/kotlin/splice/core/model/ClientWindows.kt
+++ b/gateway/core/src/main/kotlin/splice/core/model/ClientWindows.kt
@@ -9,28 +9,96 @@
 // 2026-09-05: "claudex sessions spend more time compacting than doing anything else"). The client
 // tells us its window on every status-line post (`session_id` + `context_window.context_window_size`),
 // so the proxy learns it per session and scales THAT session's counts against it — live, no relaunch.
+//
+// PERSISTED (2026-09-05, afternoon): memory-only, every daemon restart forgot every session, and each
+// one rode its first turn after the restart on the launch env's window instead of its own (the
+// "one raw turn after a restart" residual, measured on 5 of 8 sessions that afternoon). The file
+// is a warm start, not a source of truth: a session keeps posting, and a post always wins over it.
 package splice.core.model
+
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+import kotlinx.serialization.json.put
+import splice.core.util.LogSink
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
 
 private const val DEFAULT_CAPACITY = 512
 
 /** Session id -> the window Claude Code computed for an env-governed id in that process. Bounded
  *  (least-recently-touched eviction) since sessions come and go for the daemon's whole life. */
-public class ClientWindows(private val capacity: Int = DEFAULT_CAPACITY) {
+public class ClientWindows(
+    private val capacity: Int = DEFAULT_CAPACITY,
+    /** Where the registry survives a daemon restart; null (tests) keeps it in memory only. */
+    private val store: Path? = null,
+    private val log: LogSink = LogSink {},
+) {
 
     private val lock = Any()
+    private val ioLock = Any()
     private val windows = object : LinkedHashMap<String, Long>(INITIAL_CAPACITY, LOAD_FACTOR, true) {
         override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Long>?): Boolean = size > capacity
+    }
+
+    init {
+        store?.let { load(it) }
     }
 
     public fun record(sessionId: String?, window: Long?) {
         if (sessionId.isNullOrEmpty()) return
         val positive = window?.takeIf { it > 0 } ?: return
-        synchronized(lock) { windows[sessionId] = positive }
+        val changed = synchronized(lock) { windows.put(sessionId, positive) != positive }
+        // Only a CHANGED value touches the disk: a session posts every few seconds and its window
+        // changes about never, so this is one write per session, not one per post.
+        if (changed) store?.let { persist(it) }
     }
 
     /** The session's window, or null for a session that has not posted a status line yet. */
     public fun windowFor(sessionId: String?): Long? =
         sessionId?.let { synchronized(lock) { windows[it] } }
+
+    private fun load(path: Path) {
+        if (!Files.exists(path)) return
+        try {
+            val entries = Json.parseToJsonElement(Files.readString(path)).jsonObject
+            synchronized(lock) {
+                entries.forEach { (id, value) ->
+                    value.jsonPrimitive.longOrNull?.takeIf { it > 0 }?.let { windows[id] = it }
+                }
+            }
+        } catch (e: IOException) {
+            log(unreadable(path, e))
+        } catch (e: SerializationException) {
+            log(unreadable(path, e))
+        } catch (e: IllegalArgumentException) {
+            // A well-formed JSON document of the wrong shape (an array, a nested object).
+            log(unreadable(path, e))
+        }
+    }
+
+    // Least-recently-touched first, the map's own iteration order, so a reload keeps the eviction
+    // order. tmp + ATOMIC_MOVE: a concurrent reader (the next daemon) never sees a torn file.
+    private fun persist(path: Path) = synchronized(ioLock) {
+        val snapshot = synchronized(lock) { windows.toMap() }
+        val json = buildJsonObject { snapshot.forEach { (id, window) -> put(id, window) } }.toString()
+        try {
+            path.parent?.let { Files.createDirectories(it) }
+            val tmp = path.resolveSibling("${path.fileName}.tmp")
+            Files.writeString(tmp, json)
+            Files.move(tmp, path, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
+        } catch (e: IOException) {
+            log("[windows] client-window registry not saved to $path (${e::class.simpleName})\n")
+        }
+    }
+
+    private fun unreadable(path: Path, e: Exception): String =
+        "[windows] client-window registry at $path ignored (${e::class.simpleName}); sessions re-teach it\n"
 }
 
 private const val INITIAL_CAPACITY = 16

--- a/gateway/core/src/main/kotlin/splice/core/topology/AuthKind.kt
+++ b/gateway/core/src/main/kotlin/splice/core/topology/AuthKind.kt
@@ -6,6 +6,15 @@
 // never fails config parse, from() returns null, and provider arms retain generic API-key behavior.
 // Context display labels stay in their call sites (status vs boot word them differently);
 // only the shared facts live here.
+//
+// 2026-09-05 — SPLICE OWNS ITS CREDENTIAL. Every OAuth kind defaults to a file of splice's own
+// under ~/.config/splice/auth/, never the native app's (~/.codex/auth.json, ~/.grok/auth.json,
+// ~/.kimi/credentials/kimi-code.json). A file shared with the vendor's CLI or desktop app shares one
+// refresh-token family, and an OpenAI-style refresh ROTATES it: each side invalidates the other's
+// session, and the head sits without credentials while the other process rewrites the file (24
+// turns failed in the 16 s of one rotation at 18:31 that day). The native file stays an explicit
+// opt-in through auth.file; `splice login <head>` signs splice in on its own, on whichever account
+// the operator chooses — the split lets the native apps and the splice heads use different accounts.
 package splice.core.topology
 
 public sealed class AuthKind(
@@ -13,18 +22,44 @@ public sealed class AuthKind(
     public val defaultAuthFile: String?,
     public val isOAuth: Boolean,
 ) {
-    /** OAuth schemes: a browser/device login mints a refresh-capable credential file. */
-    public sealed class OAuth(wire: String, defaultAuthFile: String?) :
-        AuthKind(wire, defaultAuthFile, isOAuth = true)
+    /** OAuth schemes: a browser/device login mints a refresh-capable credential file. [authFile] is
+     *  the splice-owned default for the kind — non-null here, so the legacy knobs and every arm can
+     *  read it without a fallback literal of their own (header, 2026-09-05). [nativeAppFile] is the
+     *  vendor's own CLI/app credential file: never a default, known so doctor can name a config
+     *  that still shares it. */
+    public sealed class OAuth(
+        wire: String,
+        public val authFile: String,
+        public val nativeAppFile: String,
+        public val nativeApp: String,
+    ) : AuthKind(wire, authFile, isOAuth = true)
 
-    public data object ChatgptOAuth : OAuth("chatgpt-oauth", "~/.codex/auth.json")
-    public data object GrokOAuth : OAuth("grok-oauth", "~/.grok/auth.json")
+    public data object ChatgptOAuth : OAuth(
+        "chatgpt-oauth",
+        "~/.config/splice/auth/codex.json",
+        "~/.codex/auth.json",
+        "Codex CLI / ChatGPT app",
+    )
+
+    public data object GrokOAuth : OAuth(
+        "grok-oauth",
+        "~/.config/splice/auth/grok.json",
+        "~/.grok/auth.json",
+        "Grok CLI",
+    )
 
     // DR-98: the null here claimed a "provider-computed path", but nothing computes one — every
     // working path (device-flow login, the provider's credential read) hard-falls-back to this
     // same literal, while presence checks read the REGISTRY and so saw no file: a kimi-oauth head
     // with default config showed login-needed in status and FAILed doctor forever while serving.
-    public data object KimiOAuth : OAuth("kimi-oauth", "~/.kimi/credentials/kimi-code.json")
+    // The device identity (KimiDeviceIdentity) lives beside the file as device_id — splice's own
+    // device under the splice-owned default, the native app's only when auth.file opts into its dir.
+    public data object KimiOAuth : OAuth(
+        "kimi-oauth",
+        "~/.config/splice/auth/kimi.json",
+        "~/.kimi/credentials/kimi-code.json",
+        "Kimi CLI",
+    )
 
     /** The head holds NO credential: the caller's own auth headers are forwarded upstream, and its
      *  native login stays enabled (campaign claude-head). No auth file, no refresh, no sign-in flow

--- a/gateway/core/src/test/kotlin/AuthKindDefaultsTest.kt
+++ b/gateway/core/src/test/kotlin/AuthKindDefaultsTest.kt
@@ -1,0 +1,36 @@
+// NEW: 2026-09-05 — splice owns its credential: every OAuth kind's default file is splice's own
+// under ~/.config/splice/auth/, never the native app's, and the legacy knobs agree with it.
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import splice.core.config.Knob
+import splice.core.topology.AuthKind
+import splice.core.topology.AuthKindRegistry
+
+class AuthKindDefaultsTest {
+
+    private val nativeAppFiles =
+        listOf("~/.codex/auth.json", "~/.grok/auth.json", "~/.kimi/credentials/kimi-code.json")
+
+    @Test
+    fun `every OAuth kind defaults to a splice-owned credential file, never the native app's`() {
+        val oauth = AuthKindRegistry.knownKinds().filterIsInstance<AuthKind.OAuth>()
+        assertEquals(3, oauth.size, "the registry's OAuth kinds")
+        oauth.forEach { kind ->
+            assertTrue(kind.authFile.startsWith("~/.config/splice/auth/"), "${kind.wire}: ${kind.authFile}")
+            assertFalse(kind.authFile in nativeAppFiles, "${kind.wire} must not share the native app's file")
+            assertEquals(kind.authFile, AuthKindRegistry.defaultAuthFileFor(kind.wire))
+            // The registry knows the app's file only so doctor can name a config that still shares it.
+            assertTrue(kind.nativeAppFile in nativeAppFiles, "${kind.wire}: ${kind.nativeAppFile}")
+            assertFalse(kind.nativeAppFile == kind.authFile)
+        }
+        assertEquals(oauth.size, oauth.map { it.authFile }.toSet().size, "one file per kind")
+    }
+
+    @Test
+    fun `the legacy codex and grok knobs default to the registry's splice-owned files`() {
+        assertEquals(AuthKind.ChatgptOAuth.authFile, Knob.CODEX_AUTH_PATH.default)
+        assertEquals(AuthKind.GrokOAuth.authFile, Knob.GROK_AUTH_PATH.default)
+    }
+}

--- a/gateway/core/src/test/kotlin/ClientWindowsTest.kt
+++ b/gateway/core/src/test/kotlin/ClientWindowsTest.kt
@@ -1,11 +1,19 @@
 // NEW (2026-09-05): the per-session client window registry — what a session's status-line post
-// teaches the head about the window that session's process really runs with.
+// teaches the head about the window that session's process really runs with, and (afternoon) the
+// store that carries it across a daemon restart.
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import splice.core.model.ClientWindows
+import java.nio.file.Files
+import java.nio.file.Path
 
 class ClientWindowsTest {
+
+    private fun store(): Path =
+        Files.createTempDirectory("client-windows").resolve("state").resolve("codex-client-windows.json")
 
     @Test
     fun `a recorded session answers with its window and an unknown one with null`() {
@@ -41,5 +49,42 @@ class ClientWindowsTest {
         assertEquals(1L, windows.windowFor("a"))
         assertNull(windows.windowFor("b"))
         assertEquals(3L, windows.windowFor("c"))
+    }
+
+    @Test
+    fun `a recorded window survives a restart through the store file`() {
+        val store = store()
+        ClientWindows(store = store).record("s-persist", 272_000)
+        assertTrue(Files.exists(store), "the registry must be written through, parent dirs included")
+        val reloaded = ClientWindows(store = store)
+        assertEquals(272_000L, reloaded.windowFor("s-persist"))
+        assertNull(reloaded.windowFor("s-other"))
+    }
+
+    @Test
+    fun `an unchanged post does not rewrite the store but a changed window does`() {
+        val store = store()
+        val windows = ClientWindows(store = store)
+        windows.record("s", 272_000)
+        Files.delete(store)
+        windows.record("s", 272_000)
+        assertFalse(Files.exists(store), "the same window again is not a write")
+        windows.record("s", 400_000)
+        assertTrue(Files.exists(store), "a changed window is")
+        assertEquals(400_000L, ClientWindows(store = store).windowFor("s"))
+    }
+
+    @Test
+    fun `a corrupt store is logged by class name and ignored - the registry still learns and re-saves`() {
+        val store = store()
+        Files.createDirectories(store.parent)
+        Files.writeString(store, "{not json")
+        val lines = mutableListOf<String>()
+        val windows = ClientWindows(store = store, log = { lines += it })
+        assertNull(windows.windowFor("s"))
+        // The class name, never the content: kotlinx names the concrete decoding failure.
+        assertTrue(lines.single().contains("ignored (JsonDecodingException)"), lines.toString())
+        windows.record("s", 272_000)
+        assertEquals(272_000L, ClientWindows(store = store).windowFor("s"))
     }
 }

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesProvider.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesProvider.kt
@@ -58,16 +58,17 @@ public abstract class ResponsesProvider(
         ),
     )
 
-    /** Per-turn upstream headers beyond the shared Accept set (grok's x-grok-conv-id). Empty by
-     *  default — a header that depends on the turn/session rides HERE, never on shared state. */
-    protected open fun perTurnHeaders(sessionId: String?): Map<String, String> = emptyMap()
+    /** Per-turn upstream headers beyond the shared Accept set (grok's x-grok-conv-id, codex's
+     *  session/thread routing). Empty by default — a header that depends on the turn/session rides
+     *  HERE, never on shared state. */
+    protected open fun perTurnHeaders(meta: TurnMeta): Map<String, String> = emptyMap()
 
     final override fun buildTurn(body: AnthropicTurnBody, compact: Boolean, sessionId: String?): BuiltTurn {
         val built = parts.builder.build(body.typed, body.raw, parts.turnOptions.build(body, compact, sessionId))
         return BuiltTurn(
             built.req,
             built.meta,
-            perTurnHeaders(sessionId) + parts.turnOptions.liteHeaders(built.meta),
+            perTurnHeaders(built.meta) + parts.turnOptions.liteHeaders(built.meta),
             toolSearch = built.toolSearch,
         )
     }

--- a/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesWsRunner.kt
+++ b/gateway/dialect-openai-responses/src/main/kotlin/splice/dialect/responses/ResponsesWsRunner.kt
@@ -58,7 +58,7 @@ internal class ResponsesWsRunner(
         val request = identity.parseRequest(bodyJson)
         val chain = identity.chainKey(meta)
         if (request == null || chain == null) return null
-        val headers = handshakeHeaders(creds) + turnHeaders
+        val headers = handshakeHeaders(creds) + turnHeaders + handshakeOnlyHeaders(turnHeaders)
         val key = identity.connectionKey(chain, meta, headers)
         // Committed at SEND time, read at TERMINAL time: the frame the chaining layer just built
         // determines what the next turn's prefix must be, and only a clean terminal may commit it.
@@ -101,6 +101,13 @@ internal class ResponsesWsRunner(
         )
     }
 
+    /** codex-rs names its thread a second time on the WS handshake, as `x-client-request-id` — on
+     *  the handshake only, never on an SSE POST, so it is derived here from the provider's per-turn
+     *  `thread-id` (which rides both) rather than emitted beside it. Part of the connection key like
+     *  every other handshake header, and constant for the session like its source. */
+    private fun handshakeOnlyHeaders(turnHeaders: Map<String, String>): Map<String, String> =
+        turnHeaders[HEADER_THREAD_ID]?.let { mapOf(HEADER_CLIENT_REQUEST_ID to it) } ?: emptyMap()
+
     override fun isFailureTerminal(event: JsonObject): Boolean =
         JsonScalars.str(event[FIELD_TYPE]) in ResponsesRoundEnd.FAILED
 
@@ -118,3 +125,5 @@ internal class ResponsesWsRunner(
 }
 
 private const val FIELD_TYPE = "type"
+private const val HEADER_THREAD_ID = "thread-id"
+private const val HEADER_CLIENT_REQUEST_ID = "x-client-request-id"

--- a/gateway/dialect-openai-responses/src/test/kotlin/ResponsesWsRunnerTest.kt
+++ b/gateway/dialect-openai-responses/src/test/kotlin/ResponsesWsRunnerTest.kt
@@ -53,6 +53,9 @@ private class Rig(private val script: (Int) -> List<String>) {
     var rounds = 0
     val sent = mutableListOf<String>()
 
+    /** The headers of every handshake, in connection order (2026-09-05: the WS-only request id). */
+    val handshakes = mutableListOf<Map<String, String>>()
+
     /** Which SOCKETS were aborted, in creation order. kill() calls abort(), so this is how a test
      *  observes "the round's connection was torn down" and, more importantly, WHICH one. */
     val aborted = mutableListOf<Int>()
@@ -69,8 +72,9 @@ private class Rig(private val script: (Int) -> List<String>) {
     private var listener: WebSocket.Listener? = null
 
     @Suppress("UNUSED_PARAMETER")
-    private fun connect(unusedUri: URI, unusedHeaders: Map<String, String>, l: WebSocket.Listener): WebSocket {
+    private fun connect(unusedUri: URI, headers: Map<String, String>, l: WebSocket.Listener): WebSocket {
         listener = l
+        handshakes += headers
         // Its OWN listener, not the shared field: a rig with two live sockets would otherwise feed
         // every frame to whichever connected last.
         val index = sockets++
@@ -103,8 +107,14 @@ private class Rig(private val script: (Int) -> List<String>) {
     suspend fun accept(m: TurnMeta = meta(), body: String = BODY, headers: Map<String, String> = emptyMap()) =
         runner.attempt(body, m, headers, Credentials.Bearer("tok", "acct"))
 
-    suspend fun round(m: TurnMeta = meta(), body: String = BODY): List<JsonObject>? =
-        accept(m, body)?.let { r -> mutableListOf<JsonObject>().also { out -> r.events.collect { out += it } } }
+    suspend fun round(
+        m: TurnMeta = meta(),
+        body: String = BODY,
+        headers: Map<String, String> = emptyMap(),
+    ): List<JsonObject>? =
+        accept(m, body, headers)?.let { r ->
+            mutableListOf<JsonObject>().also { out -> r.events.collect { out += it } }
+        }
 
     fun lastSentChained(): Boolean =
         (responsesRequestJson.parseToJsonElement(sent.last()) as JsonObject)["previous_response_id"] != null
@@ -143,6 +153,21 @@ private const val BODY_ANSWERED =
         """{"type":"function_call_output","call_id":"call_9","output":"file"}]}"""
 
 class ResponsesWsRunnerTest {
+
+    /** codex-rs names its thread a second time on the WS handshake, as the client request id —
+     *  derived from the provider's per-turn `thread-id` at the handshake, so an SSE POST never
+     *  carries it and a turn without a thread id sends none (2026-09-05). */
+    @Test
+    fun `the handshake carries the thread id as x-client-request-id and nothing without one`() = runTest {
+        val rig = Rig { listOf("""{"type":"response.created"}""", completed("r1")) }
+        checkNotNull(rig.round(headers = mapOf("thread-id" to "t-1"))) { "round one" }
+        assertEquals("t-1", rig.handshakes.last()["x-client-request-id"])
+        assertEquals("t-1", rig.handshakes.last()["thread-id"])
+        // A different header set is a different connection: the second handshake carries none.
+        checkNotNull(rig.round(headers = mapOf("x-splice-probe" to "two"))) { "round two" }
+        assertEquals(2, rig.handshakes.size, "a changed per-turn header set opens a new connection")
+        assertFalse(rig.handshakes.last().containsKey("x-client-request-id"), rig.handshakes.last().toString())
+    }
 
     /** The terminal's output is read for the calls it leaves open: a next turn that answers none
      *  of them full-sends (the 2026-09-05 compaction class), one that answers them chains. */

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/ActivityLabel.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/ActivityLabel.kt
@@ -1,0 +1,109 @@
+// NEW: Claude Code's 30-second activity label, answered by the proxy (2026-09-05).
+//
+// Every 30 s (`kxo=30000`, the AgentSummary timer in Claude Code 2.1.257) the client forks the
+// session's transcript and asks the model to "Describe your most recent action in 3-5 words using
+// present tense (-ing)" — the status line's "Reading runAgent.ts". The fork carries the whole
+// conversation and every tool schema, so each label costs a full-context read: on 2026-09-05 it was
+// 2256 of the claudex head's rounds and 294M input tokens at a 48% cache-hit rate (the same
+// sessions' real turns hit 96%), for 8-13 output tokens apiece. The label is a function of the
+// transcript's last tool call, which the proxy already holds, so it is composed HERE and no
+// upstream turn happens (TurnPreparation → Preparation.Local → LocalResponses). The match is the
+// prompt's verbatim opening sentence: a reworded prompt in a later Claude Code rides upstream
+// exactly as before, and nothing else matches it short of a user typing that sentence.
+package splice.gateway.head
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import splice.core.wire.AnthropicRequest
+import splice.core.wire.ContentBlock.TextBlock
+import splice.core.wire.ContentBlock.ToolUseBlock
+
+internal class ActivityLabel {
+
+    /** The label to answer with, or null when the request is not the activity side query. */
+    fun labelFor(request: AnthropicRequest): String? {
+        if (!isSideQuery(request)) return null
+        val lastAssistant = request.messages.lastOrNull { it.role == ROLE_ASSISTANT }
+        val call = lastAssistant?.content?.filterIsInstance<ToolUseBlock>()?.lastOrNull()
+        return when {
+            lastAssistant == null -> NO_TRANSCRIPT_LABEL
+            call == null -> NO_TOOL_LABEL
+            else -> describe(call)
+        }
+    }
+
+    private fun isSideQuery(request: AnthropicRequest): Boolean {
+        val last = request.messages.lastOrNull()?.takeIf { it.role == ROLE_USER } ?: return false
+        val text = last.content.filterIsInstance<TextBlock>().joinToString("\n") { it.text }.trimStart()
+        return text.startsWith(SIDE_QUERY_OPENING)
+    }
+
+    // Present tense, 3-5 words, the file or function — Claude Code's own examples for the prompt.
+    private fun describe(call: ToolUseBlock): String {
+        FIXED_LABELS[call.name]?.let { return it }
+        FILE_TOOLS[call.name]?.let { (verb, key) -> return "$verb ${fileName(call.input, key)}" }
+        return when (call.name) {
+            "Bash" -> "Running ${commandHead(str(call.input, "command"))}"
+            "Grep" -> "Searching for ${clip(str(call.input, "pattern")) ?: "a pattern"}"
+            "Glob" -> "Finding ${clip(str(call.input, "pattern")) ?: "files"}"
+            else -> generic(call.name)
+        }
+    }
+
+    private fun generic(name: String): String =
+        if (name.startsWith(MCP_PREFIX)) "Calling ${name.substringAfterLast("__")}" else "Using $name"
+
+    private fun str(input: JsonObject, key: String): String? =
+        (input[key] as? JsonPrimitive)?.takeIf { it.isString }?.content?.takeIf { it.isNotBlank() }
+
+    private fun fileName(input: JsonObject, key: String): String =
+        clip(str(input, key)?.trimEnd('/')?.substringAfterLast('/')) ?: "a file"
+
+    /** The first real command's program and first argument — "git status", "gradlew test": past the
+     *  `cd`/`export`/assignment prelude, before any `| tail` behind it. */
+    private fun commandHead(command: String?): String {
+        val words = command.orEmpty().split(SEGMENT_SPLIT).asSequence()
+            .map { segment -> segment.trim().split(WHITESPACE).filter { it.isNotEmpty() }.dropWhile { isPrelude(it) } }
+            .firstOrNull { it.isNotEmpty() && it.first() !in SHELL_PRELUDE }
+            .orEmpty()
+            .take(2)
+            .map { it.substringAfterLast('/') }
+            .filter { it.any(Char::isLetterOrDigit) }
+        return clip(words.joinToString(" ")) ?: "a command"
+    }
+
+    private fun isPrelude(token: String): Boolean = token == "sudo" || token == "env" || token.contains('=')
+
+    private fun clip(text: String?): String? =
+        text?.takeIf { it.isNotBlank() }?.let { if (it.length > MAX_ARG_CHARS) it.take(MAX_ARG_CHARS) + "…" else it }
+}
+
+private const val ROLE_USER = "user"
+private const val ROLE_ASSISTANT = "assistant"
+private const val MCP_PREFIX = "mcp__"
+private const val MAX_ARG_CHARS = 32
+private const val SIDE_QUERY_OPENING = "Describe your most recent action in 3-5 words using present tense (-ing)."
+private const val NO_TRANSCRIPT_LABEL = "Reading the request"
+private const val NO_TOOL_LABEL = "Replying to the user"
+private const val FILE_PATH = "file_path"
+private val FILE_TOOLS = mapOf(
+    "Read" to ("Reading" to FILE_PATH),
+    "Edit" to ("Editing" to FILE_PATH),
+    "MultiEdit" to ("Editing" to FILE_PATH),
+    "NotebookEdit" to ("Editing" to "notebook_path"),
+    "Write" to ("Writing" to FILE_PATH),
+)
+private val FIXED_LABELS = mapOf(
+    "Agent" to "Delegating to a subagent",
+    "Task" to "Delegating to a subagent",
+    "WebFetch" to "Searching the web",
+    "WebSearch" to "Searching the web",
+    "TodoWrite" to "Updating the task list",
+    "TaskCreate" to "Updating the task list",
+    "TaskUpdate" to "Updating the task list",
+    "AskUserQuestion" to "Asking the user",
+    "SendMessage" to "Messaging a peer session",
+)
+private val SHELL_PRELUDE = setOf("cd", "pushd", "popd", "export", "set", "source", ".", "echo")
+private val SEGMENT_SPLIT = Regex("&&|\\|\\||[;|\\n]")
+private val WHITESPACE = Regex("\\s+")

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/AnthropicBodyParse.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/AnthropicBodyParse.kt
@@ -13,6 +13,10 @@ import splice.core.util.Cancellables
 internal class AnthropicBodyParse {
     /** Null when the body is not a parseable Anthropic request — a client 400 for both handlers,
      *  never a crash. Cancellation is not caught (runCatchingCancellable rethrows it). */
-    fun parseOrNull(text: String): AnthropicTurnBody? =
-        Cancellables.runCatchingCancellable { AnthropicParse.parseAnthropicBody(text) }.getOrNull()
+    fun parseOrNull(text: String): AnthropicTurnBody? = parse(text).getOrNull()
+
+    /** The failure travels with the rejection, so a client 400 is never silent in the daemon log
+     *  (2026-09-05: a byte-identical retry was 400'd with no line saying why). */
+    fun parse(text: String): Result<AnthropicTurnBody> =
+        Cancellables.runCatchingCancellable { AnthropicParse.parseAnthropicBody(text) }
 }

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/CollectTurn.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/CollectTurn.kt
@@ -24,14 +24,11 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import splice.core.model.ClientWindows
-import splice.core.perf.TurnPerf
 import splice.gateway.usage.QuotaTracker
 import splice.gateway.wire.ClientChannel
 import splice.gateway.wire.CollectingTerminal
 import splice.gateway.wire.ImmediateSseWriter
 import splice.gateway.wire.TurnWiring
-import splice.spi.BuiltTurn
-import splice.spi.InflightGate
 import splice.spi.Provider
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.resume
@@ -49,7 +46,8 @@ internal class CollectTurn(
      *  calls (the Node predecessor served them by collecting the terminal object). Drives the SAME
      *  fold/translator/honesty machinery into a [CollectingTerminal], then writes ONE Anthropic
      *  Messages JSON body — no SSE channel, no liveness pinger. */
-    suspend fun collect(call: ApplicationCall, built: BuiltTurn, slot: InflightGate.Slot, t0: Long, perf: TurnPerf) {
+    suspend fun collect(call: ApplicationCall, inputs: TurnInputs) {
+        val built = inputs.built
         val terminal = CollectingTerminal(
             built.meta.originalModel,
             wiring.usagePayloadBuilder(provider.catalog, built.meta, clientWindows.windowFor(built.meta.sessionId)),
@@ -61,7 +59,7 @@ internal class CollectTurn(
             writeMutex = Mutex(),
             clientGone = AtomicBoolean(false),
         )
-        val drive = driveFactory.assembleDrive(TurnInputs(built, slot, t0, perf), terminal, channel)
+        val drive = driveFactory.assembleDrive(inputs, terminal, channel)
         // collect never commits a 200 before its terminal respondText — a cancelled collect is a
         // native connection abort client-side, and sealing there only wrote an error body nobody
         // reads while polluting localOriginErrors (review 2026-07-22 round 3).

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/CompactionReplay.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/CompactionReplay.kt
@@ -1,0 +1,77 @@
+// NEW: the answers of compactions whose clients gave up, held for their retries (2026-09-05).
+//
+// Claude Code arms a 600 s wall-clock cap on an auto-compaction (`dKt=600000`, `recovery-timeout`,
+// not reset by frames), aborts at it, and retries the SAME request minutes later — on 2026-09-05
+// eight claudex compactions died at 600-602 s and four of the six retries were byte-identical, each
+// abort throwing away a 600 s upstream read. So a compaction's turn outlives its client
+// (TurnStreamer.driveDetachable), its frames are recorded (FrameRecording), and a retry that would
+// send the SAME BYTES upstream is answered from the recording (TurnPreparation → LocalResponses):
+// complete, in one burst, or still in flight, followed to its end. Keyed on session + a hash of the
+// upstream request body, which is what "the same compaction" means on the wire — a retry that
+// differs (a message arrived in between) simply runs upstream as before. Only compactions whose
+// client actually left are kept; a compaction delivered to its client has no retry to serve.
+package splice.gateway.head
+
+import splice.core.util.ElapsedClock
+import splice.core.util.MonoClock
+import splice.gateway.wire.FrameRecording
+import java.security.MessageDigest
+
+internal class CompactionReplay(
+    private val clock: ElapsedClock = ElapsedClock(MonoClock::nowMs),
+    private val ttlMs: Long = DEFAULT_TTL_MS,
+    private val capacity: Int = DEFAULT_CAPACITY,
+) {
+    private data class Entry(val recording: FrameRecording, val startedAtMs: Long)
+
+    private val lock = Any()
+    private val entries = LinkedHashMap<String, Entry>()
+
+    /** Null without a session: a retry cannot be tied to its first attempt. */
+    fun key(sessionId: String?, upstreamBody: String): String? {
+        val session = sessionId?.takeIf { it.isNotBlank() } ?: return null
+        return "$session:${sha256Hex(upstreamBody)}"
+    }
+
+    /** A compaction's recording, from its first frame: a retry may attach while it is in flight. */
+    fun begin(key: String, recording: FrameRecording) {
+        synchronized(lock) {
+            sweep()
+            entries[key] = Entry(recording, clock())
+        }
+    }
+
+    /** The drive ended. [keep] is the caller's verdict — the client was gone AND the terminal
+     *  ended cleanly (TurnTerminal.endedCleanly); anything else would replay a truncated or failed
+     *  stream to the retry, so it is dropped. A recording a newer begin() replaced is left alone. */
+    fun finish(key: String, recording: FrameRecording, keep: Boolean) {
+        synchronized(lock) {
+            val superseded = entries[key]?.recording !== recording
+            if (!superseded && !keep) entries.remove(key)
+        }
+    }
+
+    fun lookup(key: String): FrameRecording? = synchronized(lock) {
+        sweep()
+        entries[key]?.recording
+    }
+
+    /** A delivered replay has served its purpose; a second identical request runs upstream. */
+    fun consumed(key: String) {
+        synchronized(lock) { entries.remove(key) }
+    }
+
+    private fun sweep() {
+        val now = clock()
+        entries.entries.removeIf { now - it.value.startedAtMs > ttlMs }
+        while (entries.size > capacity) entries.remove(entries.keys.first())
+    }
+
+    private fun sha256Hex(text: String): String =
+        MessageDigest.getInstance("SHA-256")
+            .digest(text.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+}
+
+private const val DEFAULT_TTL_MS = 2 * 60 * 60 * 1000L
+private const val DEFAULT_CAPACITY = 32

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/CompactionReplay.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/CompactionReplay.kt
@@ -61,10 +61,17 @@ internal class CompactionReplay(
         synchronized(lock) { entries.remove(key) }
     }
 
+    // Past capacity, a settled recording goes before one still in flight: begin() inserts at the
+    // START of a compaction, so insertion order alone would evict the oldest-begun entry while its
+    // drive is still running and its retry has not arrived yet (review of PR 137). Only when every
+    // entry is in flight does the oldest go.
     private fun sweep() {
         val now = clock()
         entries.entries.removeIf { now - it.value.startedAtMs > ttlMs }
-        while (entries.size > capacity) entries.remove(entries.keys.first())
+        while (entries.size > capacity) {
+            val victim = entries.entries.firstOrNull { it.value.recording.isComplete }?.key ?: entries.keys.first()
+            entries.remove(victim)
+        }
     }
 
     private fun sha256Hex(text: String): String =

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/HeadAdmission.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/HeadAdmission.kt
@@ -29,34 +29,54 @@ internal class HeadAdmission(
         val slot = admission.acquireSlotOrRespond(call) ?: return
         telemetry.markAdmitted(perf)
         // A detached compaction takes the slot with it (TurnStreamer.driveDetachable): the drive
-        // releases it when the upstream turn ends, not this call when its client has gone.
-        var handedOff: AtomicBoolean? = null
+        // releases it when the upstream turn ends, not this call when its client has gone. The flag
+        // is this call's from the start, never a return value: the drive's cancelled-call path
+        // THROWS out of serve (review of PR 137), and a finally must not read the flag off a call
+        // that never returned.
+        val admitted = Admitted(slot, t0, perf)
 
         try {
             val prepared = admission.materializeOrRespond(call) { preparation.prepareTurn(call, perf) } ?: return
-            handedOff = serve(call, prepared, slot, t0, perf)
+            serve(call, prepared, admitted)
         } finally {
-            withContext(NonCancellable) { if (handedOff?.get() != true) slot.release() }
+            withContext(NonCancellable) { if (!admitted.handedOff.get()) admitted.slot.release() }
         }
     }
 
-    /** Returns the drive's slot-handoff flag for a driven turn; null for the answers that need none. */
-    private suspend fun serve(
-        call: ApplicationCall,
-        prepared: Preparation,
-        slot: InflightGate.Slot,
-        t0: Long,
-        perf: TurnPerf,
-    ): AtomicBoolean? = when (prepared) {
-        is Preparation.Rejected -> null.also { responses.respondInvalidRequest(call, prepared.message) }
-        is Preparation.Local -> null.also { driver.answerLocally(call, prepared) }
-        is Preparation.Replay -> null.also { driver.replay(call, prepared) }
-        is Preparation.Ready -> {
-            val inputs = TurnInputs(prepared.built, slot, t0, perf)
-            // stream:true → SSE (the interactive path); stream:false → one buffered JSON body
-            // (Claude Code's internal non-stream calls, served by collecting the same machinery).
-            if (prepared.stream) driver.stream(call, inputs) else driver.collect(call, inputs)
-            inputs.slotHandedOff
+    /** What one admitted call holds: its gate slot, its start, its perf row, and the flag a
+     *  detached drive flips when it takes the slot with it. */
+    private data class Admitted(
+        val slot: InflightGate.Slot,
+        val t0: Long,
+        val perf: TurnPerf,
+        val handedOff: AtomicBoolean = AtomicBoolean(false),
+    )
+
+    private suspend fun serve(call: ApplicationCall, prepared: Preparation, admitted: Admitted) {
+        when (prepared) {
+            is Preparation.Rejected -> responses.respondInvalidRequest(call, prepared.message)
+            is Preparation.Local -> driver.answerLocally(call, prepared)
+            is Preparation.Replay -> {
+                // A retry following a compaction still in flight is not an admission: the drive it
+                // follows holds a slot already (TurnStreamer.driveDetachable), so this one goes
+                // back before the wait — else one compaction counts twice against the gate for
+                // however long the upstream turn still runs (review of PR 137). Release is
+                // idempotent (InflightGate.Slot), so the finally above stays a no-op for it.
+                if (!prepared.recording.isComplete) admitted.slot.release()
+                driver.replay(call, prepared)
+            }
+            is Preparation.Ready -> {
+                val inputs = TurnInputs(
+                    prepared.built,
+                    admitted.slot,
+                    admitted.t0,
+                    admitted.perf,
+                    slotHandedOff = admitted.handedOff,
+                )
+                // stream:true → SSE (the interactive path); stream:false → one buffered JSON body
+                // (Claude Code's internal non-stream calls, served by collecting the same machinery).
+                if (prepared.stream) driver.stream(call, inputs) else driver.collect(call, inputs)
+            }
         }
     }
 }

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/HeadAdmission.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/HeadAdmission.kt
@@ -9,6 +9,9 @@ package splice.gateway.head
 import io.ktor.server.application.ApplicationCall
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
+import splice.core.perf.TurnPerf
+import splice.spi.InflightGate
+import java.util.concurrent.atomic.AtomicBoolean
 
 internal class HeadAdmission(
     private val deps: HeadDeps,
@@ -25,23 +28,35 @@ internal class HeadAdmission(
         val t0 = deps.clock()
         val slot = admission.acquireSlotOrRespond(call) ?: return
         telemetry.markAdmitted(perf)
+        // A detached compaction takes the slot with it (TurnStreamer.driveDetachable): the drive
+        // releases it when the upstream turn ends, not this call when its client has gone.
+        var handedOff: AtomicBoolean? = null
 
         try {
             val prepared = admission.materializeOrRespond(call) { preparation.prepareTurn(call, perf) } ?: return
-            when (prepared) {
-                is Preparation.Rejected -> responses.respondInvalidRequest(call, prepared.message)
-                is Preparation.Ready -> {
-                    // stream:true → SSE (the interactive path); stream:false → one buffered JSON body
-                    // (Claude Code's internal non-stream calls, served by collecting the same machinery).
-                    if (prepared.stream) {
-                        driver.stream(call, prepared.built, slot, t0, perf)
-                    } else {
-                        driver.collect(call, prepared.built, slot, t0, perf)
-                    }
-                }
-            }
+            handedOff = serve(call, prepared, slot, t0, perf)
         } finally {
-            withContext(NonCancellable) { slot.release() }
+            withContext(NonCancellable) { if (handedOff?.get() != true) slot.release() }
+        }
+    }
+
+    /** Returns the drive's slot-handoff flag for a driven turn; null for the answers that need none. */
+    private suspend fun serve(
+        call: ApplicationCall,
+        prepared: Preparation,
+        slot: InflightGate.Slot,
+        t0: Long,
+        perf: TurnPerf,
+    ): AtomicBoolean? = when (prepared) {
+        is Preparation.Rejected -> null.also { responses.respondInvalidRequest(call, prepared.message) }
+        is Preparation.Local -> null.also { driver.answerLocally(call, prepared) }
+        is Preparation.Replay -> null.also { driver.replay(call, prepared) }
+        is Preparation.Ready -> {
+            val inputs = TurnInputs(prepared.built, slot, t0, perf)
+            // stream:true → SSE (the interactive path); stream:false → one buffered JSON body
+            // (Claude Code's internal non-stream calls, served by collecting the same machinery).
+            if (prepared.stream) driver.stream(call, inputs) else driver.collect(call, inputs)
+            inputs.slotHandedOff
         }
     }
 }

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/HeadServer.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/HeadServer.kt
@@ -36,7 +36,8 @@ public class HeadServer(
     private val gate get() = deps.gate
     private val log get() = deps.log
 
-    private val driver = TurnDriver(provider, deps)
+    private val compactionReplay = CompactionReplay()
+    private val driver = TurnDriver(provider, deps, compactionReplay)
     private val window = AdmissionWindow()
     private val responses = AdmissionResponses()
     private val clientAuth = ClientAuth(deps, responses)
@@ -49,7 +50,7 @@ public class HeadServer(
         clientAuth,
         admissionGate,
         AdmissionTelemetry(deps.gate, deps.clock),
-        TurnPreparation(provider, deps, bodyReader, bodyParse, clientAuth),
+        TurnPreparation(provider, deps, bodyReader, bodyParse, clientAuth, compactionReplay),
         responses,
         driver,
     )
@@ -109,6 +110,9 @@ public class HeadServer(
             log("[${provider.key}] stop: draining timed out with inflight=$inflight — forcing engine stop\n")
         }
         engine.stop()
+        // A detached compaction (TurnStreamer) has no head to record for once the engine is down;
+        // the driver is reused by startLocked, so this ends compactions, never their scope.
+        driver.stopDetached()
         deps.usageStore.flushNow()
     }
 }

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/LocalResponses.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/LocalResponses.kt
@@ -11,8 +11,10 @@ import io.ktor.server.application.ApplicationCall
 import io.ktor.server.response.header
 import io.ktor.server.response.respondText
 import io.ktor.server.response.respondTextWriter
+import splice.core.turn.ErrorType
 import splice.core.turn.Usage
 import splice.gateway.wire.CollectingTerminal
+import splice.gateway.wire.FrameWrite
 import splice.gateway.wire.SseEmitterFactory
 import splice.gateway.wire.TurnTerminal
 import splice.gateway.wire.TurnWiring
@@ -59,21 +61,54 @@ internal class LocalResponses(
 
     /** Every recorded frame, then every one still arriving while the compaction is in flight. A
      *  client that hangs up on the replay too leaves the recording in place for the next retry;
-     *  a delivered replay consumes it. */
+     *  a delivered replay consumes it. A recording that ends WITHOUT a clean terminal (the drive
+     *  was cancelled: its own client long gone, the seal abandons and writes nothing) is ended
+     *  here with the honest error frame the seal gives an attached client, so this client retries
+     *  as well — and finds the entry gone (CompactionReplay.finish), so that attempt runs upstream. */
     suspend fun replay(call: ApplicationCall, replayed: Preparation.Replay) {
         quotaHeaders(call)
         var frames = 0
+        var whole = false
         call.respondTextWriter(ContentType.Text.EventStream) {
-            replayed.recording.follow { frame ->
+            whole = replayed.recording.follow { frame ->
                 write(frame)
                 flush()
                 frames += 1
+            }
+            if (!whole) {
+                sealFollower(replayed) { frame ->
+                    write(frame)
+                    flush()
+                }
             }
         }
         replay.consumed(replayed.key)
         val who = replayed.sessionId?.let { "session ${it.take(TAG_CHARS)}" } ?: "no session"
         deps.log(
-            "[${provider.key}] compaction answer replayed ($who, $frames frames; the retry cost no upstream turn)\n",
+            if (whole) {
+                "[${provider.key}] compaction answer replayed ($who, $frames frames; the retry cost no upstream turn)\n"
+            } else {
+                "[${provider.key}] compaction retry followed a compaction that did not finish ($who, $frames frames; " +
+                    "sealed with an error, the next retry runs upstream)\n"
+            },
+        )
+    }
+
+    // The one failure ending the wire knows (SseEmitter.emitError, L3): an overloaded error, which
+    // Claude Code retries — the same frame CancellationSeal writes for an attached client.
+    private suspend fun sealFollower(replayed: Preparation.Replay, write: FrameWrite) {
+        val emitter = emitters.create(
+            write = write,
+            model = replayed.model,
+            usagePayload = wiring.usagePayloadBuilderFor(
+                provider.catalog,
+                replayed.model,
+                deps.clientWindows.windowFor(replayed.sessionId),
+            ),
+        )
+        emitter.emitError(
+            ErrorType.OVERLOADED,
+            "${provider.key}: the compaction this retry followed did not finish — retry",
         )
     }
 

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/LocalResponses.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/LocalResponses.kt
@@ -1,0 +1,94 @@
+// NEW: the two response shapes the proxy serves WITHOUT an upstream turn (2026-09-05): the activity
+// label (ActivityLabel — composed here) and a detached compaction's recorded answer (CompactionReplay
+// — replayed here). Both hold the admission slot for their own duration only, ride the same quota
+// headers and usage payload a driven turn does, and write through Ktor exactly as TurnStreamer does,
+// so Claude Code cannot tell them from a model's answer — which is the point.
+package splice.gateway.head
+
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.response.header
+import io.ktor.server.response.respondText
+import io.ktor.server.response.respondTextWriter
+import splice.core.turn.Usage
+import splice.gateway.wire.CollectingTerminal
+import splice.gateway.wire.SseEmitterFactory
+import splice.gateway.wire.TurnTerminal
+import splice.gateway.wire.TurnWiring
+import splice.spi.Provider
+
+internal class LocalResponses(
+    private val provider: Provider,
+    private val deps: HeadDeps,
+    private val replay: CompactionReplay,
+) {
+    private val emitters = SseEmitterFactory()
+    private val wiring = TurnWiring()
+
+    /** One text block, an end_turn terminal, zero usage: the side query is not a context read. */
+    suspend fun answer(call: ApplicationCall, local: Preparation.Local) {
+        val usage = wiring.usagePayloadBuilderFor(
+            provider.catalog,
+            local.model,
+            deps.clientWindows.windowFor(local.sessionId),
+        )
+        quotaHeaders(call)
+        if (local.stream) {
+            call.respondTextWriter(ContentType.Text.EventStream) {
+                val emitter = emitters.create(
+                    write = { frame ->
+                        write(frame)
+                        flush()
+                    },
+                    model = local.model,
+                    usagePayload = usage,
+                )
+                emitText(emitter, local.text)
+            }
+        } else {
+            val terminal = CollectingTerminal(local.model, usage)
+            emitText(terminal, local.text)
+            call.respondText(
+                terminal.responseBody().toString(),
+                ContentType.Application.Json,
+                HttpStatusCode.fromValue(terminal.httpStatus()),
+            )
+        }
+    }
+
+    /** Every recorded frame, then every one still arriving while the compaction is in flight. A
+     *  client that hangs up on the replay too leaves the recording in place for the next retry;
+     *  a delivered replay consumes it. */
+    suspend fun replay(call: ApplicationCall, replayed: Preparation.Replay) {
+        quotaHeaders(call)
+        var frames = 0
+        call.respondTextWriter(ContentType.Text.EventStream) {
+            replayed.recording.follow { frame ->
+                write(frame)
+                flush()
+                frames += 1
+            }
+        }
+        replay.consumed(replayed.key)
+        val who = replayed.sessionId?.let { "session ${it.take(TAG_CHARS)}" } ?: "no session"
+        deps.log(
+            "[${provider.key}] compaction answer replayed ($who, $frames frames; the retry cost no upstream turn)\n",
+        )
+    }
+
+    // The head's quota windows ride every response (TurnStreamer / CollectTurn do the same).
+    private fun quotaHeaders(call: ApplicationCall) {
+        deps.quota?.clientHeaders()?.forEach { (name, value) -> call.response.header(name, value) }
+    }
+
+    private suspend fun emitText(terminal: TurnTerminal, text: String) {
+        terminal.ensureStarted()
+        val block = terminal.openText()
+        terminal.textDelta(block, text)
+        terminal.closeAll()
+        terminal.emitTerminal(hasToolUse = false, incomplete = false, usage = Usage())
+    }
+}
+
+private const val TAG_CHARS = 8

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnDriver.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnDriver.kt
@@ -19,9 +19,6 @@ package splice.gateway.head
 import io.ktor.server.application.ApplicationCall
 import kotlinx.coroutines.CancellationException
 import splice.core.perf.PerfKeys
-import splice.core.perf.TurnPerf
-import splice.spi.BuiltTurn
-import splice.spi.InflightGate
 import splice.spi.Provider
 import splice.spi.RetryNotice
 
@@ -29,6 +26,7 @@ import splice.spi.RetryNotice
 internal class TurnDriver(
     private val provider: Provider,
     private val deps: HeadDeps,
+    private val compactionReplay: CompactionReplay = CompactionReplay(),
 ) {
     private val log get() = deps.log
 
@@ -80,7 +78,8 @@ internal class TurnDriver(
         deps,
         TurnRoundRun(provider, log, sseRoundDriver, turnFinish),
     )
-    private val streamer = TurnStreamer(provider, deps, driveFactory, this)
+    private val streamer = TurnStreamer(provider, deps, driveFactory, this, compactionReplay)
+    private val localResponses = LocalResponses(provider, deps, compactionReplay)
 
     // Pre-priced HD-24 contingency: collect() moved to its own file (CollectTurn.kt) because the
     // un-split TurnDriver.kt measured ratio 1.83, just over the 1.8 gate.
@@ -91,9 +90,15 @@ internal class TurnDriver(
     internal fun healthCounters(): HeadHealthCounts = health.snapshot()
 
     /** Open the SSE writer, wire the per-turn collaborators, run the single turn. */
-    suspend fun stream(call: ApplicationCall, built: BuiltTurn, slot: InflightGate.Slot, t0: Long, perf: TurnPerf) {
-        streamer.stream(call, TurnInputs(built, slot, t0, perf))
+    suspend fun stream(call: ApplicationCall, inputs: TurnInputs) {
+        streamer.stream(call, inputs)
     }
+
+    /** Claude Code's activity side query, answered by the proxy (ActivityLabel): no upstream turn. */
+    suspend fun answerLocally(call: ApplicationCall, local: Preparation.Local) = localResponses.answer(call, local)
+
+    /** A compaction retry served from the detached first attempt's recording (CompactionReplay). */
+    suspend fun replay(call: ApplicationCall, replayed: Preparation.Replay) = localResponses.replay(call, replayed)
 
     /** Drive one turn, emit classified failures, and — if a cancellation lands (head stop,
      *  write-timeout, parent cancel) — seal the terminal honestly before rethrowing (see
@@ -128,10 +133,13 @@ internal class TurnDriver(
 
     /** Non-stream sibling of [stream]: Claude Code sends stream:false on some internal calls (the
      *  Node predecessor served them by collecting the terminal object). See [CollectTurn]. */
-    suspend fun collect(call: ApplicationCall, built: BuiltTurn, slot: InflightGate.Slot, t0: Long, perf: TurnPerf) =
-        collectTurn.collect(call, built, slot, t0, perf)
+    suspend fun collect(call: ApplicationCall, inputs: TurnInputs) = collectTurn.collect(call, inputs)
 
     /** Head restart = fresh diagnostic baseline (the HeadHealth doc's promised behavior; the
      *  counters lived through control-plane restarts before — review 2026-07-19). */
     internal fun resetHealth() = health.reset()
+
+    /** Head stop: end the detached compactions this head still drives; the scope stays usable for
+     *  the restart (TurnStreamer.stopDetached). */
+    internal fun stopDetached() = streamer.stopDetached()
 }

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnInputs.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnInputs.kt
@@ -6,6 +6,7 @@ package splice.gateway.head
 import splice.core.perf.TurnPerf
 import splice.spi.BuiltTurn
 import splice.spi.InflightGate
+import java.util.concurrent.atomic.AtomicBoolean
 
 /** Admission-time inputs threaded into a drive — grouped so the drive assembler stays one
  *  cohesive argument across the stream and collect entries. */
@@ -14,4 +15,7 @@ internal data class TurnInputs(
     val slot: InflightGate.Slot,
     val t0: Long,
     val perf: TurnPerf,
+    /** Set by TurnStreamer when a detached compaction takes [slot] with it: the drive releases the
+     *  slot when the upstream turn ends, and HeadAdmission's finally must then leave it alone. */
+    val slotHandedOff: AtomicBoolean = AtomicBoolean(false),
 )

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnPreparation.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnPreparation.kt
@@ -28,8 +28,15 @@ internal sealed class Preparation {
     /** Answered by the proxy itself: the activity side query (ActivityLabel). No upstream turn. */
     data class Local(val text: String, val model: String, val sessionId: String?, val stream: Boolean) : Preparation()
 
-    /** A byte-identical retry of a compaction whose first client gave up: served from its recording. */
-    data class Replay(val recording: FrameRecording, val key: String, val sessionId: String?) : Preparation()
+    /** A byte-identical retry of a compaction whose first client gave up: served from its recording.
+     *  [model] is the row id the retry asked for, for the honest error frame a follower is sealed
+     *  with when the recording ends without a clean terminal. */
+    data class Replay(
+        val recording: FrameRecording,
+        val key: String,
+        val sessionId: String?,
+        val model: String,
+    ) : Preparation()
 }
 
 internal class TurnPreparation(
@@ -100,8 +107,20 @@ internal class TurnPreparation(
         perf.mark(PerfKeys.BUILD)
         // A compaction retry whose bytes match a compaction that outlived its first client is
         // answered from that recording (TurnStreamer records it, LocalResponses replays it).
-        val replayed = if (built.meta.compact && parsed.typed.stream) replayFor(built) else null
+        val replayed = if (built.meta.compact) compactionReplay(built, parsed.typed.stream) else null
         return replayed ?: Preparation.Ready(built, parsed.typed.stream)
+    }
+
+    /** Stream-only, both halves: the detached drive lives in TurnStreamer.stream() and CollectTurn
+     *  has no recording, so a non-stream compaction is served attached, as every turn was before
+     *  2026-09-05. Claude Code's auto-compaction streams; the log line is the tell if that changes. */
+    private fun compactionReplay(built: BuiltTurn, stream: Boolean): Preparation.Replay? {
+        if (stream) return replayFor(built)
+        deps.log(
+            "[${provider.key}] non-stream compaction (${who(built.meta.sessionId)}served attached: " +
+                "no detached drive, no replay)\n",
+        )
+        return null
     }
 
     private fun replayFor(built: BuiltTurn): Preparation.Replay? {
@@ -112,7 +131,7 @@ internal class TurnPreparation(
             "[${provider.key}] compaction retry matches a detached compaction ($state, " +
                 "${who(built.meta.sessionId)}replaying its answer, no upstream turn)\n",
         )
-        return Preparation.Replay(recording, key, built.meta.sessionId)
+        return Preparation.Replay(recording, key, built.meta.sessionId, built.meta.originalModel)
     }
 
     // The class, never the content (safe-failure-render): the body is the user's transcript. The

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnPreparation.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnPreparation.kt
@@ -4,18 +4,32 @@
 // forwarded-header merge whose operand order (`prepared.extraHeaders + forwardedClientHeaders`)
 // is what makes the CALLER's value replace the provider's configured default. Split out (HD-24);
 // Preparation WIDENED private nested -> internal, because HeadAdmission dispatches on it.
+//
+// TWO MORE OUTCOMES (2026-09-05), both "this head answers without an upstream turn": Local — the
+// activity side query Claude Code sends every 30 s (ActivityLabel), and Replay — a compaction retry
+// whose bytes match a compaction that outlived its first client (CompactionReplay).
 package splice.gateway.head
 
+import io.ktor.http.HttpHeaders
 import io.ktor.server.application.ApplicationCall
+import splice.core.parse.AnthropicTurnBody
 import splice.core.perf.PerfKeys
 import splice.core.perf.TurnPerf
+import splice.core.wire.AnthropicRequest
 import splice.gateway.compact.CompactClassifier
+import splice.gateway.wire.FrameRecording
 import splice.spi.BuiltTurn
 import splice.spi.Provider
 
 internal sealed class Preparation {
     data class Ready(val built: BuiltTurn, val stream: Boolean) : Preparation()
     data class Rejected(val message: String) : Preparation()
+
+    /** Answered by the proxy itself: the activity side query (ActivityLabel). No upstream turn. */
+    data class Local(val text: String, val model: String, val sessionId: String?, val stream: Boolean) : Preparation()
+
+    /** A byte-identical retry of a compaction whose first client gave up: served from its recording. */
+    data class Replay(val recording: FrameRecording, val key: String, val sessionId: String?) : Preparation()
 }
 
 internal class TurnPreparation(
@@ -24,25 +38,48 @@ internal class TurnPreparation(
     private val bodyReader: RequestBodyReader,
     private val bodyParse: AnthropicBodyParse,
     private val clientAuth: ClientAuth,
+    private val replay: CompactionReplay = CompactionReplay(),
 ) {
     private val compactClassifier = CompactClassifier()
+    private val activityLabel = ActivityLabel()
 
     suspend fun prepareTurn(call: ApplicationCall, perf: TurnPerf): Preparation {
         val body = bodyReader.receiveBodyBounded(call, deps.maxRequestBytes)
         perf.mark(PerfKeys.RECV)
         perf.setCount(PerfKeys.REQ_BYTES, body.bytes.toLong())
-        val parsed = bodyParse.parseOrNull(body.text)
-            ?: return Preparation.Rejected("invalid request body")
+        val parsing = bodyParse.parse(body.text)
+        val parsed = parsing.getOrNull() ?: return rejectedBody(call, body, parsing.exceptionOrNull())
         val unwrappedModel = provider.catalog.unwrap(parsed.typed.model)
         if (!provider.catalog.contains(parsed.typed.model)) {
             return Preparation.Rejected("this head proxies its own models only; got $unwrappedModel")
         }
+        val sessionId = call.request.headers[SESSION_HEADER]
+        val label = activityLabel.labelFor(parsed.typed)
+        return if (label != null) local(label, parsed.typed, sessionId, perf) else build(call, parsed, sessionId, perf)
+    }
 
+    // The activity side query never reaches a model: see ActivityLabel for the measurement.
+    private fun local(
+        label: String,
+        request: AnthropicRequest,
+        sessionId: String?,
+        perf: TurnPerf,
+    ): Preparation.Local {
+        perf.mark(PerfKeys.PARSE)
+        deps.log("[${provider.key}] activity label answered locally: \"$label\" (${who(sessionId)}no upstream turn)\n")
+        return Preparation.Local(label, request.model, sessionId, request.stream)
+    }
+
+    private fun build(
+        call: ApplicationCall,
+        parsed: AnthropicTurnBody,
+        sessionId: String?,
+        perf: TurnPerf,
+    ): Preparation {
         // One scan of system + last-user text: classification and shadow instrumentation share it.
         val compactProbe = compactClassifier.classifyCompact(parsed.typed)
         deps.shadow.record(parsed.typed, compactProbe)
         perf.mark(PerfKeys.PARSE)
-        val sessionId = call.request.headers["x-claude-code-session-id"]
         val fromProvider = provider.buildTurn(parsed, compactProbe.compact, sessionId)
         // Every dialect's turn names its client session (2026-09-02): only the responses dialect
         // kept the id on its meta, so a chat or passthrough head's abort could not be tied to a
@@ -61,6 +98,37 @@ internal class TurnPreparation(
             prepared
         }
         perf.mark(PerfKeys.BUILD)
-        return Preparation.Ready(built, parsed.typed.stream)
+        // A compaction retry whose bytes match a compaction that outlived its first client is
+        // answered from that recording (TurnStreamer records it, LocalResponses replays it).
+        val replayed = if (built.meta.compact && parsed.typed.stream) replayFor(built) else null
+        return replayed ?: Preparation.Ready(built, parsed.typed.stream)
     }
+
+    private fun replayFor(built: BuiltTurn): Preparation.Replay? {
+        val key = replay.key(built.meta.sessionId, built.requestBody.toString()) ?: return null
+        val recording = replay.lookup(key) ?: return null
+        val state = if (recording.isComplete) "finished" else "still running"
+        deps.log(
+            "[${provider.key}] compaction retry matches a detached compaction ($state, " +
+                "${who(built.meta.sessionId)}replaying its answer, no upstream turn)\n",
+        )
+        return Preparation.Replay(recording, key, built.meta.sessionId)
+    }
+
+    // The class, never the content (safe-failure-render): the body is the user's transcript. The
+    // declared length beside the read one tells a truncated read from a malformed body.
+    private fun rejectedBody(call: ApplicationCall, body: ReceivedBody, cause: Throwable?): Preparation.Rejected {
+        val declared = call.request.headers[HttpHeaders.ContentLength] ?: "no content-length"
+        val why = cause?.let { it::class.simpleName } ?: "no exception"
+        deps.log(
+            "[${provider.key}] request rejected: invalid request body " +
+                "(${body.bytes} bytes read, $declared declared, $why)\n",
+        )
+        return Preparation.Rejected("invalid request body")
+    }
+
+    private fun who(sessionId: String?): String = sessionId?.let { "session ${it.take(TAG_CHARS)}, " } ?: ""
 }
+
+private const val SESSION_HEADER = "x-claude-code-session-id"
+private const val TAG_CHARS = 8

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnStreamer.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnStreamer.kt
@@ -128,12 +128,14 @@ internal class TurnStreamer(
             try {
                 driver.driveSealingCancellation(drive)
             } finally {
-                recording.complete()
+                // The terminal's own verdict, not a frame literal (L3): an error frame or an
+                // abandon is not an answer a retry may be handed. It goes into the recording too,
+                // for a retry already following it (LocalResponses.replay seals on a false).
+                val whole = drive.emitter.endedCleanly
+                recording.complete(whole)
                 drive.channel.flushQuietly()
                 val wasDetached = drive.channel.detached.get()
-                // The terminal's own verdict, not a frame literal (L3): an error frame or an
-                // abandon is not an answer a retry may be handed.
-                val kept = wasDetached && drive.emitter.endedCleanly
+                val kept = wasDetached && whole
                 replay.finish(key, recording, keep = kept)
                 inputs.slot.release()
                 if (wasDetached) deps.log(finishLine(drive, recording, kept))

--- a/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnStreamer.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/head/TurnStreamer.kt
@@ -1,18 +1,43 @@
 // NEW: the SSE writer open + per-turn channel/emitter assembly.
 // Split from TurnDriver (concentration, 2026-08-19) so neither file is
 // billed for the other's subsystems. Same-package.
+//
+// A COMPACTION OUTLIVES ITS CLIENT (2026-09-05): Claude Code aborts an auto-compaction at 600 s of
+// wall clock and retries the same bytes minutes later, and every abort used to cancel a 600 s
+// upstream read. A compact stream turn is therefore driven on a scope the call's cancellation
+// cannot reach, with a recording channel: a lost client detaches the channel and the turn runs on;
+// its recorded answer serves the retry (CompactionReplay, LocalResponses). The admission slot goes
+// with the drive and comes back when the upstream turn ends. Ordinary turns are untouched.
+//
+// The detached scope OUTLIVES A HEAD RESTART: HeadServer stops and starts on the same driver, so a
+// stop ends the compactions still driving (cancelChildren) and never the scope — a cancelled scope
+// turned the first compaction after a restart into an empty 200 with its slot handed off to
+// nobody (review 2026-09-05, splice-astra). A scope that cannot launch any more (the daemon's own,
+// at shutdown) is checked before the hand-off, and the launch is ATOMIC so its finally settles
+// the slot and the recording even when the cancellation lands between the check and the start.
 package splice.gateway.head
 
 import io.ktor.http.ContentType
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.response.header
 import io.ktor.server.response.respondTextWriter
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import splice.gateway.wire.ClientChannel
+import splice.gateway.wire.FrameRecording
 import splice.gateway.wire.ImmediateSseWriter
 import splice.gateway.wire.SseEmitterFactory
 import splice.gateway.wire.TurnWiring
+import splice.spi.LifecycleScope
+import splice.spi.ProcessDispatchers
 import splice.spi.Provider
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -21,14 +46,31 @@ internal class TurnStreamer(
     private val deps: HeadDeps,
     private val driveFactory: TurnDriveFactory,
     private val driver: TurnDriver,
+    private val replay: CompactionReplay,
+    /** Where a detached compaction runs: a NAMED owner (LifecycleScope: a supervisor, so one failing
+     *  compaction never cancels a sibling) with no parent, so the call's cancellation cannot reach
+     *  it, on the background lane of the runtime seam (HD-19). Injectable for the same reason the
+     *  auth providers' prefetch scope is: a test can drain it before teardown. */
+    private val detachedScope: CoroutineScope = LifecycleScope(ProcessDispatchers().background()),
 ) {
     private val emitters = SseEmitterFactory()
     private val wiring = TurnWiring()
+
+    // The drive handles every turn failure itself; anything that still escapes a detached
+    // compaction is a bug, logged by class (safe-failure-render) rather than lost to stderr.
+    private val detachedContext = CoroutineName("compaction-detached") +
+        CoroutineExceptionHandler { _, e ->
+            deps.log("[${provider.key}] detached compaction crashed (${e::class.simpleName})\n")
+        }
 
     /** Open the SSE writer, wire the per-turn collaborators, run the single turn. */
     suspend fun stream(call: ApplicationCall, inputs: TurnInputs) {
         val built = inputs.built
         val perf = inputs.perf
+        val replayKey = if (built.meta.compact) replay.key(built.meta.sessionId, built.requestBody.toString()) else null
+        // No recording without a scope to detach onto: the compaction then runs attached, as every
+        // turn did before 2026-09-05, instead of being handed to a launch that never starts.
+        val recording = if (replayKey != null && detachedScope.isActive) FrameRecording() else null
         // The head's quota windows ride every response as the headers Claude Code reads into its
         // rate_limits (the 5h/7d bars): the client sees the head's real plan usage, proxy or not.
         deps.quota?.clientHeaders()?.forEach { (name, value) -> call.response.header(name, value) }
@@ -39,6 +81,7 @@ internal class TurnStreamer(
                 coalesced = ImmediateSseWriter(writeRaw = { frame -> write(frame) }, flushRaw = { flush() }),
                 writeMutex = Mutex(),
                 clientGone = AtomicBoolean(false),
+                recording = recording,
             )
             val emitter = emitters.create(
                 write = { frame ->
@@ -52,18 +95,79 @@ internal class TurnStreamer(
                 ),
             )
             val drive = driveFactory.assembleDrive(inputs, emitter, channel)
+            if (replayKey == null || recording == null) {
+                try {
+                    // The 200 + SSE headers are committed once respondTextWriter opens, so any failure
+                    // must become an honest `event: error` frame — NOT escape and leave the client an
+                    // empty/truncated 200 (the "empty or malformed response (HTTP 200)" class).
+                    driver.driveSealingCancellation(drive)
+                } finally {
+                    // Terminal frames force-flush already; this covers abandon / exception paths.
+                    // DR-93 (redo): quiet by contract — see ClientChannel.flushQuietly. A raw
+                    // coalesced.flush() here is walled off (kt-turn-finally-flush-quietly): its
+                    // dead-socket throw would replace the primary outcome or cancellation.
+                    channel.flushQuietly()
+                }
+            } else {
+                driveDetachable(drive, inputs, replayKey, recording)
+            }
+        }
+    }
+
+    /** Runs the drive on [detachedScope] and waits for it. Ktor cancelling THIS call (the client hung
+     *  up mid-lull, no write having failed) detaches the channel and returns; the drive runs on.
+     *  The slot goes with the drive (TurnInputs.slotHandedOff): released when the upstream turn
+     *  ends, whichever way, not when this call does. */
+    private suspend fun driveDetachable(drive: TurnDrive, inputs: TurnInputs, key: String, recording: FrameRecording) {
+        replay.begin(key, recording)
+        inputs.slotHandedOff.set(true)
+        // ATOMIC: the body starts even if the scope was cancelled since the isActive check, so the
+        // finally below always runs; the drive's first suspension then throws the cancellation and
+        // the seal writes the honest error frame to the still-attached client.
+        val job = detachedScope.launch(detachedContext, start = CoroutineStart.ATOMIC) {
             try {
-                // The 200 + SSE headers are committed once respondTextWriter opens, so any failure
-                // must become an honest `event: error` frame — NOT escape and leave the client an
-                // empty/truncated 200 (the "empty or malformed response (HTTP 200)" class).
                 driver.driveSealingCancellation(drive)
             } finally {
-                // Terminal frames force-flush already; this covers abandon / exception paths.
-                // DR-93 (redo): quiet by contract — see ClientChannel.flushQuietly. A raw
-                // coalesced.flush() here is walled off (kt-turn-finally-flush-quietly): its
-                // dead-socket throw would replace the primary outcome or cancellation.
-                channel.flushQuietly()
+                recording.complete()
+                drive.channel.flushQuietly()
+                val wasDetached = drive.channel.detached.get()
+                // The terminal's own verdict, not a frame literal (L3): an error frame or an
+                // abandon is not an answer a retry may be handed.
+                val kept = wasDetached && drive.emitter.endedCleanly
+                replay.finish(key, recording, keep = kept)
+                inputs.slot.release()
+                if (wasDetached) deps.log(finishLine(drive, recording, kept))
             }
+        }
+        try {
+            job.join()
+        } catch (e: CancellationException) {
+            if (job.isActive && drive.channel.detachIfRecording()) {
+                val who = drive.sessionTag()?.let { "session $it, " } ?: ""
+                deps.log(
+                    "[${provider.key}] client gone (${who}call cancelled) — " +
+                        "compaction continues detached; its answer is held for a retry\n",
+                )
+            }
+            throw e
+        }
+    }
+
+    /** Head stop: a detached compaction has no head to record for — end the ones still driving
+     *  (each finally releases its slot and drops its recording). The scope itself survives, because
+     *  HeadServer restarts on this same streamer and a cancelled scope launches nothing (header). */
+    fun stopDetached() {
+        detachedScope.coroutineContext.cancelChildren()
+    }
+
+    private fun finishLine(drive: TurnDrive, recording: FrameRecording, kept: Boolean): String {
+        val who = drive.sessionTag()?.let { "session $it" } ?: "no session"
+        return if (kept) {
+            "[${provider.key}] detached compaction finished ($who) — " +
+                "${recording.size} frames held for a byte-identical retry\n"
+        } else {
+            "[${provider.key}] detached compaction ended without a terminal frame ($who) — " +
+                "nothing held; a retry runs upstream\n"
         }
     }
 }

--- a/gateway/gateway/src/main/kotlin/splice/gateway/wire/ClientChannel.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/wire/ClientChannel.kt
@@ -7,6 +7,14 @@
 // pinger flips it on a failed keepalive write — the same mechanism on the same three fields this
 // data class holds, so both became member functions instead of free functions taking the fields as
 // separate arguments.
+//
+// DETACHABLE (2026-09-05): a channel built with a [FrameRecording] belongs to a turn that must
+// OUTLIVE its client — a compaction, which Claude Code aborts at 600 s of wall clock and retries
+// byte-identically minutes later. On such a channel every frame is recorded as well as written,
+// and a lost client (failed write, failed keepalive, or Ktor cancelling the call) DETACHES the
+// channel instead of failing or cancelling the turn: no more bytes reach the socket, the turn runs
+// on, and the recording answers the retry (TurnStreamer.driveDetachable, CompactionReplay). A
+// channel with no recording behaves exactly as before — ordinary turns still cancel on a lost client.
 package splice.gateway.wire
 
 import kotlinx.coroutines.CoroutineScope
@@ -38,12 +46,19 @@ private const val SSE_KEEPALIVE_COMMENT = ": ping\n\n"
 // slot behind it) undetected for up to 10s; tightened to 2s. Same mechanism, smaller tick.
 private const val CLIENT_PING_INTERVAL_MS = 2_000L
 
+private const val DETACHED_NOTE = "compaction continues detached; its answer is held for a retry"
+
 /** Per-turn client write surface: the coalesced writer, a mutex serializing the emitter vs the
  *  keepalive pinger, and the clientGone flag a failed write flips. */
 internal data class ClientChannel(
     val coalesced: ImmediateSseWriter,
     val writeMutex: Mutex,
     val clientGone: AtomicBoolean,
+    /** Set for a turn that must outlive its client (a compaction): every frame is appended here as
+     *  well as written, and a lost client detaches the channel instead of failing the turn. */
+    val recording: FrameRecording? = null,
+    /** Flipped once for good by [detachIfRecording]: writes are recorded, none reach the socket. */
+    val detached: AtomicBoolean = AtomicBoolean(false),
 ) {
     /** Client-side write instrumented: frame counts/bytes, first-frame/first-delta marks, and the
      *  summed write+flush time (a slow reader shows up as write_ms, not as fake stream time).
@@ -51,12 +66,15 @@ internal data class ClientChannel(
      *  reads it to classify the ending as ClientAbandoned instead of upstream truncation. The
      *  caller holds [writeMutex] around this call; it does not lock itself. */
     fun timedClientWrite(frame: String, perf: TurnPerf, clock: ElapsedClock) {
+        recording?.append(frame)
+        if (detached.get()) return
         val t = clock()
         try {
             coalesced.write(frame)
         } catch (e: IOException) {
             clientGone.set(true)
-            throw e
+            if (!detachIfRecording()) throw e
+            return
         }
         perf.add(PerfKeys.WRITE_MS, clock() - t)
         perf.add(PerfKeys.FRAMES_OUT, 1)
@@ -68,6 +86,17 @@ internal data class ClientChannel(
         perf.add(PerfKeys.BYTES_OUT, frame.length.toLong())
         perf.markOnce(PerfKeys.FIRST_FRAME)
         if (frame.startsWith(DELTA_FRAME_PREFIX)) perf.markOnce(PerfKeys.FIRST_DELTA)
+    }
+
+    /** Stop writing to the socket for good; the turn runs on and the recording stands in for the
+     *  client. False — and nothing changes — for a channel without a recording, so every caller
+     *  that only DETECTS the loss (a failed write or ping, Ktor's cancel of the call) keeps failing
+     *  or cancelling an ordinary turn exactly as before. Idempotent. */
+    fun detachIfRecording(): Boolean {
+        if (recording == null) return false
+        clientGone.set(true)
+        detached.set(true)
+        return true
     }
 
     /** DR-93 (redo): the turn-finally flush, quiet BY CONTRACT. On a dead socket the flush itself
@@ -115,18 +144,32 @@ internal data class ClientChannel(
                 // returns true, so this loop is exactly as unbounded as before; a test can wire a
                 // ticker that paces N pings instantly and then stops the loop.
                 if (!ticker.awaitTick(CLIENT_PING_INTERVAL_MS)) return@launch
+                if (detached.get()) {
+                    // A frame write detached the channel before this tick: the one log line for it.
+                    log("[$headKey] client gone (${who(session)}a frame write failed) — $DETACHED_NOTE\n")
+                    return@launch
+                }
                 try {
                     writeMutex.withLock { coalesced.write(SSE_KEEPALIVE_COMMENT) }
                 } catch (e: IOException) {
-                    clientGone.set(true)
-                    // The class, not just the message: ClosedChannelException carries none, and
-                    // "keepalive write failed: null" said nothing about who closed what (2026-09-02).
-                    val why = e::class.simpleName + (e.message?.let { ": $it" } ?: "")
-                    val who = session?.let { "session $it, " } ?: ""
-                    log("[$headKey] client gone (${who}keepalive write failed: $why) — cancelling turn\n")
-                    turnJob.cancel()
+                    pingFailed(e, turnJob, headKey, log, session)
                     return@launch
                 }
             }
         }
+
+    private fun pingFailed(e: IOException, turnJob: Job, headKey: String, log: LogSink, session: String?) {
+        clientGone.set(true)
+        // The class, not just the message: ClosedChannelException carries none, and
+        // "keepalive write failed: null" said nothing about who closed what (2026-09-02).
+        val why = e::class.simpleName + (e.message?.let { ": $it" } ?: "")
+        if (detachIfRecording()) {
+            log("[$headKey] client gone (${who(session)}keepalive write failed: $why) — $DETACHED_NOTE\n")
+        } else {
+            log("[$headKey] client gone (${who(session)}keepalive write failed: $why) — cancelling turn\n")
+            turnJob.cancel()
+        }
+    }
+
+    private fun who(session: String?): String = session?.let { "session $it, " } ?: ""
 }

--- a/gateway/gateway/src/main/kotlin/splice/gateway/wire/FrameRecording.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/wire/FrameRecording.kt
@@ -3,7 +3,10 @@
 // runs on detached (ClientChannel), every frame lands here, and the client's byte-identical retry is
 // served from it — the frames so far at once, the rest as they arrive, done at the terminal.
 // Whether the recording is a WHOLE answer is the terminal's fact (TurnTerminal.endedCleanly), not
-// something read off the frames: no terminal literal lives outside SseEmitter (L3).
+// something read off the frames: no terminal literal lives outside SseEmitter (L3). The drive
+// hands that verdict in at complete(), and a follower reads it back from follow() — a follower
+// already on a recording when its drive fails is the one retry CompactionReplay.finish cannot
+// turn away (review of PR 137), so the verdict has to reach it through the recording itself.
 package splice.gateway.wire
 
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -12,13 +15,16 @@ import kotlinx.coroutines.flow.update
 
 internal class FrameRecording {
 
-    private data class Progress(val frames: Int, val complete: Boolean)
+    private data class Progress(val frames: Int, val complete: Boolean, val whole: Boolean = false)
 
     private val lock = Any()
     private val frames = ArrayList<String>()
     private val progress = MutableStateFlow(Progress(0, false))
 
     val isComplete: Boolean get() = progress.value.complete
+
+    /** The drive's verdict: true when its terminal ended cleanly (meaningless before complete). */
+    val isWhole: Boolean get() = progress.value.whole
     val size: Int get() = progress.value.frames
 
     fun append(frame: String) {
@@ -29,13 +35,15 @@ internal class FrameRecording {
         progress.update { it.copy(frames = count) }
     }
 
-    /** No more frames will come. Followers drain what is recorded and return. */
-    fun complete() {
-        progress.update { it.copy(complete = true) }
+    /** No more frames will come. Followers drain what is recorded and return [whole], the drive's
+     *  verdict on its own terminal. */
+    fun complete(whole: Boolean) {
+        progress.update { it.copy(complete = true, whole = whole) }
     }
 
-    /** Deliver every frame recorded so far and every one still to come; returns once complete. */
-    suspend fun follow(write: FrameWrite) {
+    /** Deliver every frame recorded so far and every one still to come; returns once complete,
+     *  with the verdict handed to [complete]: false means the frames are not a whole answer. */
+    suspend fun follow(write: FrameWrite): Boolean {
         var seen = 0
         while (true) {
             val now = progress.value
@@ -44,7 +52,7 @@ internal class FrameRecording {
                 batch.forEach { write(it) }
                 seen = now.frames
             }
-            if (now.complete && now.frames == seen) return
+            if (now.complete && now.frames == seen) return now.whole
             progress.first { it.frames > seen || it.complete }
         }
     }

--- a/gateway/gateway/src/main/kotlin/splice/gateway/wire/FrameRecording.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/wire/FrameRecording.kt
@@ -1,0 +1,51 @@
+// NEW: an append-only record of one turn's client frames that can be FOLLOWED while it is still
+// being written (2026-09-05). What a compaction leaves behind when its client hangs up: the turn
+// runs on detached (ClientChannel), every frame lands here, and the client's byte-identical retry is
+// served from it — the frames so far at once, the rest as they arrive, done at the terminal.
+// Whether the recording is a WHOLE answer is the terminal's fact (TurnTerminal.endedCleanly), not
+// something read off the frames: no terminal literal lives outside SseEmitter (L3).
+package splice.gateway.wire
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+
+internal class FrameRecording {
+
+    private data class Progress(val frames: Int, val complete: Boolean)
+
+    private val lock = Any()
+    private val frames = ArrayList<String>()
+    private val progress = MutableStateFlow(Progress(0, false))
+
+    val isComplete: Boolean get() = progress.value.complete
+    val size: Int get() = progress.value.frames
+
+    fun append(frame: String) {
+        val count = synchronized(lock) {
+            frames.add(frame)
+            frames.size
+        }
+        progress.update { it.copy(frames = count) }
+    }
+
+    /** No more frames will come. Followers drain what is recorded and return. */
+    fun complete() {
+        progress.update { it.copy(complete = true) }
+    }
+
+    /** Deliver every frame recorded so far and every one still to come; returns once complete. */
+    suspend fun follow(write: FrameWrite) {
+        var seen = 0
+        while (true) {
+            val now = progress.value
+            if (now.frames > seen) {
+                val batch = synchronized(lock) { frames.subList(seen, now.frames).toList() }
+                batch.forEach { write(it) }
+                seen = now.frames
+            }
+            if (now.complete && now.frames == seen) return
+            progress.first { it.frames > seen || it.complete }
+        }
+    }
+}

--- a/gateway/gateway/src/main/kotlin/splice/gateway/wire/SseEmitter.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/wire/SseEmitter.kt
@@ -24,6 +24,7 @@ import splice.core.turn.ErrorType
 import splice.core.turn.Usage
 import splice.spi.WireSink
 import java.util.concurrent.CancellationException
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
 private const val TYPE = "type"
@@ -44,11 +45,14 @@ public class SseEmitter internal constructor(
     // AtomicReference so an illegal ended-without-ending combination is unrepresentable.
     private enum class SealState { OPEN, ENDING, ENDED }
     private val seal = AtomicReference(SealState.OPEN)
+    private val cleanEnd = AtomicBoolean(false)
 
     // The shared stop_reason derivation (L3) — one definition, held rather than copied.
     private val envelope = TerminalEnvelope()
 
     override val hasEnded: Boolean get() = seal.get() == SealState.ENDED
+
+    override val endedCleanly: Boolean get() = cleanEnd.get()
 
     override suspend fun ensureStarted(): Unit = start.ensureStart()
 
@@ -70,6 +74,7 @@ public class SseEmitter internal constructor(
                 },
             )
             frames.frame("message_stop", buildJsonObject { put(TYPE, "message_stop") })
+            cleanEnd.set(true)
         } catch (e: CancellationException) {
             // Cancelled mid-frame — release so the cancellation seal's emitError
             // (TurnDriver.driveSealingCancellation) can still seal honestly; a stranded ENDING

--- a/gateway/gateway/src/main/kotlin/splice/gateway/wire/TurnTerminal.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/wire/TurnTerminal.kt
@@ -35,6 +35,12 @@ public interface TurnTerminal : WireSink {
      *  truncated-200 fix, review 2026-07-22 round 3). */
     public val hasEnded: Boolean
 
+    /** True once [emitTerminal] delivered the clean ending — never for an error or an abandon.
+     *  What tells a detached compaction's recording (TurnStreamer) apart from a truncated or
+     *  failed one without any consumer reading terminal literals off the frames (L3). Default
+     *  false: the collecting sink has no detached consumer. */
+    public val endedCleanly: Boolean get() = false
+
     /** The ONLY clean ending — implementors derive the stop_reason literal internally (L3). */
     public suspend fun emitTerminal(hasToolUse: Boolean, incomplete: Boolean, usage: Usage)
 

--- a/gateway/gateway/src/main/kotlin/splice/gateway/wire/TurnWiring.kt
+++ b/gateway/gateway/src/main/kotlin/splice/gateway/wire/TurnWiring.kt
@@ -22,7 +22,16 @@ internal class TurnWiring(
 
     /** The Anthropic usage payload builder — shared by the stream emitter and the non-stream
      *  collector so both report tokens identically. */
-    fun usagePayloadBuilder(catalog: ModelCatalog, meta: TurnMeta, sessionWindow: Long? = null): UsagePayloadBuilder {
+    fun usagePayloadBuilder(catalog: ModelCatalog, meta: TurnMeta, sessionWindow: Long? = null): UsagePayloadBuilder =
+        usagePayloadBuilderFor(catalog, meta.originalModel, sessionWindow)
+
+    /** The same builder for a response the proxy composes without a provider build (LocalResponses):
+     *  the row id is all it ever read of the meta. */
+    fun usagePayloadBuilderFor(
+        catalog: ModelCatalog,
+        originalModel: String,
+        sessionWindow: Long? = null,
+    ): UsagePayloadBuilder {
         var factorLogged = false
         return { usage ->
             // Anthropic convention (Claude Code HUD/autocompact): input_tokens and cache_read_input_tokens
@@ -53,12 +62,12 @@ internal class TurnWiring(
             // breadcrumb even though every displayed surface stays self-consistent. Non-launched
             // clients (the e2e probe, a bare curl) receive scaled counts against a window they never
             // declared — by design; the raw truth lives in splice's own accounting above.
-            val clientWindow = catalog.clientContextWindowFor(meta.originalModel, sessionWindow)
-            val scale = catalog.usageScale(meta.originalModel, sessionWindow)
+            val clientWindow = catalog.clientContextWindowFor(originalModel, sessionWindow)
+            val scale = catalog.usageScale(originalModel, sessionWindow)
             if (scale != 1.0 && !factorLogged) {
                 factorLogged = true
                 log(
-                    "[usage] row '${meta.originalModel}' reports client-scaled tokens " +
+                    "[usage] row '$originalModel' reports client-scaled tokens " +
                         "(factor $scale, client window $clientWindow" +
                         "${if (sessionWindow != null) ", the session's own" else ", the launch env"})\n",
                 )

--- a/gateway/gateway/src/test/kotlin/ClientChannelDetachTest.kt
+++ b/gateway/gateway/src/test/kotlin/ClientChannelDetachTest.kt
@@ -1,0 +1,62 @@
+// NEW (2026-09-05): a recording channel outlives its client — a failed write detaches it instead of
+// failing the turn, and a channel without a recording still fails exactly as before.
+import kotlinx.coroutines.sync.Mutex
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import splice.core.perf.TurnPerf
+import splice.core.util.ElapsedClock
+import splice.gateway.wire.ClientChannel
+import splice.gateway.wire.FrameRecording
+import splice.gateway.wire.ImmediateSseWriter
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicBoolean
+
+class ClientChannelDetachTest {
+
+    private val clock = ElapsedClock { 0L }
+
+    private fun channel(recording: FrameRecording?, writeRaw: (String) -> Unit) = ClientChannel(
+        ImmediateSseWriter(writeRaw = { writeRaw(it) }, flushRaw = {}),
+        Mutex(),
+        AtomicBoolean(false),
+        recording = recording,
+    )
+
+    @Test
+    fun `a recording channel detaches on a failed write - later frames are recorded, not written, nothing thrown`() {
+        val recording = FrameRecording()
+        val written = mutableListOf<String>()
+        var dead = false
+        val ch = channel(recording) { if (dead) throw IOException("Broken pipe") else written += it }
+        val perf = TurnPerf()
+        ch.timedClientWrite("event: message_start\n\n", perf, clock)
+        dead = true
+        ch.timedClientWrite("event: content_block_delta\n\n", perf, clock) // fails: detaches
+        ch.timedClientWrite("event: message_stop\n\n", perf, clock) // skipped on the socket, recorded
+        assertTrue(ch.detached.get())
+        assertTrue(ch.clientGone.get())
+        assertEquals(1, written.size, "nothing reaches the socket after the detach")
+        assertEquals(3, recording.size, "every frame is recorded, before and after")
+    }
+
+    @Test
+    fun `a channel without a recording still throws and flips clientGone`() {
+        val ch = channel(null) { throw IOException("Broken pipe") }
+        assertThrows(IOException::class.java) { ch.timedClientWrite("event: ping\n\n", TurnPerf(), clock) }
+        assertTrue(ch.clientGone.get())
+        assertFalse(ch.detached.get())
+        assertFalse(ch.detachIfRecording(), "no recording, no detach: the turn keeps failing on a lost client")
+    }
+
+    @Test
+    fun `detachIfRecording is the one switch and is idempotent`() {
+        val ch = channel(FrameRecording()) { }
+        assertTrue(ch.detachIfRecording())
+        assertTrue(ch.detachIfRecording())
+        assertTrue(ch.detached.get())
+        assertTrue(ch.clientGone.get())
+    }
+}

--- a/gateway/gateway/src/test/kotlin/FrameRecordingTest.kt
+++ b/gateway/gateway/src/test/kotlin/FrameRecordingTest.kt
@@ -1,0 +1,53 @@
+// NEW (2026-09-05): a detached compaction's frame record — followable while it is still being written.
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import splice.gateway.wire.FrameRecording
+
+class FrameRecordingTest {
+
+    @Test
+    fun `a follower that starts after completion gets every frame in order and returns`() = runBlocking {
+        val recording = FrameRecording()
+        recording.append("event: message_start\n\n")
+        recording.append("event: content_block_delta\n\n")
+        recording.append("event: message_stop\n\n")
+        recording.complete()
+        val got = mutableListOf<String>()
+        withTimeout(5_000) { recording.follow { got += it } }
+        assertEquals(3, got.size)
+        assertTrue(got[0].startsWith("event: message_start"))
+        assertTrue(recording.isComplete)
+        assertEquals(3, recording.size)
+    }
+
+    @Test
+    fun `a follower that starts mid-way gets the rest as it arrives and returns at completion`() = runBlocking {
+        val recording = FrameRecording()
+        recording.append("one")
+        val got = mutableListOf<String>()
+        val follower = async(Dispatchers.Default) { withTimeout(10_000) { recording.follow { got += it } } }
+        delay(100) // the follower has drained "one" and is parked on the next frame
+        recording.append("two")
+        delay(100)
+        recording.append("event: message_stop\n\n")
+        recording.complete()
+        follower.await()
+        assertEquals(listOf("one", "two", "event: message_stop\n\n"), got)
+    }
+
+    @Test
+    fun `a recording is not complete until told so`() {
+        val recording = FrameRecording()
+        recording.append("event: message_start\n\n")
+        assertFalse(recording.isComplete)
+        recording.complete()
+        assertTrue(recording.isComplete)
+    }
+}

--- a/gateway/gateway/src/test/kotlin/FrameRecordingTest.kt
+++ b/gateway/gateway/src/test/kotlin/FrameRecordingTest.kt
@@ -18,7 +18,7 @@ class FrameRecordingTest {
         recording.append("event: message_start\n\n")
         recording.append("event: content_block_delta\n\n")
         recording.append("event: message_stop\n\n")
-        recording.complete()
+        recording.complete(whole = true)
         val got = mutableListOf<String>()
         withTimeout(5_000) { recording.follow { got += it } }
         assertEquals(3, got.size)
@@ -37,7 +37,7 @@ class FrameRecordingTest {
         recording.append("two")
         delay(100)
         recording.append("event: message_stop\n\n")
-        recording.complete()
+        recording.complete(whole = true)
         follower.await()
         assertEquals(listOf("one", "two", "event: message_stop\n\n"), got)
     }
@@ -47,7 +47,26 @@ class FrameRecordingTest {
         val recording = FrameRecording()
         recording.append("event: message_start\n\n")
         assertFalse(recording.isComplete)
-        recording.complete()
+        recording.complete(whole = true)
         assertTrue(recording.isComplete)
+    }
+
+    /** The drive's verdict reaches a follower that was already on the recording when the drive
+     *  ended: it is what LocalResponses.replay seals on (review of PR 137). */
+    @Test
+    fun `a follower gets the drive's verdict back - false when the recording is not a whole answer`() = runBlocking {
+        val failed = FrameRecording()
+        failed.append("event: message_start\n\n")
+        val follower = async(Dispatchers.Default) { withTimeout(10_000) { failed.follow { } } }
+        delay(100)
+        failed.complete(whole = false)
+        assertFalse(follower.await(), "an abandoned drive leaves no whole answer")
+        assertFalse(failed.isWhole)
+
+        val whole = FrameRecording()
+        whole.append("event: message_stop\n\n")
+        whole.complete(whole = true)
+        assertTrue(whole.follow { }, "a clean terminal is a whole answer")
+        assertTrue(whole.isWhole)
     }
 }

--- a/gateway/gateway/src/test/kotlin/head/ActivityLabelTest.kt
+++ b/gateway/gateway/src/test/kotlin/head/ActivityLabelTest.kt
@@ -1,0 +1,111 @@
+// NEW (2026-09-05): the activity label the proxy composes for Claude Code's 30-second side query,
+// instead of a full-context upstream read every 30 s per session.
+package head
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import splice.core.parse.AnthropicParse
+import splice.core.wire.AnthropicRequest
+import splice.gateway.head.ActivityLabel
+
+class ActivityLabelTest {
+
+    private val label = ActivityLabel()
+
+    private fun request(vararg messages: String): AnthropicRequest =
+        AnthropicParse.parseAnthropicBody("""{"model":"m","messages":[${messages.joinToString(",")}]}""").typed
+
+    private fun toolUse(name: String, input: String) =
+        """{"role":"assistant","content":[{"type":"text","text":"On it."},""" +
+            """{"type":"tool_use","id":"t1","name":"$name","input":$input}]}"""
+
+    private val toolResult = """{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"ok"}]}"""
+    private val user = """{"role":"user","content":"fix the bug"}"""
+
+    // The prompt as Claude Code 2.1.257 builds it (wxo): the opening sentence, the previous label,
+    // its good/bad examples.
+    private val query = """{"role":"user","content":[{"type":"text","text":""" +
+        """"Describe your most recent action in 3-5 words using present tense (-ing). """ +
+        """Name the file or function, not the branch. Do not use tools.\n\n""" +
+        """Previous: \"Reading foo\" — say something NEW.\n\nGood: \"Reading runAgent.ts\""}]}"""
+
+    private fun labelAfter(name: String, input: String) =
+        label.labelFor(request(user, toolUse(name, input), toolResult, query))
+
+    @Test
+    fun `file tools name the file`() {
+        assertEquals("Reading TurnStreamer.kt", labelAfter("Read", """{"file_path":"/repo/g/TurnStreamer.kt"}"""))
+        assertEquals(
+            "Editing HeadAdmission.kt",
+            labelAfter("Edit", """{"file_path":"/r/HeadAdmission.kt","old_string":"a"}"""),
+        )
+        assertEquals("Writing notes.md", labelAfter("Write", """{"file_path":"notes.md","content":"x"}"""))
+        assertEquals("Editing lab.ipynb", labelAfter("NotebookEdit", """{"notebook_path":"/n/lab.ipynb"}"""))
+        assertEquals("Reading a file", labelAfter("Read", """{}"""))
+    }
+
+    @Test
+    fun `bash names the first real command past the shell prelude and before the pipe`() {
+        assertEquals("Running git status", labelAfter("Bash", """{"command":"cd /repo && git status --short"}"""))
+        assertEquals(
+            "Running gradlew test",
+            labelAfter("Bash", """{"command":"JAVA_OPTS=-Xmx1g ./gradlew test -q 2>&1 | tail -5"}"""),
+        )
+        assertEquals(
+            "Running cat build.log",
+            labelAfter("Bash", """{"command":"set -e; MY=/x; cd /x; cat build.log"}"""),
+        )
+        assertEquals("Running python3", labelAfter("Bash", """{"command":"python3 - <<'EOF'\nprint(1)\nEOF"}"""))
+        assertEquals("Running a command", labelAfter("Bash", """{"command":""}"""))
+        assertEquals("Running a command", labelAfter("Bash", """{}"""))
+    }
+
+    @Test
+    fun `search tools name the pattern and the rest their kind`() {
+        assertEquals("Searching for perTurnHeaders", labelAfter("Grep", """{"pattern":"perTurnHeaders","path":"g"}"""))
+        assertEquals("Finding **/*.kt", labelAfter("Glob", """{"pattern":"**/*.kt"}"""))
+        assertEquals("Delegating to a subagent", labelAfter("Agent", """{"prompt":"x"}"""))
+        assertEquals("Updating the task list", labelAfter("TodoWrite", """{"todos":[]}"""))
+        assertEquals("Calling web_search_exa", labelAfter("mcp__exa__web_search_exa", """{"query":"x"}"""))
+        assertEquals("Using Frobnicate", labelAfter("Frobnicate", """{}"""))
+    }
+
+    @Test
+    fun `a long argument is clipped`() {
+        val long = "a".repeat(60)
+        assertEquals("Searching for ${"a".repeat(32)}…", labelAfter("Grep", """{"pattern":"$long"}"""))
+    }
+
+    @Test
+    fun `the last tool call of the last assistant message wins`() {
+        val twoCalls = """{"role":"assistant","content":[""" +
+            """{"type":"tool_use","id":"a","name":"Read","input":{"file_path":"a.kt"}},""" +
+            """{"type":"tool_use","id":"b","name":"Edit","input":{"file_path":"b.kt"}}]}"""
+        val results = """{"role":"user","content":[""" +
+            """{"type":"tool_result","tool_use_id":"a","content":"1"},""" +
+            """{"type":"tool_result","tool_use_id":"b","content":"2"}]}"""
+        assertEquals("Editing b.kt", label.labelFor(request(user, twoCalls, results, query)))
+    }
+
+    @Test
+    fun `no tool call yet and no transcript have their own labels`() {
+        val textOnly = """{"role":"assistant","content":[{"type":"text","text":"Here is the fix."}]}"""
+        assertEquals("Replying to the user", label.labelFor(request(user, textOnly, query)))
+        assertEquals("Reading the request", label.labelFor(request(query)))
+    }
+
+    @Test
+    fun `anything but the verbatim side query at the head of the last user message is not answered`() {
+        assertNull(label.labelFor(request(user, toolUse("Read", """{"file_path":"a"}"""), toolResult, user)))
+        val reworded = """{"role":"user","content":"Describe your most recent action in 3 words."}"""
+        assertNull(label.labelFor(request(user, reworded)))
+        val quoted = """{"role":"user","content":"Why does Claude Code send \"Describe your most recent action """ +
+            """in 3-5 words using present tense (-ing).\" every 30 seconds?"}"""
+        assertNull(label.labelFor(request(quoted)))
+        // The sentence in an assistant message, not the last user message.
+        val assistantSays = """{"role":"assistant","content":"Describe your most recent action in 3-5 words using """ +
+            """present tense (-ing)."}"""
+        assertNull(label.labelFor(request(user, assistantSays)))
+    }
+}

--- a/gateway/gateway/src/test/kotlin/head/CompactionReplayTest.kt
+++ b/gateway/gateway/src/test/kotlin/head/CompactionReplayTest.kt
@@ -1,0 +1,77 @@
+// NEW (2026-09-05): the store of detached compactions' answers — what a byte-identical retry finds.
+package head
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import splice.core.util.ElapsedClock
+import splice.gateway.head.CompactionReplay
+import splice.gateway.wire.FrameRecording
+
+class CompactionReplayTest {
+
+    private var now = 0L
+    private val replay = CompactionReplay(clock = ElapsedClock { now }, ttlMs = 1_000, capacity = 2)
+
+    private fun whole() = FrameRecording().apply {
+        append("event: message_start\n\n")
+        append("event: message_stop\n\n")
+        complete()
+    }
+
+    @Test
+    fun `the key is the session and the upstream bytes - no session, no key`() {
+        assertNull(replay.key(null, "{}"))
+        assertNull(replay.key(" ", "{}"))
+        assertEquals(replay.key("s", """{"a":1}"""), replay.key("s", """{"a":1}"""))
+        assertNotEquals(replay.key("s", """{"a":1}"""), replay.key("s", """{"a":2}"""))
+        assertNotEquals(replay.key("s", "{}"), replay.key("t", "{}"))
+    }
+
+    @Test
+    fun `an in-flight recording is found by a retry and only a kept one survives its finish`() {
+        val key = checkNotNull(replay.key("s", "{}"))
+        val inFlight = FrameRecording().apply { append("event: message_start\n\n") }
+        replay.begin(key, inFlight)
+        assertSame(inFlight, replay.lookup(key), "a retry attaches to the compaction still in flight")
+        replay.finish(key, inFlight, keep = false) // the client stayed, or the ending was not clean
+        assertNull(replay.lookup(key), "not kept: the retry runs upstream")
+        val kept = whole()
+        replay.begin(key, kept)
+        replay.finish(key, kept, keep = true)
+        assertSame(kept, replay.lookup(key))
+        replay.consumed(key)
+        assertNull(replay.lookup(key), "a delivered replay is spent")
+    }
+
+    @Test
+    fun `a finish for a superseded recording leaves the newer one alone`() {
+        val key = checkNotNull(replay.key("s", "{}"))
+        val old = whole()
+        val newer = whole()
+        replay.begin(key, old)
+        replay.begin(key, newer)
+        replay.finish(key, old, keep = false)
+        assertSame(newer, replay.lookup(key))
+    }
+
+    @Test
+    fun `entries expire by age and the oldest goes first past capacity`() {
+        val k1 = checkNotNull(replay.key("s", "1"))
+        val k2 = checkNotNull(replay.key("s", "2"))
+        val k3 = checkNotNull(replay.key("s", "3"))
+        replay.begin(k1, whole())
+        now = 500
+        replay.begin(k2, whole())
+        now = 800
+        replay.begin(k3, whole()) // capacity 2: k1 goes
+        assertNull(replay.lookup(k1))
+        assertNotNull(replay.lookup(k2))
+        now = 1_600 // k2 is 1100 ms old, past the 1000 ms ttl; k3 is 800 ms old
+        assertNull(replay.lookup(k2))
+        assertNotNull(replay.lookup(k3))
+    }
+}

--- a/gateway/gateway/src/test/kotlin/head/CompactionReplayTest.kt
+++ b/gateway/gateway/src/test/kotlin/head/CompactionReplayTest.kt
@@ -19,7 +19,7 @@ class CompactionReplayTest {
     private fun whole() = FrameRecording().apply {
         append("event: message_start\n\n")
         append("event: message_stop\n\n")
-        complete()
+        complete(whole = true)
     }
 
     @Test
@@ -73,5 +73,24 @@ class CompactionReplayTest {
         now = 1_600 // k2 is 1100 ms old, past the 1000 ms ttl; k3 is 800 ms old
         assertNull(replay.lookup(k2))
         assertNotNull(replay.lookup(k3))
+    }
+
+    /** Review of PR 137: insertion order alone evicted the oldest-BEGUN entry, which can be a
+     *  compaction still driving whose retry has not arrived yet. A settled one goes first. */
+    @Test
+    fun `past capacity a settled recording goes before one still in flight`() {
+        val live = checkNotNull(replay.key("s", "live"))
+        val settled = checkNotNull(replay.key("s", "settled"))
+        val third = checkNotNull(replay.key("s", "third"))
+        val inFlight = FrameRecording().apply { append("event: message_start\n\n") }
+        replay.begin(live, inFlight) // oldest, and still driving
+        replay.begin(settled, whole())
+        replay.begin(third, FrameRecording()) // capacity 2: the settled one goes, not the oldest
+        assertSame(inFlight, replay.lookup(live), "a compaction still in flight keeps its entry")
+        assertNull(replay.lookup(settled))
+        assertNotNull(replay.lookup(third))
+        replay.begin(checkNotNull(replay.key("s", "fourth")), FrameRecording()) // all in flight: oldest goes
+        assertNull(replay.lookup(live))
+        assertNotNull(replay.lookup(third))
     }
 }

--- a/gateway/gateway/src/test/kotlin/head/HeadServerCompactionReplayTest.kt
+++ b/gateway/gateway/src/test/kotlin/head/HeadServerCompactionReplayTest.kt
@@ -1,0 +1,204 @@
+// NEW (2026-09-05): a compaction outlives its client. Claude Code aborts an auto-compaction at 600 s
+// of wall clock and retries the same bytes minutes later; before this, every abort cancelled a 600 s
+// upstream read. Driven through the REAL production path: a real HeadServer, a raw client socket
+// closed mid-turn (a real FIN, as in HeadServerCollectDisconnectTest), an upstream parked on
+// SCENARIO:hold, then the byte-identical retry served from the recording with no second upstream
+// turn — and the gate slot travelling with the detached drive, not with the dead call.
+package head
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import mock.MockChatGptUpstream
+import mock.awaitListening
+import mock.freshPort
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import splice.core.auth.AuthDescription
+import splice.core.auth.Credentials
+import splice.core.auth.RefreshableAuthProvider
+import splice.core.model.ModelCatalog
+import splice.core.model.ModelEntry
+import splice.core.turn.ReasoningDisplay
+import splice.core.turn.WatchdogBudget
+import splice.gateway.compact.CompactStats
+import splice.gateway.compact.ShadowClassifier
+import splice.gateway.head.HeadDeps
+import splice.gateway.head.HeadServer
+import splice.gateway.perf.PerfStats
+import splice.gateway.usage.UsageStore
+import splice.provider.codex.CodexProvider
+import splice.spi.InflightGate
+import splice.spi.ProviderTuning
+import splice.spi.UpstreamClient
+import java.net.Socket
+import java.nio.file.Files
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.Duration.Companion.seconds
+
+private class CompactionReplayAuth : RefreshableAuthProvider {
+    override suspend fun credentials(): Credentials = Credentials.Bearer("tok-cr", "acct-cr")
+    override suspend fun refresh(): Credentials = credentials()
+    override suspend fun describe(): AuthDescription = AuthDescription(true, "fake")
+}
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class HeadServerCompactionReplayTest {
+
+    private val mock = MockChatGptUpstream()
+    private val port = freshPort()
+    private val gate = InflightGate({ 0 })
+    private val lines = CopyOnWriteArrayList<String>()
+    private lateinit var head: HeadServer
+    private val client = HttpClient(CIO) {
+        defaultRequest { bearerAuth("test-inference-token") }
+    }
+
+    @BeforeAll
+    fun setUp() = runBlocking {
+        val tmp = Files.createTempDirectory("head-compaction-replay")
+        head = HeadServer(
+            provider = CodexProvider(
+                tuning = ProviderTuning(
+                    key = "codex",
+                    label = "claudex",
+                    catalog = ModelCatalog(
+                        discoveryPrefix = "claude-codex--",
+                        models = listOf(ModelEntry("gpt-5.6-sol", "Sol", contextWindow = 272_000)),
+                        defaultContextWindow = 272_000,
+                    ),
+                    pinnedModel = "gpt-5.6-sol",
+                    auth = CompactionReplayAuth(),
+                    baseUrl = mock.baseUrl,
+                    // Enormous on purpose: nothing in this test may end the turn but the hold release.
+                    watchdog = WatchdogBudget(600.seconds, 600.seconds, 900.seconds),
+                ),
+                showReasoning = ReasoningDisplay.TEXT,
+                replayReasoning = false,
+                configEffort = "high",
+                configSummary = "detailed",
+            ),
+            listenPort = port,
+            deps = HeadDeps(
+                upstream = UpstreamClient(firstByteTimeoutMs = 600_000, totalTimeoutMs = 900_000, maxRetries = 2),
+                inferenceToken = "test-inference-token",
+                gate = gate,
+                shadow = ShadowClassifier(log = {}),
+                compactStats = CompactStats(tmp.resolve("compact.jsonl")),
+                usageStore = UsageStore(tmp.resolve("usage.json"), tmp.resolve("ratelimit.json")),
+                perfStats = PerfStats(tmp.resolve("perf.jsonl")),
+                log = { lines += it },
+            ),
+        )
+        head.start()
+        awaitListening(port)
+    }
+
+    @AfterAll
+    fun tearDown() = runBlocking {
+        mock.releaseHold() // never leave a parked upstream thread behind
+        head.stop()
+        mock.stop()
+        client.close()
+    }
+
+    // Claude Code's verbatim summarizer marker makes this a compaction (CompactClassifier); the
+    // scenario parks the upstream after its first delta ("held") until the test releases it.
+    private val body = """{"model":"claude-codex--gpt-5.6-sol","stream":true,"max_tokens":64,""" +
+        """"system":"SCENARIO:hold You are tasked with summarizing conversations for another agent.",""" +
+        """"messages":[{"role":"user","content":"compact"}]}"""
+
+    /** A real client whose close() is a real FIN — no HTTP-client pool or cancellation semantics. */
+    private fun openCompaction(): Socket {
+        val socket = Socket("127.0.0.1", port)
+        val request = "POST /v1/messages HTTP/1.1\r\n" +
+            "Host: 127.0.0.1:$port\r\n" +
+            "Authorization: Bearer test-inference-token\r\n" +
+            "Content-Type: application/json\r\n" +
+            "x-claude-code-session-id: sess-compaction\r\n" +
+            "Content-Length: ${body.toByteArray().size}\r\n" +
+            "Connection: close\r\n\r\n" + body
+        socket.getOutputStream().write(request.toByteArray())
+        socket.getOutputStream().flush()
+        return socket
+    }
+
+    private suspend fun waitFor(capMs: Long, cond: () -> Boolean): Boolean {
+        val deadline = System.currentTimeMillis() + capMs
+        while (System.currentTimeMillis() < deadline) {
+            if (cond()) return true
+            delay(50)
+        }
+        return cond()
+    }
+
+    private fun logged(fragment: String): Boolean = lines.any { it.contains(fragment) }
+
+    /** RED before the fix (review 2026-09-05, splice-astra): stop() cancelled the detached scope and
+     *  start() reused the same driver, so the first compaction after a head restart launched into a
+     *  dead scope — an empty 200 with the slot handed off to nobody. The mock's happy path (no
+     *  SCENARIO marker) streams a whole answer; only the restart is under test here. */
+    @Test
+    fun `a compaction after a head stop and start is still driven whole and its slot comes back`() = runBlocking {
+        head.stop()
+        head.start()
+        awaitListening(port)
+        val upstreamBefore = mock.upstreamBodies.size
+        val sse = post(body.replace("SCENARIO:hold ", ""))
+        assertTrue(
+            sse.contains("event: message_stop"),
+            "a whole answer after the restart: $sse\n${lines.joinToString("")}",
+        )
+        assertTrue(!sse.contains("event: error"), "no error frame after the restart: $sse")
+        assertEquals(upstreamBefore + 1, mock.upstreamBodies.size, "the compaction went upstream")
+        assertTrue(waitFor(5_000) { gate.snapshot().inflight == 0 }, "the slot must come back: ${gate.snapshot()}")
+    }
+
+    private suspend fun post(json: String): String =
+        client.post("http://127.0.0.1:$port/v1/messages") {
+            header("Content-Type", "application/json")
+            header("x-claude-code-session-id", "sess-compaction")
+            setBody(json)
+        }.bodyAsText()
+
+    @Test
+    fun `a compaction whose client hangs up finishes detached and its answer is replayed to the retry`() = runBlocking {
+        mock.resetHold()
+        val upstreamBefore = mock.upstreamBodies.size
+        val socket = openCompaction()
+        assertTrue(waitFor(15_000) { mock.upstreamBodies.size > upstreamBefore }, "the compaction must reach upstream")
+        assertTrue(waitFor(15_000) { gate.snapshot().inflight == 1 }, "the compaction must hold a gate slot")
+        socket.close()
+        assertTrue(waitFor(20_000) { logged("compaction continues detached") }, lines.joinToString())
+        assertEquals(1L, mock.holdRelease.count, "the upstream must still be parked: nothing here has finished")
+        assertEquals(1, gate.snapshot().inflight, "the slot travels with the detached drive, not the dead call")
+
+        mock.releaseHold()
+        assertTrue(waitFor(20_000) { logged("held for a byte-identical retry") }, lines.joinToString())
+        assertTrue(waitFor(10_000) { gate.snapshot().inflight == 0 }, "the slot comes back when the upstream turn ends")
+        val upstreamAfterFirst = mock.upstreamBodies.size
+
+        val sse = post(body)
+        val again = if (sse.contains("held")) "" else "\nsecond try: ${post(body)}"
+        assertTrue(
+            sse.contains("held"),
+            "the retry must receive the recorded answer: $sse$again\n${lines.joinToString("")}",
+        )
+        assertTrue(sse.contains("event: message_stop"), "the recorded answer must be whole: $sse")
+        assertEquals(upstreamAfterFirst, mock.upstreamBodies.size, "the retry must not start a second upstream turn")
+        assertTrue(logged("replaying its answer, no upstream turn"), lines.joinToString())
+        assertTrue(waitFor(5_000) { logged("compaction answer replayed") }, lines.joinToString())
+        assertTrue(waitFor(5_000) { gate.snapshot().inflight == 0 }, "the replay releases its own slot")
+    }
+}

--- a/gateway/gateway/src/test/kotlin/head/HeadServerCompactionReplayTest.kt
+++ b/gateway/gateway/src/test/kotlin/head/HeadServerCompactionReplayTest.kt
@@ -233,7 +233,8 @@ class HeadServerCompactionReplayTest {
         assertTrue(sse.contains("event: message_stop"), "the follower gets the whole answer: $sse")
         assertEquals(upstreamBefore + 1, mock.upstreamBodies.size, "one upstream turn served both attempts")
         assertTrue(waitFor(10_000) { gate.snapshot().inflight == 0 }, "every slot comes back: ${gate.snapshot()}")
-        assertTrue(logged("the retry cost no upstream turn", mark), lines.drop(mark).joinToString())
+        // Logged after the response is written: the client can be back before the server gets there.
+        assertTrue(waitFor(5_000) { logged("the retry cost no upstream turn", mark) }, lines.drop(mark).joinToString())
         assertTrue(waitFor(5_000) { logged("compaction answer replayed") }, lines.joinToString())
         assertTrue(waitFor(5_000) { gate.snapshot().inflight == 0 }, "the replay releases its own slot")
     }

--- a/gateway/gateway/src/test/kotlin/head/HeadServerCompactionReplayTest.kt
+++ b/gateway/gateway/src/test/kotlin/head/HeadServerCompactionReplayTest.kt
@@ -14,6 +14,7 @@ import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
+import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import mock.MockChatGptUpstream
@@ -143,7 +144,10 @@ class HeadServerCompactionReplayTest {
         return cond()
     }
 
-    private fun logged(fragment: String): Boolean = lines.any { it.contains(fragment) }
+    /** [since]: lines are shared across the class's tests; a fragment one test also logs is only
+     *  evidence when it appears after the mark the caller took. */
+    private fun logged(fragment: String, since: Int = 0): Boolean =
+        lines.drop(since).any { it.contains(fragment) }
 
     /** RED before the fix (review 2026-09-05, splice-astra): stop() cancelled the detached scope and
      *  start() reused the same driver, so the first compaction after a head restart launched into a
@@ -180,6 +184,9 @@ class HeadServerCompactionReplayTest {
         assertTrue(waitFor(15_000) { mock.upstreamBodies.size > upstreamBefore }, "the compaction must reach upstream")
         assertTrue(waitFor(15_000) { gate.snapshot().inflight == 1 }, "the compaction must hold a gate slot")
         socket.close()
+        // Either detach path may notice the FIN first (Ktor cancelling the call, or the keepalive
+        // pinger's failed write, a real race in this run: review of PR 137); both log the shared
+        // DETACHED_NOTE, which is the fact under test. The slot assertion below holds for both.
         assertTrue(waitFor(20_000) { logged("compaction continues detached") }, lines.joinToString())
         assertEquals(1L, mock.holdRelease.count, "the upstream must still be parked: nothing here has finished")
         assertEquals(1, gate.snapshot().inflight, "the slot travels with the detached drive, not the dead call")
@@ -198,6 +205,35 @@ class HeadServerCompactionReplayTest {
         assertTrue(sse.contains("event: message_stop"), "the recorded answer must be whole: $sse")
         assertEquals(upstreamAfterFirst, mock.upstreamBodies.size, "the retry must not start a second upstream turn")
         assertTrue(logged("replaying its answer, no upstream turn"), lines.joinToString())
+    }
+
+    /** Review of PR 137: a retry that arrives while the compaction is still driving follows the live
+     *  recording. It must not hold a second gate slot for the wait (the drive holds one), and it
+     *  receives the whole answer from the one upstream turn. */
+    @Test
+    fun `a retry that arrives while the compaction is still in flight follows it on the drive's slot`() = runBlocking {
+        mock.resetHold()
+        val mark = lines.size
+        val upstreamBefore = mock.upstreamBodies.size
+        val socket = openCompaction()
+        assertTrue(waitFor(15_000) { mock.upstreamBodies.size > upstreamBefore }, "the compaction must reach upstream")
+        assertTrue(waitFor(15_000) { gate.snapshot().inflight == 1 }, "the compaction must hold a gate slot")
+        socket.close()
+        assertTrue(waitFor(20_000) { logged("compaction continues detached", mark) }, lines.drop(mark).joinToString())
+
+        val retry = async { post(body) }
+        assertTrue(waitFor(10_000) { logged("still running", mark) }, lines.drop(mark).joinToString())
+        assertTrue(waitFor(5_000) { gate.snapshot().inflight == 1 }, "one compaction, one slot: ${gate.snapshot()}")
+        assertEquals(1L, mock.holdRelease.count, "the upstream must still be parked: the retry is following it")
+        assertEquals(1, gate.snapshot().inflight, "the follower rides the drive's slot, it does not hold its own")
+
+        mock.releaseHold()
+        val sse = retry.await()
+        assertTrue(sse.contains("held"), "the follower gets the recorded answer: $sse")
+        assertTrue(sse.contains("event: message_stop"), "the follower gets the whole answer: $sse")
+        assertEquals(upstreamBefore + 1, mock.upstreamBodies.size, "one upstream turn served both attempts")
+        assertTrue(waitFor(10_000) { gate.snapshot().inflight == 0 }, "every slot comes back: ${gate.snapshot()}")
+        assertTrue(logged("the retry cost no upstream turn", mark), lines.drop(mark).joinToString())
         assertTrue(waitFor(5_000) { logged("compaction answer replayed") }, lines.joinToString())
         assertTrue(waitFor(5_000) { gate.snapshot().inflight == 0 }, "the replay releases its own slot")
     }

--- a/gateway/gateway/src/test/kotlin/head/HeadServerLocalAnswerTest.kt
+++ b/gateway/gateway/src/test/kotlin/head/HeadServerLocalAnswerTest.kt
@@ -1,0 +1,147 @@
+// NEW (2026-09-05): Claude Code's activity side query is answered by the head itself — through the
+// REAL production path (HeadServer over HTTP, both response shapes) — and the upstream never sees it.
+package head
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import kotlinx.coroutines.runBlocking
+import mock.MockChatGptUpstream
+import mock.awaitListening
+import mock.freshPort
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import splice.core.auth.AuthDescription
+import splice.core.auth.Credentials
+import splice.core.auth.RefreshableAuthProvider
+import splice.core.model.ModelCatalog
+import splice.core.model.ModelEntry
+import splice.core.turn.ReasoningDisplay
+import splice.core.turn.WatchdogBudget
+import splice.gateway.compact.CompactStats
+import splice.gateway.compact.ShadowClassifier
+import splice.gateway.head.HeadDeps
+import splice.gateway.head.HeadServer
+import splice.gateway.perf.PerfStats
+import splice.gateway.usage.UsageStore
+import splice.provider.codex.CodexProvider
+import splice.spi.InflightGate
+import splice.spi.ProviderTuning
+import splice.spi.UpstreamClient
+import java.nio.file.Files
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.Duration.Companion.seconds
+
+private class LocalAnswerAuth : RefreshableAuthProvider {
+    override suspend fun credentials(): Credentials = Credentials.Bearer("tok-la", "acct-la")
+    override suspend fun refresh(): Credentials = credentials()
+    override suspend fun describe(): AuthDescription = AuthDescription(true, "fake")
+}
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class HeadServerLocalAnswerTest {
+
+    private val mock = MockChatGptUpstream()
+    private val port = freshPort()
+    private val lines = CopyOnWriteArrayList<String>()
+    private lateinit var head: HeadServer
+    private val client = HttpClient(CIO) {
+        defaultRequest { bearerAuth("test-inference-token") }
+    }
+
+    @BeforeAll
+    fun setUp() = runBlocking {
+        val tmp = Files.createTempDirectory("head-local-answer")
+        head = HeadServer(
+            provider = CodexProvider(
+                tuning = ProviderTuning(
+                    key = "codex",
+                    label = "claudex",
+                    catalog = ModelCatalog(
+                        discoveryPrefix = "claude-codex--",
+                        models = listOf(ModelEntry("gpt-5.6-sol", "Sol", contextWindow = 272_000)),
+                        defaultContextWindow = 272_000,
+                    ),
+                    pinnedModel = "gpt-5.6-sol",
+                    auth = LocalAnswerAuth(),
+                    baseUrl = mock.baseUrl,
+                    watchdog = WatchdogBudget(20.seconds, 20.seconds, 30.seconds),
+                ),
+                showReasoning = ReasoningDisplay.TEXT,
+                replayReasoning = false,
+                configEffort = "high",
+                configSummary = "detailed",
+            ),
+            listenPort = port,
+            deps = HeadDeps(
+                upstream = UpstreamClient(firstByteTimeoutMs = 20_000, totalTimeoutMs = 30_000, maxRetries = 1),
+                inferenceToken = "test-inference-token",
+                gate = InflightGate({ 0 }),
+                shadow = ShadowClassifier(log = {}),
+                compactStats = CompactStats(tmp.resolve("compact.jsonl")),
+                usageStore = UsageStore(tmp.resolve("usage.json"), tmp.resolve("ratelimit.json")),
+                perfStats = PerfStats(tmp.resolve("perf.jsonl")),
+                log = { lines += it },
+            ),
+        )
+        head.start()
+        awaitListening(port)
+    }
+
+    @AfterAll
+    fun tearDown() = runBlocking {
+        head.stop()
+        mock.stop()
+        client.close()
+    }
+
+    // The transcript's last tool call is a Read; the last user message is the side query verbatim.
+    private fun body(stream: Boolean) =
+        """{"model":"claude-codex--gpt-5.6-sol","stream":$stream,"max_tokens":64,""" +
+            """"system":"You are a test.","messages":[{"role":"user","content":"fix it"},""" +
+            """{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Read",""" +
+            """"input":{"file_path":"/repo/src/runAgent.ts"}}]},""" +
+            """{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":"ok"}]},""" +
+            """{"role":"user","content":"Describe your most recent action in 3-5 words using present tense """ +
+            """(-ing). Name the file or function, not the branch. Do not use tools."}]}"""
+
+    private suspend fun post(stream: Boolean): String =
+        client.post("http://127.0.0.1:$port/v1/messages") {
+            header("Content-Type", "application/json")
+            header("x-claude-code-session-id", "sess-label")
+            setBody(body(stream))
+        }.bodyAsText()
+
+    @Test
+    fun `the streamed side query gets a one-block end_turn answer and upstream sees nothing`() = runBlocking {
+        val before = mock.upstreamBodies.size
+        val sse = post(stream = true)
+        assertTrue(sse.contains("event: message_start"), sse)
+        assertTrue(sse.contains("Reading runAgent.ts"), sse)
+        assertTrue(sse.contains("\"stop_reason\":\"end_turn\""), sse)
+        assertTrue(sse.contains("event: message_stop"), sse)
+        assertEquals(before, mock.upstreamBodies.size, "no upstream turn may happen for the side query")
+        assertTrue(
+            lines.any { it.contains("activity label answered locally: \"Reading runAgent.ts\"") },
+            lines.joinToString(),
+        )
+    }
+
+    @Test
+    fun `the non-stream side query gets the same answer as one JSON body`() = runBlocking {
+        val before = mock.upstreamBodies.size
+        val json = post(stream = false)
+        assertTrue(json.contains("\"text\":\"Reading runAgent.ts\""), json)
+        assertTrue(json.contains("\"stop_reason\":\"end_turn\""), json)
+        assertEquals(before, mock.upstreamBodies.size, "no upstream turn may happen for the side query")
+    }
+}

--- a/gateway/gateway/src/test/kotlin/head/HeadServerLocalAnswerTest.kt
+++ b/gateway/gateway/src/test/kotlin/head/HeadServerLocalAnswerTest.kt
@@ -129,6 +129,10 @@ class HeadServerLocalAnswerTest {
         assertTrue(sse.contains("Reading runAgent.ts"), sse)
         assertTrue(sse.contains("\"stop_reason\":\"end_turn\""), sse)
         assertTrue(sse.contains("event: message_stop"), sse)
+        // Wire-exact beyond the text (review of PR 137): the usage block the HUD reads and an id in
+        // the shape the client parses (MessageIds), pinned as presence and shape, not values.
+        assertTrue(sse.contains("\"usage\":"), "the synthesized answer must carry a usage block: $sse")
+        assertTrue(MESSAGE_ID.containsMatchIn(sse), "the message id must match the shape the client parses: $sse")
         assertEquals(before, mock.upstreamBodies.size, "no upstream turn may happen for the side query")
         assertTrue(
             lines.any { it.contains("activity label answered locally: \"Reading runAgent.ts\"") },
@@ -142,6 +146,10 @@ class HeadServerLocalAnswerTest {
         val json = post(stream = false)
         assertTrue(json.contains("\"text\":\"Reading runAgent.ts\""), json)
         assertTrue(json.contains("\"stop_reason\":\"end_turn\""), json)
+        assertTrue(json.contains("\"usage\":"), "the synthesized answer must carry a usage block: $json")
+        assertTrue(MESSAGE_ID.containsMatchIn(json), "the message id must match the shape the client parses: $json")
         assertEquals(before, mock.upstreamBodies.size, "no upstream turn may happen for the side query")
     }
 }
+
+private val MESSAGE_ID = Regex("\"id\":\"msg_[0-9]+_[0-9]+\"")

--- a/gateway/provider-codex/src/main/kotlin/splice/provider/codex/CodexProvider.kt
+++ b/gateway/provider-codex/src/main/kotlin/splice/provider/codex/CodexProvider.kt
@@ -1,11 +1,13 @@
 // NEW: the codex Provider — the shared openai-responses base (ResponsesProvider) with codex quirks
 // (chatgpt-oauth, account_id header, first-message-hash cache key, max effort ceiling, summary
 // supported, spark drops summary). The reasoning-policy wiring lives in the base; this class adds
-// ONLY the ChatGPT-Account-ID header and the codex quirk profile.
+// ONLY the ChatGPT-Account-ID header, codex-rs's per-turn routing/session headers
+// (CodexRoutingHeaders) and the codex quirk profile.
 package splice.provider.codex
 
 import splice.core.auth.Credentials
 import splice.core.turn.ReasoningDisplay
+import splice.core.turn.TurnMeta
 import splice.core.util.DaemonLog
 import splice.core.util.LogSink
 import splice.dialect.responses.FoldConfig
@@ -32,6 +34,11 @@ public class CodexProvider(
      *  (gateway/spikes/results/responses-websocket.md): handshake, event vocabulary and
      *  previous_response_id chaining all confirmed. No other Responses upstream has been probed. */
     override val supportsWebSocket: Boolean = true
+
+    private val routing = CodexRoutingHeaders()
+
+    /** codex-rs's per-turn routing/session headers — the measurement is in CodexRoutingHeaders. */
+    override fun perTurnHeaders(meta: TurnMeta): Map<String, String> = routing.forTurn(meta)
 
     override fun extraHeaders(creds: Credentials): Map<String, String> = buildMap {
         put("Accept", "text/event-stream")

--- a/gateway/provider-codex/src/main/kotlin/splice/provider/codex/CodexRoutingHeaders.kt
+++ b/gateway/provider-codex/src/main/kotlin/splice/provider/codex/CodexRoutingHeaders.kt
@@ -1,0 +1,39 @@
+// NEW: the per-turn routing/session headers codex-rs sends on every request (2026-09-05), so a
+// splice turn lands where its predecessors did and reads the prompt cache warm.
+//
+// Measured before this file existed (claudex perf JSONL, 2026-09-05): a session's first turn after
+// a reconnect read 12-21% of its prompt from the cache and its second 99% — same bytes, same
+// prompt_cache_key, a different backend replica. The cache is routed by the key AND by connection
+// locality, and codex-rs pins that locality with headers splice never sent: `session-id` and
+// `thread-id` (codex-rs `build_session_headers`; the underscore spellings were dropped 2026-05-13)
+// and `x-codex-routing-hint` (`model=<model>`, codex backend only). They ride BuiltTurn.extraHeaders,
+// so the SSE POST and the WS handshake carry them alike; the WS-only `x-client-request-id` is
+// derived from `thread-id` at the handshake (ResponsesWsRunner). Because per-turn headers are part
+// of the WS connection identity, they are CONSTANT for a session: the thread id derives from the
+// session id, not the conversation, so a compaction (a new first message, a new chain) keeps the
+// same affinity for the system-prompt + tool prefix the two conversations share.
+package splice.provider.codex
+
+import splice.core.turn.TurnMeta
+import java.util.UUID
+
+internal class CodexRoutingHeaders {
+
+    /** No session id (a bare curl, the e2e probe) = the routing hint alone. */
+    fun forTurn(meta: TurnMeta): Map<String, String> = buildMap {
+        put(HEADER_ROUTING_HINT, "model=${meta.upstreamModel}")
+        val session = meta.sessionId?.takeIf { it.isNotBlank() } ?: return@buildMap
+        put(HEADER_SESSION_ID, session)
+        put(HEADER_THREAD_ID, threadIdFor(session))
+    }
+
+    /** codex-rs sends a UUID; a name-based UUID over the session id is one the backend cannot tell
+     *  apart from it, stable for the session's life, and never shared by two sessions. */
+    private fun threadIdFor(session: String): String =
+        UUID.nameUUIDFromBytes("$THREAD_NAMESPACE:$session".toByteArray(Charsets.UTF_8)).toString()
+}
+
+private const val HEADER_SESSION_ID = "session-id"
+private const val HEADER_THREAD_ID = "thread-id"
+private const val HEADER_ROUTING_HINT = "x-codex-routing-hint"
+private const val THREAD_NAMESPACE = "splice-thread"

--- a/gateway/provider-codex/src/test/kotlin/CodexProviderTest.kt
+++ b/gateway/provider-codex/src/test/kotlin/CodexProviderTest.kt
@@ -103,6 +103,18 @@ class CodexProviderTest {
     }
 
     @Test
+    fun `a built turn carries codex-rs's session, thread and routing headers for its session`() {
+        val codex = provider(accountIdHeader = false)
+        val built = codex.buildTurn(deferrableTurnBody(), compact = false, sessionId = "s1")
+        assertEquals("s1", built.extraHeaders["session-id"])
+        assertEquals("model=${built.meta.upstreamModel}", built.extraHeaders["x-codex-routing-hint"])
+        assertTrue(built.extraHeaders.containsKey("thread-id"), built.extraHeaders.toString())
+        // Same session, a compaction: the same three values (the WS connection key must not churn).
+        val compact = codex.buildTurn(deferrableTurnBody(), compact = true, sessionId = "s1")
+        assertEquals(built.extraHeaders["thread-id"], compact.extraHeaders["thread-id"])
+    }
+
+    @Test
     fun `codex production profile emits empty instructions on lite turns`() {
         val built = provider(accountIdHeader = false).buildTurn(
             deferrableTurnBody(),

--- a/gateway/provider-codex/src/test/kotlin/CodexRoutingHeadersTest.kt
+++ b/gateway/provider-codex/src/test/kotlin/CodexRoutingHeadersTest.kt
@@ -1,0 +1,55 @@
+// NEW (2026-09-05): the codex routing/session headers — a reconnect must read the prompt cache warm,
+// and the set must be constant for a session so the WS connection key never churns on it.
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import splice.core.turn.ReasoningDisplay
+import splice.core.turn.TurnMeta
+import splice.provider.codex.CodexRoutingHeaders
+
+class CodexRoutingHeadersTest {
+
+    private val routing = CodexRoutingHeaders()
+
+    private fun meta(session: String?, conversation: String? = "conv-1") = TurnMeta(
+        compact = false,
+        showReasoning = ReasoningDisplay.TEXT,
+        stream = true,
+        originalModel = "claude-codex--gpt-5.6-sol",
+        upstreamModel = "gpt-5.6",
+        clientMaxTokens = null,
+        effort = "high",
+        summary = null,
+        budgetTokens = null,
+        conversationKey = conversation,
+        sessionId = session,
+    )
+
+    @Test
+    fun `a session's turns carry the session id, a uuid thread id and the model routing hint`() {
+        val headers = routing.forTurn(meta("sess-a"))
+        assertEquals("sess-a", headers["session-id"])
+        assertEquals("model=gpt-5.6", headers["x-codex-routing-hint"])
+        val uuid = Regex("[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}")
+        assertTrue(headers.getValue("thread-id").matches(uuid), headers.toString())
+        assertEquals(3, headers.size, headers.toString())
+    }
+
+    @Test
+    fun `the set is constant across a session's conversations - a compaction keeps its affinity`() {
+        assertEquals(routing.forTurn(meta("sess-a", "conv-1")), routing.forTurn(meta("sess-a", "conv-2")))
+    }
+
+    @Test
+    fun `two sessions never share a thread id`() {
+        assertNotEquals(routing.forTurn(meta("sess-a"))["thread-id"], routing.forTurn(meta("sess-b"))["thread-id"])
+    }
+
+    @Test
+    fun `no session id means the routing hint alone`() {
+        val hintOnly = mapOf("x-codex-routing-hint" to "model=gpt-5.6")
+        assertEquals(hintOnly, routing.forTurn(meta(null)))
+        assertEquals(hintOnly, routing.forTurn(meta("  ")))
+    }
+}

--- a/gateway/provider-grok/src/main/kotlin/splice/provider/grok/GrokProvider.kt
+++ b/gateway/provider-grok/src/main/kotlin/splice/provider/grok/GrokProvider.kt
@@ -6,6 +6,7 @@
 package splice.provider.grok
 
 import splice.core.turn.ReasoningDisplay
+import splice.core.turn.TurnMeta
 import splice.core.util.DaemonLog
 import splice.core.util.LogSink
 import splice.dialect.responses.CacheKeyStrategy
@@ -29,8 +30,8 @@ public class GrokProvider(
     // Grok Build sets both the body prompt_cache_key AND x-grok-conv-id for sticky routing. The
     // header rides the PER-TURN BuiltTurn (via the base's perTurnHeaders hook) — a shared provider
     // field raced concurrent sessions into each other's affinity header (audit 2026-07-18).
-    override fun perTurnHeaders(sessionId: String?): Map<String, String> =
-        sessionId?.takeIf { it.isNotEmpty() }?.let { mapOf("x-grok-conv-id" to it) } ?: emptyMap()
+    override fun perTurnHeaders(meta: TurnMeta): Map<String, String> =
+        meta.sessionId?.takeIf { it.isNotEmpty() }?.let { mapOf("x-grok-conv-id" to it) } ?: emptyMap()
 }
 
 /** Holder for the grok quirk profile. A class rather than a static namespace so the profile is


### PR DESCRIPTION
## Why

Three things a day of Codex sessions on splice showed (2026-09-05), plus one credential rule the operator set.

- **Compactions cut off by the client.** Claude Code abandons an auto-compaction at 600 s (a hard client constant, not `API_TIMEOUT_MS`) and retries the same bytes minutes later. Astra compactions run 5-10 minutes, so 7 of the day's 78 were cancelled upstream at 600 s and re-run cold.
- **A side query burning tokens.** Every 30 s during a subagent turn the client re-sends the whole transcript asking for a 3-5 word present-tense activity label: 294M input tokens in a day at 48% cache hit, for text nobody reads twice.
- **Cold reconnects.** Turns after a WebSocket reconnect read the prompt cache cold; codex-rs sends session/thread/routing headers splice did not.
- **Shared credentials.** The codex head read `~/.codex/auth.json`, the same file codex-cli and the ChatGPT desktop app refresh. An OpenAI-style refresh rotates the refresh token, so each side signed the other out; one rotation left the head with "no upstream credentials" for 16 s (24 failed turns). Operator law: native apps and splice heads keep separate credentials, and may be separate accounts.

## What

- **A compaction outlives its client.** A compact stream turn drives on a scope the call's cancellation cannot reach and records its frames (`FrameRecording`); a lost client detaches the channel, the turn finishes, and the byte-identical retry is served from the recording or follows the live turn (`CompactionReplay`, keyed on session + body hash, 2 h TTL). Slot and recording are settled by the drive's own `finally`. A head stop ends compactions still driving; the scope survives a restart (the first cut cancelled it: the first compaction after a stop-start came back empty with a leaked slot, pinned by a regression test).
- **The activity-label side query is answered locally** (`ActivityLabel`, `LocalResponses`): recognised by its prompt, answered from the transcript's last tool call, no upstream turn.
- **codex-rs headers ride every turn**: `session-id`, `thread-id`, `x-codex-routing-hint`, and `x-client-request-id` on the WebSocket handshake (`CodexRoutingHeaders`, a `perTurnHeaders` hook on the Responses provider; grok's conv id moves onto the same hook).
- **Learned client windows persist** per head (`<head>-client-windows.json`), so the first turn after a restart is scaled right. A rejected request body logs its byte counts and failure class.
- **Every OAuth head signs in on its own credential file.** `chatgpt-oauth`, `grok-oauth`, `kimi-oauth` default to `~/.config/splice/auth/{codex,grok,kimi}.json`, written by `splice login <head>`; the apps' files are used only when `auth.file` names one. The auth-kind registry is the single source (splice-owned `authFile` plus the native app's file per kind); the `CODEX_AUTH_PATH` / `GROK_AUTH_PATH` knobs reference it; the login command and the kimi and openai-chat arms resolve through it. `splice doctor` warns on a config that still names an app's file, with the exact fix. README, example config and CHANGELOG updated.

## Verified

- Standalone tree (HEAD + this diff): 1201 module tests, 0 failed; detekt and the ast-grep walls clean; oracle replay 11/11 byte-match; CX-19 wall green; ledger floor OK.
- Red-green: the stop-start compaction regression test failed on the old scope handling and passes now; the registry-default test fails on any native-file default.
- Live 2026-09-05: side-query answered locally within minutes of install (0 upstream rows for it since); persisted windows restored after restart; a compaction cut by a restart continued detached and was held for its retry; all three heads signed in on splice-owned files, doctor clean.

Stacked on #136 (base `fix/compaction-is-a-turn`). The code-mode work in the same checkout is deliberately not in this PR and comes separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
