### PR TITLE
chore(release): cut v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## splice v0.3.2 — code mode keeps its workers and its evidence, and fails in words - 2026-09-07
+
 ### Fixed
 - **Code mode no longer runs out of workers behind clients that never came back.** A script whose
   client calls were never answered (the session was abandoned, compacted or killed) kept its worker

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ curl -fsSL https://github.com/torad-labs/splice/releases/latest/download/install
 To pin one version instead of following `latest` (prereleases never become `latest`):
 
 ```bash
-curl -fsSL https://github.com/torad-labs/splice/releases/download/v0.3.1/install.sh \
-  | env SPLICE_VERSION=v0.3.1 bash
+curl -fsSL https://github.com/torad-labs/splice/releases/download/v0.3.2/install.sh \
+  | env SPLICE_VERSION=v0.3.2 bash
 ```
 
 **Option 2: from source** (no `gh` needed):

--- a/bin/splice-launch
+++ b/bin/splice-launch
@@ -62,7 +62,7 @@ DANGEROUS="false"
 # — bump both together whenever this shim's behavior changes. No code generation.
 SPLICE_SHIM_VERSION="shim-2"
 # Hand-paired with splice.core.GATEWAY_VERSION. Release acceptance verifies the marker.
-SPLICE_GATEWAY_VERSION="0.3.1"
+SPLICE_GATEWAY_VERSION="0.3.2"
 
 need_jar() {
   if [ ! -f "$JAR" ]; then

--- a/gateway/core/src/main/kotlin/splice/core/Versions.kt
+++ b/gateway/core/src/main/kotlin/splice/core/Versions.kt
@@ -3,7 +3,7 @@
 // /health). Single daemon (P4): one version restarts every head together (documented change).
 package splice.core
 
-public const val GATEWAY_VERSION: String = "0.3.1"
+public const val GATEWAY_VERSION: String = "0.3.2"
 
 // Hand-paired with the SPLICE_SHIM_VERSION marker embedded in bin/splice-launch (same
 // hand-paired pattern as GATEWAY_VERSION/wantVersion already used for head staleness in

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "splice",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "splice",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "workspaces": [
         "webui"
       ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "splice",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "engines": {
     "node": ">=24"
   },


### PR DESCRIPTION
Version cut for v0.3.2: the four paired version sites (Versions.kt, bin/splice-launch, package.json, package-lock.json), the README install URL, and the CHANGELOG release heading over the Unreleased entries merged in #148 (code-mode worker slots, lost-script evidence, readable failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)