### PR TITLE
fix(code-mode): measure history on the conversation and degrade instead of refusing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 ## splice v0.3.1 — silent-stream reliability and the code-mode beta - 2026-09-06
 
+### Fixed
+- **Code mode no longer refuses a conversation whose environment moved.** A completed script's
+  history baseline is now measured on the conversation alone; the lite preamble (the eager tool
+  list and the base instructions) is excluded. Claude Code grows its tool list mid-conversation
+  (ToolSearch loading a deferred schema, an MCP reconnect), and one such growth after a completed
+  script made every later Astra/Sol turn fail with `code-mode logical history does not match its
+  persisted baseline` until the session compacted. The same growth during a script's own resume
+  turn was misread as new user content and interrupted the script.
+- **History that cannot be placed degrades instead of failing.** A record that no longer lines up,
+  a record past its 24-hour retention, a result from another session or model, or a running script
+  whose history moved underneath it now continues upstream on the client's own history, where its
+  client calls are ordinary tool calls. Each degradation logs once per conversation under
+  `[<head>][code-mode]`. Persisted records from 0.3.1 carry the old measurement and are omitted the
+  same way, so an already-stuck conversation recovers on its next turn.
+
 ### Added
 - **Default-off JavaScript code mode for ChatGPT providers.** Set `code_mode = true` in a
   `chatgpt-oauth` + `openai-responses` provider's quirks to enable the bundled GraalJS runner and

--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ code_mode = true # beta; false or omitted disables both runner and guidance
 
 Enabling it automatically appends orchestration guidance to the caller's instructions and exposes splice's bundled JavaScript runner on eligible GPT-6 Astra/Sol turns. Compaction, toolless turns, and forced named-tool choices keep the ordinary path. Direct tools remain available; all real operations use Claude Code's permission-checked client handlers. No Codex or Node installation is required. Child JVMs bound workers, time, and heap and deny guest host/I/O access; Graal community is not an OS-hardened sandbox against same-user attackers.
 
+If a completed script's history can no longer be placed (the record aged out, the session switched model, the conversation moved underneath a running script), splice sends the client's own history upstream instead, where the script's client calls are ordinary tool calls, and logs one `[code-mode]` line for the head. The conversation continues; only that script's batching is lost from the model's view.
+
 Every head using that provider shares the setting. Topology is read only when the daemon boots: finish ongoing work, edit TOML, then run `splice restart` for a **full daemon restart**. A head restart alone does not reload TOML. Finish code-mode work before toggling or restarting: pending JavaScript execution cannot survive a daemon restart, and splice never reruns the lost source automatically.
 
 In a bounded real-Astra test on synthetic tasks, guidance improved batching without reducing graded correctness. That is not a guarantee of better output or less redundant investigation on arbitrary projects; the feature remains beta.

--- a/gateway/app/src/main/kotlin/splice/app/provider/ResponsesArm.kt
+++ b/gateway/app/src/main/kotlin/splice/app/provider/ResponsesArm.kt
@@ -85,6 +85,7 @@ internal class ResponsesArm(
                 CodeModeBridgeConfig(
                     runtime = JvmCodeModeRuntime(),
                     stateFile = statePaths.stateDir.resolve("${ctx.key}-code-mode.json"),
+                    log = HeadScopedLogs.headScopedLog(ctx.key, log),
                 ),
             )
         } else {

--- a/gateway/provider-codex/src/main/kotlin/splice/provider/codex/CodexCodeModeBridge.kt
+++ b/gateway/provider-codex/src/main/kotlin/splice/provider/codex/CodexCodeModeBridge.kt
@@ -4,6 +4,7 @@ package splice.provider.codex
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import splice.core.turn.GatewayCustomCall
+import splice.core.util.LogSink
 import splice.spi.CodeModeResult
 import splice.spi.CodeModeRuntime
 import splice.spi.RoundInterceptor
@@ -25,6 +26,8 @@ public data class CodeModeBridgeConfig(
     val maxCalls: Int = 64,
     val maxRounds: Int = 32,
     val clock: Clock = Clock.systemUTC(),
+    /** Head-scoped sink for history-degradation lines; uninstalled it is a no-op. */
+    val log: LogSink = LogSink { },
 )
 
 /** Codex-only protocol bridge. It schedules client tools but never executes them. */
@@ -38,13 +41,13 @@ public class CodexCodeModeBridge(private val config: CodeModeBridgeConfig) {
     )
 
     private val json = Json { encodeDefaults = true }
-    private val wire = CodexCodeModeWire(json)
+    private val wire = CodexCodeModeWire(json, config.log)
     private val registry = CodexCodeModeRegistry(config, json)
     private val validation = CodexCodeModeValidation(config)
     private val machine = CodexCodeModeMachine(config, registry, validation)
     private val driver = CodexCodeModeDriver(config, registry, wire, validation, machine)
     private val resume = CodexCodeModeResume(registry, wire, validation, machine, driver)
-    private val controller = CodexCodeModeTurn(registry, wire, driver, resume)
+    private val controller = CodexCodeModeTurn(registry, wire, driver, resume, config.log)
 
     init {
         require(config.maxRecords > 0) { "code-mode maxRecords must be positive" }

--- a/gateway/provider-codex/src/main/kotlin/splice/provider/codex/CodexCodeModeHistory.kt
+++ b/gateway/provider-codex/src/main/kotlin/splice/provider/codex/CodexCodeModeHistory.kt
@@ -15,7 +15,7 @@ internal class CodexCodeModeHistory(json: Json) {
 
     fun hasExtraContent(bodyJson: String, record: CodeModeRecord): Boolean {
         val input = codec.root(bodyJson)?.second ?: return true
-        val projected = codec.projection.project(input)
+        val projected = codec.conversation(codec.projection.project(input)).body
         val validBaseline = codec.validFullPrefix(input, record) ||
             codec.validPrefix(projected.logicalItems, record)
         if (!validBaseline) return true
@@ -39,24 +39,33 @@ internal class CodexCodeModeHistory(json: Json) {
         return logicalExtra || replayExtra
     }
 
+    /**
+     * Rewrites every completed record it can still place. A record whose baseline no longer matches
+     * is OMITTED, never fatal: its client calls stay in the history as the ordinary tool calls the
+     * client already saw, which is the pre-code-mode wire shape. Records after an omitted one were
+     * measured on top of its canonical items, so they omit too; the caller logs each omission.
+     */
     fun canonicalize(bodyJson: String, records: List<CodeModeRecord>): CodeModeRewrite {
         val root = codec.root(bodyJson)
             ?: return CodeModeRewrite(null, "code mode requires a Responses input array")
-        var input = codec.projection.project(root.second)
+        val conversation = codec.conversation(codec.projection.project(root.second))
+        var body = conversation.body
+        val omitted = mutableListOf<CodeModeOmission>()
         records.forEach { record ->
-            val rewritten = canonicalizeRecord(input, record)
-            rewritten.error?.let { return CodeModeRewrite(null, it) }
-            input = checkNotNull(rewritten.input)
+            val rewritten = canonicalizeRecord(body, record)
+            val error = rewritten.error
+            if (error == null) body = checkNotNull(rewritten.input) else omitted += CodeModeOmission(record, error)
         }
-        return codec.rebuilt(root.first, input)
+        return codec.rebuilt(root.first, conversation, body).copy(omitted = omitted)
     }
 
     fun restoreBaseline(bodyJson: String, record: CodeModeRecord): CodeModeRewrite {
         val root = codec.root(bodyJson)
             ?: return CodeModeRewrite(null, "code mode requires a Responses input array")
-        val restored = restoreProjected(codec.projection.project(root.second), record)
+        val conversation = codec.conversation(codec.projection.project(root.second))
+        val restored = restoreProjected(conversation.body, record)
         return restored.error?.let { CodeModeRewrite(null, it) }
-            ?: codec.rebuilt(root.first, checkNotNull(restored.input))
+            ?: codec.rebuilt(root.first, conversation, checkNotNull(restored.input))
     }
 
     private fun restoreProjected(input: ResponsesCodeModeInput, record: CodeModeRecord): ProjectedRewrite {

--- a/gateway/provider-codex/src/main/kotlin/splice/provider/codex/CodexCodeModeHistoryCodec.kt
+++ b/gateway/provider-codex/src/main/kotlin/splice/provider/codex/CodexCodeModeHistoryCodec.kt
@@ -12,21 +12,39 @@ import splice.dialect.responses.ResponsesCodeModeInput
 import splice.dialect.responses.ResponsesCodeModeProjection
 import java.security.MessageDigest
 
+/**
+ * Every persisted count, digest and offset is CONVERSATION-relative: the lite preamble (the leading
+ * developer-role items — `additional_tools` and the base instructions) is split off before a record
+ * is measured and put back after a rewrite. The preamble is environment, not history: Claude Code
+ * grows its tool list mid-conversation (ToolSearch loading a deferred schema, an MCP server
+ * reconnecting) and its system prompt moves too. The 2026-09-07 live failure was two sessions whose
+ * tool count went 35 -> 36 one turn after a completed script; the whole-input digest then refused
+ * every later turn with "logical history does not match its persisted baseline".
+ */
 internal class CodexCodeModeHistoryCodec(private val json: Json) {
     val projection = ResponsesCodeModeProjection()
 
     fun inputBoundary(bodyJson: String): CodeModeInputBoundary? {
         val input = root(bodyJson)?.second ?: return null
-        val projected = projection.project(input)
+        val rawBody = input.dropWhile(::isPreamble)
+        val body = conversation(projection.project(input)).body
         return CodeModeInputBoundary(
-            fullCount = input.size,
-            logicalCount = projected.logicalItems.size,
-            logicalDigest = digest(JsonArray(projected.logicalItems).toString()),
-            fullDigest = digest(input.toString()),
-            nativeSegments = projected.nativeSegments.map {
+            fullCount = rawBody.size,
+            logicalCount = body.logicalItems.size,
+            logicalDigest = digest(JsonArray(body.logicalItems).toString()),
+            fullDigest = digest(JsonArray(rawBody).toString()),
+            nativeSegments = body.nativeSegments.map {
                 CodeModeNativeSegment(it.logicalOffset, it.items)
             },
         )
+    }
+
+    /** Splits the projected input into its lite preamble and the conversation the records measure. */
+    fun conversation(input: ResponsesCodeModeInput): CodeModeConversation {
+        val preamble = input.logicalItems.takeWhile(::isPreamble)
+        val offset = preamble.size
+        val replay = input.replayItems.map { it.copy(logicalOffset = maxOf(0, it.logicalOffset - offset)) }
+        return CodeModeConversation(preamble, ResponsesCodeModeInput(input.logicalItems.drop(offset), replay))
     }
 
     fun validPrefix(items: List<JsonElement>, record: CodeModeRecord): Boolean {
@@ -35,12 +53,19 @@ internal class CodexCodeModeHistoryCodec(private val json: Json) {
     }
 
     fun validFullPrefix(input: JsonArray, record: CodeModeRecord): Boolean {
-        if (input.size < record.baselineInputCount) return false
-        return digest(JsonArray(input.take(record.baselineInputCount)).toString()) == record.baselineInputDigest
+        val rawBody = input.dropWhile(::isPreamble)
+        if (rawBody.size < record.baselineInputCount) return false
+        return digest(JsonArray(rawBody.take(record.baselineInputCount)).toString()) == record.baselineInputDigest
     }
 
-    fun rebuilt(root: JsonObject, input: ResponsesCodeModeInput): CodeModeRewrite =
-        CodeModeRewrite(JsonObject(root + (FIELD_INPUT to projection.rebuild(input))).toString())
+    fun rebuilt(root: JsonObject, conversation: CodeModeConversation, body: ResponsesCodeModeInput): CodeModeRewrite {
+        val offset = conversation.preamble.size
+        val joined = ResponsesCodeModeInput(
+            conversation.preamble + body.logicalItems,
+            body.replayItems.map { it.copy(logicalOffset = it.logicalOffset + offset) },
+        )
+        return CodeModeRewrite(JsonObject(root + (FIELD_INPUT to projection.rebuild(joined))).toString())
+    }
 
     fun root(bodyJson: String): Pair<JsonObject, JsonArray>? {
         val root = json.parseToJsonElement(bodyJson) as? JsonObject ?: return null
@@ -59,15 +84,28 @@ internal class CodexCodeModeHistoryCodec(private val json: Json) {
 
     fun string(item: JsonObject?, key: String): String = JsonScalars.str(item, key).orEmpty()
 
+    private fun isPreamble(element: JsonElement): Boolean {
+        val item = element as? JsonObject ?: return false
+        return string(item, FIELD_ROLE) == ROLE_DEVELOPER && string(item, FIELD_CALL_ID).isEmpty()
+    }
+
     private fun digest(value: String): String = MessageDigest.getInstance("SHA-256")
         .digest(value.toByteArray())
         .joinToString("") { "%02x".format(it) }
 }
 
+/** The lite preamble a request arrived with, and the conversation body every record is measured on. */
+internal data class CodeModeConversation(
+    val preamble: List<JsonElement>,
+    val body: ResponsesCodeModeInput,
+)
+
 internal const val CODE_MODE_FIELD_CALL_ID = "call_id"
 internal const val CODE_MODE_FIELD_TYPE = "type"
 private const val FIELD_INPUT = "input"
 private const val FIELD_OUTPUT = "output"
+private const val FIELD_ROLE = "role"
+private const val ROLE_DEVELOPER = "developer"
 private const val FIELD_CALL_ID = CODE_MODE_FIELD_CALL_ID
 private const val FIELD_TYPE = CODE_MODE_FIELD_TYPE
 private const val TYPE_CUSTOM_OUTPUT = "custom_tool_call_output"

--- a/gateway/provider-codex/src/main/kotlin/splice/provider/codex/CodexCodeModeState.kt
+++ b/gateway/provider-codex/src/main/kotlin/splice/provider/codex/CodexCodeModeState.kt
@@ -80,14 +80,14 @@ internal data class CodeModeRecordSnapshot(
         source = source,
         phase = when {
             phase == CodeModePhase.ACTIVE -> CodeModePhase.LOST
-            metadataVersion != CODE_MODE_METADATA_VERSION -> CodeModePhase.LOST
+            staleMetadata() -> CodeModePhase.LOST
             else -> phase
         },
         pending = pending.toMutableList(),
         results = results.mapValues { (id, value) -> value.restore(id) }.toMutableMap(),
         output = output,
         error = when {
-            metadataVersion != CODE_MODE_METADATA_VERSION ->
+            staleMetadata() ->
                 "code-mode replay metadata is unavailable; source was not rerun"
             phase == CodeModePhase.ACTIVE ->
                 "code-mode process state was lost after completed client calls: ${results.keys}; source was not rerun"
@@ -106,6 +106,11 @@ internal data class CodeModeRecordSnapshot(
         continuity = continuity,
         continuityReplay = continuityReplay,
     )
+
+    /** A completed record with old metadata is still terminal — the rewrite omits it (and logs) rather
+     *  than refusing the conversation; only an unfinished one has nothing left to resume. */
+    private fun staleMetadata(): Boolean =
+        metadataVersion != CODE_MODE_METADATA_VERSION && phase != CodeModePhase.COMPLETED
 }
 
 internal data class CodeModeRecord(

--- a/gateway/provider-codex/src/main/kotlin/splice/provider/codex/CodexCodeModeTurn.kt
+++ b/gateway/provider-codex/src/main/kotlin/splice/provider/codex/CodexCodeModeTurn.kt
@@ -6,12 +6,15 @@ import kotlinx.coroutines.sync.withLock
 import splice.core.turn.ErrorType
 import splice.core.turn.GatewayCustomCall
 import splice.core.turn.TurnOutcome
+import splice.core.util.LogSink
 import splice.spi.CodeModeResult
 import splice.spi.InterceptedRoundPost
 import splice.spi.WireSink
 import java.security.MessageDigest
+import java.util.concurrent.ConcurrentHashMap
 
 private const val CODE_MODE_LOCK_STRIPES: Int = 64
+private const val RECORD_ID_LOG_CHARS: Int = 8
 
 internal data class CodeModeRunInput(
     val turn: CodexCodeModeBridge.Turn,
@@ -31,14 +34,25 @@ internal data class CodeModeRunContext(
     val post: InterceptedRoundPost,
 )
 
+/**
+ * History that no longer lines up with a record is DEGRADED, never refused. The status quo before
+ * code mode was "send the history the client sent", and the client's history is always a valid one:
+ * the owned callbacks are real tool calls with real outputs. A refusal instead turns any false
+ * positive (a grown tool list, a model switch, a record past its TTL) into a dead conversation with
+ * no way out but compaction — which is what happened live on 2026-09-07.
+ */
 internal class CodexCodeModeTurn(
     private val registry: CodexCodeModeRegistry,
     private val wire: CodexCodeModeWire,
     private val driver: CodexCodeModeDriver,
     private val resume: CodexCodeModeResume,
+    private val log: LogSink,
 ) {
     private val identity = CodexCodeModeIdentity()
     private val locks = List(CODE_MODE_LOCK_STRIPES) { Mutex() }
+
+    /** Conversation-scoped notes already logged — one line per conversation, not one per turn. */
+    private val announced: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
     suspend fun run(input: CodeModeRunInput): TurnOutcome {
         val key = identity.turnKey(input.turn)
@@ -65,48 +79,81 @@ internal class CodexCodeModeTurn(
         initialOuter: GatewayCustomCall?,
         bodyJson: String,
     ): TurnOutcome {
+        historyNotes(context.turn, context.key, context.digest)
+            .filter { announced.add("${context.key}|$it") }
+            .forEach { log("[code-mode] $it") }
         val completed = registry.completed(context.key)
-        val historyFailure = historyFailure(context.turn, context.key, context.digest)
-        val resultIds = context.turn.toolResults.map(CodeModeResult::id).toSet()
-        val owner = registry.owner(context.key, context.digest, resultIds)
-        val replay = completed.any { it.lastDigest == context.digest }
         val completedHistory = wire.canonicalize(bodyJson, completed)
-        val rewritten = if (completedHistory.error == null && owner != null) {
-            wire.restoreBaseline(checkNotNull(completedHistory.bodyJson), owner)
-        } else {
-            completedHistory
-        }
-        val historyError = rewritten.error?.let(::failure)
-        val canonicalBody = rewritten.bodyJson
+        completedHistory.error?.let { return failure(it) }
+        val canonicalBody = checkNotNull(completedHistory.bodyJson)
+        val owner = placedOwner(context, canonicalBody)
         return when {
-            historyFailure != null -> historyFailure
-            historyError != null -> historyError
-            owner?.phase == CodeModePhase.ACTIVE -> resume.active(owner, context, checkNotNull(canonicalBody))
-            owner?.phase == CodeModePhase.LOST -> resume.lost(owner, context, checkNotNull(canonicalBody))
-            replay -> driver.drive(context, null, checkNotNull(canonicalBody), context.post(canonicalBody))
-            else -> driver.drive(context, initialOuter, checkNotNull(canonicalBody), context.post(canonicalBody))
+            owner != null -> resumeOwner(owner, context)
+            completed.any { it.lastDigest == context.digest } ->
+                driver.drive(context, null, canonicalBody, context.post(canonicalBody))
+            else -> driver.drive(context, initialOuter, canonicalBody, context.post(canonicalBody))
         }
     }
 
-    private fun historyFailure(
+    /** The active or lost owner whose baseline still places in this history, with that history
+     *  restored around it — or null when there is none, or when the one there was is abandoned. */
+    private fun placedOwner(context: CodeModeRunContext, canonicalBody: String): PlacedOwner? {
+        val resultIds = context.turn.toolResults.map(CodeModeResult::id).toSet()
+        val owner = registry.owner(context.key, context.digest, resultIds) ?: return null
+        val restored = wire.restoreBaseline(canonicalBody, owner)
+        val error = restored.error ?: return PlacedOwner(owner, checkNotNull(restored.bodyJson))
+        abandon(owner, error)
+        return null
+    }
+
+    private suspend fun resumeOwner(placed: PlacedOwner, context: CodeModeRunContext): TurnOutcome =
+        if (placed.record.phase == CodeModePhase.ACTIVE) {
+            resume.active(placed.record, context, placed.bodyJson)
+        } else {
+            resume.lost(placed.record, context, placed.bodyJson)
+        }
+
+    /** A running script whose history moved underneath it is abandoned: cell closed, evidence kept
+     *  on the LOST record, and the turn continues upstream on the client's own history. */
+    private fun abandon(owner: CodeModeRecord, error: String) {
+        registry.lose(owner, "code-mode history no longer places the running script: $error; source was not rerun")
+        log(
+            "[code-mode] abandoned record ${owner.id.take(RECORD_ID_LOG_CHARS)} (outer ${owner.outerCallId}): " +
+                "$error — continuing upstream on the client's history",
+        )
+    }
+
+    /** Diagnostics only. Each of these used to refuse the turn; none of them makes the client's
+     *  history invalid, so they are logged and the turn proceeds without a rewrite for those ids. */
+    private fun historyNotes(
         turn: CodexCodeModeBridge.Turn,
         key: String,
         digest: String,
-    ): TurnOutcome.Failure? {
+    ): List<String> {
         val resultIds = turn.toolResults.map(CodeModeResult::id).toSet()
         val foreign = registry.foreignResultOwner(key, resultIds)
         val unknown = registry.unknownBridgeResults(key, resultIds)
-        return when {
-            registry.expiredHistory(key, digest, resultIds) -> failure("expired code-mode history")
-            foreign != null -> failure("code-mode tool result belongs to another session or model")
-            unknown.isNotEmpty() -> failure("unknown or expired code-mode tool results: $unknown")
-            else -> null
+        return buildList {
+            if (registry.expiredHistory(key, digest, resultIds)) {
+                add("expired code-mode history for this conversation; its client calls stay ordinary tool calls")
+            }
+            if (foreign != null) {
+                add(
+                    "code-mode results in this history belong to another session or model " +
+                        "(record ${foreign.id.take(RECORD_ID_LOG_CHARS)}); they stay ordinary tool calls",
+                )
+            }
+            if (unknown.isNotEmpty()) {
+                add("unknown or expired code-mode tool results stay ordinary tool calls: $unknown")
+            }
         }
     }
 
     private fun failure(message: String): TurnOutcome.Failure =
         TurnOutcome.Failure(ErrorType.INVALID_REQUEST, message)
 }
+
+private data class PlacedOwner(val record: CodeModeRecord, val bodyJson: String)
 
 private class CodexCodeModeIdentity {
     fun turnKey(turn: CodexCodeModeBridge.Turn): String = digest(

--- a/gateway/provider-codex/src/main/kotlin/splice/provider/codex/CodexCodeModeWire.kt
+++ b/gateway/provider-codex/src/main/kotlin/splice/provider/codex/CodexCodeModeWire.kt
@@ -11,10 +11,15 @@ import kotlinx.serialization.json.put
 import splice.core.reasoning.ReasoningReplay
 import splice.core.turn.TurnOutcome
 import splice.core.util.JsonScalars
+import splice.core.util.LogSink
 import splice.dialect.responses.ResponsesCodeModeProjection
+import java.util.concurrent.ConcurrentHashMap
 
-internal class CodexCodeModeWire(private val json: Json) {
+internal class CodexCodeModeWire(private val json: Json, private val log: LogSink) {
     private val history = CodexCodeModeHistory(json)
+
+    /** Record ids whose omission was already logged — one line per record, not one per turn. */
+    private val announced: MutableSet<String> = ConcurrentHashMap.newKeySet()
 
     fun injectTool(request: JsonObject): JsonObject {
         val input = request[FIELD_INPUT] as? JsonArray ?: return request
@@ -44,8 +49,17 @@ internal class CodexCodeModeWire(private val json: Json) {
     fun hasExtraContent(bodyJson: String, record: CodeModeRecord): Boolean =
         history.hasExtraContent(bodyJson, record)
 
-    fun canonicalize(bodyJson: String, records: List<CodeModeRecord>): CodeModeRewrite =
-        history.canonicalize(bodyJson, records)
+    fun canonicalize(bodyJson: String, records: List<CodeModeRecord>): CodeModeRewrite {
+        val rewrite = history.canonicalize(bodyJson, records)
+        rewrite.omitted.filter { announced.add(it.record.id) }.forEach { omission ->
+            log(
+                "[code-mode] history rewrite skipped record ${omission.record.id.take(RECORD_ID_LOG_CHARS)} " +
+                    "(outer ${omission.record.outerCallId}): ${omission.reason} — its client calls stay in " +
+                    "the history as ordinary tool calls",
+            )
+        }
+        return rewrite
+    }
 
     fun restoreBaseline(bodyJson: String, record: CodeModeRecord): CodeModeRewrite =
         history.restoreBaseline(bodyJson, record)
@@ -92,10 +106,22 @@ internal data class CodeModeInputBoundary(
     val nativeSegments: List<CodeModeNativeSegment>,
 )
 
-internal data class CodeModeRewrite(val bodyJson: String?, val error: String? = null)
+internal data class CodeModeRewrite(
+    val bodyJson: String?,
+    val error: String? = null,
+    val omitted: List<CodeModeOmission> = emptyList(),
+)
+
+/** A completed record the rewrite could not place; the reason is what the digest check reported. */
+internal data class CodeModeOmission(val record: CodeModeRecord, val reason: String)
 
 internal const val CODE_MODE_TOOL_NAME = "splice_exec"
-internal const val CODE_MODE_METADATA_VERSION = 2
+
+/** v3 (2026-09-07): counts, digests and native offsets are conversation-relative (lite preamble
+ *  excluded). A v2 record's numbers point into the whole input, so it is never re-placed: a
+ *  completed one is omitted from the rewrite, an unfinished one is LOST. */
+internal const val CODE_MODE_METADATA_VERSION = 3
+private const val RECORD_ID_LOG_CHARS = 8
 private const val FIELD_CONTENT = "content"
 private const val FIELD_INPUT = "input"
 private const val FIELD_TYPE = "type"

--- a/gateway/provider-codex/src/test/kotlin/CodeModeBridgeTestSupport.kt
+++ b/gateway/provider-codex/src/test/kotlin/CodeModeBridgeTestSupport.kt
@@ -11,6 +11,7 @@ import splice.core.turn.ReasoningDisplay
 import splice.core.turn.TurnMeta
 import splice.core.turn.TurnOutcome
 import splice.core.turn.Usage
+import splice.core.util.LogSink
 import splice.provider.codex.CodeModeBridgeConfig
 import splice.provider.codex.CodexCodeModeBridge
 import splice.spi.BuiltTurn
@@ -33,6 +34,9 @@ abstract class CodeModeBridgeTestSupport {
     @TempDir
     protected lateinit var tempDir: Path
 
+    /** Every line the bridge logged through its head-scoped sink, across every bridge built here. */
+    protected val logLines = mutableListOf<String>()
+
     protected fun bridge(
         runtime: CodeModeRuntime,
         maxRecords: Int = 8,
@@ -47,6 +51,7 @@ abstract class CodeModeBridgeTestSupport {
             ttl = ttl,
             maxRounds = maxRounds,
             clock = clock,
+            log = LogSink { logLines += it },
         ),
     )
 
@@ -87,10 +92,11 @@ abstract class CodeModeBridgeTestSupport {
         result: String = "",
         sessionId: String = "session-a",
         results: List<CodeModeResult>? = null,
+        model: String = "gpt-6-astra",
     ) = CodexCodeModeBridge.Turn(
         sessionId = sessionId,
         conversationKey = "splice-first-message",
-        model = "gpt-6-astra",
+        model = model,
         tools = setOf("Read", "Edit"),
         toolResults = results ?: resultId?.let { listOf(CodeModeResult(it, result)) }.orEmpty(),
     )

--- a/gateway/provider-codex/src/test/kotlin/CodexCodeModeEnvironmentTest.kt
+++ b/gateway/provider-codex/src/test/kotlin/CodexCodeModeEnvironmentTest.kt
@@ -1,0 +1,156 @@
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import splice.core.turn.TurnOutcome
+import splice.spi.CodeModeStep
+import java.nio.file.Files
+
+/**
+ * The environment around a conversation moves while the conversation stands still: Claude Code grows
+ * its tool list (ToolSearch loading a deferred schema, an MCP reconnect) and its system prompt
+ * changes. Live on 2026-09-07 two sessions went 35 -> 36 eager tools one turn after a completed
+ * script and every later turn was refused. These pin the contract: records measure the conversation
+ * only, and history that no longer places a record degrades to the client's own history.
+ */
+class CodexCodeModeEnvironmentTest : CodeModeBridgeTestSupport() {
+    @Test
+    fun `a tool list that grows after the script turn still resumes and rewrites the history`() = runTest {
+        val runtime = ScriptedRuntime(
+            ArrayDeque(
+                listOf(
+                    CodeModeStep.Calls(listOf(call("runtime-read", "Read"))),
+                    CodeModeStep.Completed("done"),
+                ),
+            ),
+        )
+        val manager = bridge(runtime)
+        val sink = RecordingSink()
+        manager.interceptor(turn(), null, disableParallel = false)
+            .intercept(liteBody(tools = listOf("Read"), instructions = "s"), sink) { outerOutcome() }
+        val readId = sink.tools.single().id
+
+        var posted = ""
+        val outcome = manager.interceptor(turn(readId, "A"), null, disableParallel = false)
+            .intercept(liteBody(listOf("Read", "Edit"), "s", callback(readId)), RecordingSink()) { body ->
+                posted = body
+                completedOutcome()
+            }
+
+        assertTrue(outcome is TurnOutcome.Success)
+        // A grown tool list is a RESUME, not an interruption: the cell received the result.
+        assertEquals(2, runtime.cell.advances)
+        assertEquals("A", runtime.cell.results.last().single().output)
+        val items = Json.parseToJsonElement(posted).jsonObject.getValue("input").jsonArray
+        assertEquals(2, items[0].jsonObject.getValue("tools").jsonArray.size)
+        assertEquals(listOf("user", "custom_tool_call", "custom_tool_call_output"), shapes(items).drop(2))
+        assertFalse(readId in posted)
+        assertTrue(logLines.none { "skipped" in it || "abandoned" in it })
+    }
+
+    @Test
+    fun `instructions that change after the script turn still place the record`() = runTest {
+        val runtime = ScriptedRuntime(
+            ArrayDeque(
+                listOf(
+                    CodeModeStep.Calls(listOf(call("runtime-read", "Read"))),
+                    CodeModeStep.Completed("done"),
+                ),
+            ),
+        )
+        val manager = bridge(runtime)
+        val sink = RecordingSink()
+        manager.interceptor(turn(), null, disableParallel = false)
+            .intercept(liteBody(listOf("Read"), "first prompt"), sink) { outerOutcome() }
+        val readId = sink.tools.single().id
+
+        var posted = ""
+        manager.interceptor(turn(readId, "A"), null, disableParallel = false)
+            .intercept(liteBody(listOf("Read"), "second prompt", callback(readId)), RecordingSink()) { body ->
+                posted = body
+                completedOutcome()
+            }
+
+        val items = Json.parseToJsonElement(posted).jsonObject.getValue("input").jsonArray
+        assertEquals("second prompt", items[1].jsonObject.getValue("content").jsonPrimitive.content)
+        assertEquals(listOf("user", "custom_tool_call", "custom_tool_call_output"), shapes(items).drop(2))
+        assertFalse(readId in posted)
+    }
+
+    @Test
+    fun `a completed record whose metadata predates v3 is omitted from the rewrite and logged`() = runTest {
+        val runtime = ScriptedRuntime(
+            ArrayDeque(
+                listOf(
+                    CodeModeStep.Calls(listOf(call("runtime-read", "Read"))),
+                    CodeModeStep.Completed("done"),
+                ),
+            ),
+        )
+        val manager = bridge(runtime)
+        val sink = RecordingSink()
+        manager.interceptor(turn(), null, disableParallel = false)
+            .intercept(liteBody(listOf("Read"), "s"), sink) { outerOutcome() }
+        val readId = sink.tools.single().id
+        manager.interceptor(turn(readId, "A"), null, disableParallel = false)
+            .intercept(liteBody(listOf("Read"), "s", callback(readId)), RecordingSink()) { completedOutcome() }
+        val stateFile = tempDir.resolve("bridge.json")
+        val persisted = Files.readString(stateFile)
+        Files.writeString(stateFile, persisted.replace("\"metadataVersion\":3", "\"metadataVersion\":2"))
+
+        val restored = bridge(ScriptedRuntime(ArrayDeque(listOf(CodeModeStep.Completed("must not run")))))
+        var posted = ""
+        val outcome = restored.interceptor(turn(readId, "A"), null, disableParallel = false)
+            .intercept(liteBody(listOf("Read"), "s", callback(readId)), RecordingSink()) { body ->
+                posted = body
+                completedOutcome()
+            }
+
+        assertTrue(outcome is TurnOutcome.Success)
+        assertTrue(readId in posted)
+        assertFalse("outer-call" in posted)
+        assertTrue(logLines.any { "history rewrite skipped record" in it && "metadata is unavailable" in it })
+    }
+
+    @Test
+    fun `a model switch keeps the conversation alive on the client history`() = runTest {
+        val runtime = ScriptedRuntime(ArrayDeque(listOf(CodeModeStep.Calls(listOf(call("runtime-read", "Read"))))))
+        val manager = bridge(runtime)
+        val sink = RecordingSink()
+        manager.interceptor(turn(), null, disableParallel = false)
+            .intercept(liteBody(listOf("Read"), "s"), sink) { outerOutcome() }
+        val readId = sink.tools.single().id
+
+        var posted = ""
+        val outcome = manager.interceptor(turn(readId, "A", model = "gpt-6-sol"), null, disableParallel = false)
+            .intercept(liteBody(listOf("Read"), "s", callback(readId)), RecordingSink()) { body ->
+                posted = body
+                completedOutcome()
+            }
+
+        assertTrue(outcome is TurnOutcome.Success)
+        assertTrue(readId in posted)
+        assertEquals(1, runtime.cell.advances)
+        assertTrue(logLines.any { "belong to another session or model" in it })
+    }
+
+    private fun liteBody(tools: List<String>, instructions: String, history: String = ""): String {
+        val toolItems = tools.joinToString(",") { """{"type":"function","name":"$it"}""" }
+        return """{"input":[{"type":"additional_tools","role":"developer","tools":[$toolItems]},""" +
+            """{"role":"developer","content":"$instructions"},{"role":"user","content":"start"}$history]}"""
+    }
+
+    private fun callback(id: String): String =
+        """,{"type":"function_call","call_id":"$id","name":"Read","arguments":"{}"},""" +
+            """{"type":"function_call_output","call_id":"$id","output":"A"}"""
+
+    private fun shapes(items: JsonArray): List<String> = items.map { item ->
+        item.jsonObject["type"]?.jsonPrimitive?.content ?: item.jsonObject.getValue("role").jsonPrimitive.content
+    }
+}

--- a/gateway/provider-codex/src/test/kotlin/CodexCodeModeHistoryTest.kt
+++ b/gateway/provider-codex/src/test/kotlin/CodexCodeModeHistoryTest.kt
@@ -66,7 +66,7 @@ class CodexCodeModeHistoryTest : CodeModeBridgeTestSupport() {
     }
 
     @Test
-    fun `unexpected native replay at another baseline offset is rejected`() = runTest {
+    fun `unexpected native replay at another baseline offset abandons the script and continues upstream`() = runTest {
         val runtime = ScriptedRuntime(
             ArrayDeque(
                 listOf(
@@ -88,9 +88,13 @@ class CodexCodeModeHistoryTest : CodeModeBridgeTestSupport() {
                 completedOutcome()
             }
 
-        assertTrue(outcome is TurnOutcome.Failure)
-        assertEquals(0, upstreamCalls)
+        // The running cell is closed without rerunning its source, and the turn goes upstream on
+        // the client's history rather than failing the conversation.
+        assertTrue(outcome is TurnOutcome.Success)
+        assertEquals(1, upstreamCalls)
         assertEquals(1, runtime.cell.advances)
+        assertTrue(runtime.cell.closed)
+        assertTrue(logLines.any { "abandoned record" in it && "native discovery history was edited" in it })
     }
 
     private fun nativeSearchBody(searchId: String): String =

--- a/gateway/provider-codex/src/test/kotlin/CodexCodeModeLifecycleTest.kt
+++ b/gateway/provider-codex/src/test/kotlin/CodexCodeModeLifecycleTest.kt
@@ -131,7 +131,7 @@ class CodexCodeModeLifecycleTest : CodeModeBridgeTestSupport() {
     }
 
     @Test
-    fun `expired mapping reports history failure after registry reconstruction`() = runTest {
+    fun `expired mapping continues upstream on the client history after registry reconstruction`() = runTest {
         val clock = MutableClock(1_000)
         val runtime = ScriptedRuntime(ArrayDeque(listOf(CodeModeStep.Calls(listOf(call("r1", "Read"))))))
         val manager = bridge(runtime, ttl = 1.hours, clock = clock)
@@ -146,11 +146,18 @@ class CodexCodeModeLifecycleTest : CodeModeBridgeTestSupport() {
             ttl = 1.hours,
             clock = clock,
         )
+        var posted = ""
         val outcome = restored.interceptor(turn(resultId, "A"), null, disableParallel = false)
-            .intercept(requestWithResult(resultId, "A"), RecordingSink()) { completedOutcome() }
+            .intercept(requestWithResult(resultId, "A"), RecordingSink()) { body ->
+                posted = body
+                completedOutcome()
+            }
 
-        assertTrue(outcome is TurnOutcome.Failure)
-        assertTrue((outcome as TurnOutcome.Failure).message.contains("expired"))
+        // The record is gone, so nothing can be rewritten: the client's own history goes upstream
+        // untouched (its callback is an ordinary tool call there) and the turn is not refused.
+        assertTrue(outcome is TurnOutcome.Success)
+        assertTrue(resultId in posted)
+        assertTrue(logLines.any { "expired code-mode history" in it })
     }
 
     @Test


### PR DESCRIPTION
## What

Code mode refused every later turn of a conversation once Claude Code's tool list grew after a completed script. The baseline digest covered the Responses-lite preamble (eager tool list + instructions), which is environment, not history. Two live sessions hit it within twelve minutes of enabling the beta on 2026-09-07 (35 -> 36 eager tools, `code-mode logical history does not match its persisted baseline` on every Astra turn until compaction). The same conflation made a grown tool list during a script's resume turn look like new user content and interrupt the script.

## Fix

- Records are measured conversation-relative: leading developer-role items are split off before a record is counted/hashed and put back after a rewrite (`CodexCodeModeHistoryCodec.conversation`). `CODE_MODE_METADATA_VERSION` 2 -> 3.
- History that cannot be placed degrades instead of failing: unplaceable completed record, pre-v3 record, record past retention, result from another session or model, running script whose history moved. The turn continues upstream on the client's own history (its client calls are ordinary tool calls there), with one `[<head>][code-mode]` log line per record/conversation.
- Pre-v3 completed records on disk stay terminal and are omitted from the rewrite, so a conversation already stuck on 0.3.1 recovers on its next turn.

## Proof

- provider-codex 102 tests (4 new in `CodexCodeModeEnvironmentTest`: grown tool list resumes and rewrites, changed instructions, pre-v3 record omitted and logged, model switch). Two existing tests re-pinned to the degrade contract (expired mapping, edited native history).
- Full local gate: every module's clean check, gateway suite 299/299 in a 4096-task box, all 24 non-gradle legs incl. the packaged code-mode mock against the fat jar.
- Live: jar `df8a3234…` installed on the operator's machine; the first Astra turn after restart omitted two pre-v3 records with the log line and completed; 291 ok turns, 0 failures since.

Replaces the published v0.3.1 (same version, republished after promotion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
